### PR TITLE
Simple toggle to stop the automatic assignment of public IP's for all the nodes.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -65,6 +65,7 @@ func newDefaultCluster() *Cluster {
 		CreateRecordSet:          false,
 		RecordSetTTL:             300,
 		Subnets:                  []*Subnet{},
+		MapPublicIPs:             true,
 		Experimental:             experimental,
 	}
 }
@@ -167,6 +168,7 @@ type Cluster struct {
 	StackTags                map[string]string `yaml:"stackTags,omitempty"`
 	UseCalico                bool              `yaml:"useCalico,omitempty"`
 	Subnets                  []*Subnet         `yaml:"subnets,omitempty"`
+	MapPublicIPs             bool              `yaml:"mapPublicIPs,omitempty"`
 	Experimental             Experimental      `yaml:"experimental"`
 	providedEncryptService   encryptService
 }

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -125,6 +125,10 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # IP address of Kubernetes dns service (must be contained by serviceCIDR)
 # dnsServiceIP: 10.3.0.10
 
+# Uncomment to provision nodes without a public IP. This assumes your VPC route table is setup to route to the internet via a NAT gateway.
+# If you did not set vpcId and routeTableId the cluster will not bootstrap.
+# mapPublicIPs: false
+
 # Expiration in days from creation time of TLS assets. By default, the CA will
 # expire in 10 years and the server and client certificates will expire in 1
 # year.

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -341,7 +341,7 @@
         "KeyName": "{{$.KeyName}}",
         "NetworkInterfaces": [
           {
-            "AssociatePublicIpAddress": true,
+            "AssociatePublicIpAddress": {{.MapPublicIPs}},
             "DeleteOnTermination": true,
             "DeviceIndex": "0",
             "GroupSet": [
@@ -452,6 +452,11 @@
 	    "Protocol" : "TCP"
 	  }
 	],
+	{{if .MapPublicIPs}}
+	"Scheme": "internet-facing",
+	{{else}}
+	"Scheme": "internal",
+	{{end}}
 	"SecurityGroups" : [
 	  { "Ref" : "SecurityGroupElbAPIServer" }
 	]
@@ -794,7 +799,7 @@
       "Properties": {
         "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
         "CidrBlock": "{{$subnet.InstanceCIDR}}",
-        "MapPublicIpOnLaunch": true,
+        "MapPublicIpOnLaunch": {{.MapPublicIPs}},
         "Tags": [
           {
             "Key": "KubernetesCluster",


### PR DESCRIPTION
This toggle still requires the operator to bootstrap the VPC with a NAT gateway, but i think it's fair to expect the operator to do this manually/with external tooling.

I might send a subsequent PR to add functionality to create a NAT gateway from kube-aws. Gateway initialization takes several (sometimes 5+) minutes though, so i'm slightly worried cluster bootstrap might be affected.