### PR TITLE
feat(test): Implement an easier way to run k8s conformance tests against kube-aws-provisioned cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *~
 /config/templates.go
 .idea/
+.envrc

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,28 @@
+# End-to-end testing for kube-aws
+
+This directory contains a set of tools to run end-to-end testing for kube-aws.
+It is composed of:
+
+* Cluster creation using `kube-aws`
+* [Kubernetes Conformance Tests](https://github.com/kubernetes/kubernetes/blob/master/docs/devel/e2e-tests.md#conformance-tests)
+
+To run e2e tests, you should have set all he required env vars.
+For convenience, creating `.envrc` used by `direnv` like as follows would be good.
+
+```
+export KUBE_AWS_KEY_NAME=...
+export KUBE_AWS_KMS_KEY_ARN=arn:aws:kms:us-west-1:<account id>:key/<id>
+export KUBE_AWS_DOMAIN=example.com
+export KUBE_AWS_REGION=us-west-1
+export KUBE_AWS_AVAILABILITY_ZONE=us-west-1b
+export KUBE_AWS_HOSTED_ZONE_ID=...
+
+export DOCKER_REPO=quay.io/mumoshu/
+export SSH_PRIVATE_KEY=path/to/private/key/matching/key/name
+```
+
+Finally, run e2e tests like:
+
+```
+$ KUBE_AWS_CLUSTER_NAME=kubeawstest ./run all
+```

--- a/e2e/kubernetes/Dockerfile
+++ b/e2e/kubernetes/Dockerfile
@@ -1,0 +1,31 @@
+FROM golang:1.7.1
+
+ARG KUBERNETES_VERSION=${KUBERNETES_VERSION:-v1.4.3+coreos.0}
+
+RUN apt-get update && \
+    apt-get install -y rsync && \
+    go get -u github.com/jteeuwen/go-bindata/go-bindata && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /go
+
+RUN git clone --depth 1 https://github.com/coreos/kubernetes -b $KUBERNETES_VERSION && \
+    cd kubernetes && \
+    git branch && \
+    git checkout -b $KUBERNETES_VERSION && \
+    git branch && \
+    make all WHAT=cmd/kubectl && \
+    find . -type f -executable -name kubectl && \
+    ./_output/local/bin/linux/amd64/kubectl version --client && \
+    make all WHAT=vendor/github.com/onsi/ginkgo/ginkgo && \
+    make all WHAT=test/e2e/e2e.test && \
+    rm -Rf .git
+
+ENV KUBERNETES_PROVIDER skeleton
+ENV KUBERNETES_CONFORMANCE_TEST Y
+
+ADD conformance.sh /
+
+WORKDIR /go/kubernetes
+
+CMD /conformance.sh

--- a/e2e/kubernetes/Makefile
+++ b/e2e/kubernetes/Makefile
@@ -6,6 +6,7 @@ KUBE_AWS_ASSETS ?= /missing-kube-aws-assets
 SSH_PRIVATE_KEY ?=
 SSH_CMD ?= ssh -i $(SSH_PRIVATE_KEY)
 MASTER_HOST ?=
+FOCUS ?= \[Conformance\]
 
 .PHONY: build
 build:
@@ -28,7 +29,7 @@ ssh:
 .PHONY: run-remotely
 run-remotely:
 	rsync -a -e 'ssh -i $(SSH_PRIVATE_KEY)' $(KUBE_AWS_ASSETS)/ core@$(MASTER_HOST):/home/core/kube
-	ssh -i $(SSH_PRIVATE_KEY) core@$(MASTER_HOST) 'sh -c "docker pull $(DOCKER_TAG_SANITIZED) && container_id=$$(docker run -d -v /home/core/kube:/kube $(DOCKER_TAG_SANITIZED)) && echo \$$container_id && docker logs -f \$$container_id"'
+	ssh -i $(SSH_PRIVATE_KEY) core@$(MASTER_HOST) 'sh -c "docker pull $(DOCKER_TAG_SANITIZED) && container_id=$$(docker run -d -v /home/core/kube:/kube -e FOCUS='$(FOCUS)' $(DOCKER_TAG_SANITIZED)) && echo \$$container_id && docker logs -f \$$container_id"'
 
 .PHONY: get-log
 get-log:

--- a/e2e/kubernetes/Makefile
+++ b/e2e/kubernetes/Makefile
@@ -36,6 +36,10 @@ get-log:
 	full_container_id=$$($(SSH_CMD) core@$(MASTER_HOST) 'docker ps -a --no-trunc | grep $(DOCKER_TAG_SANITIZED) | tee /dev/stderr | head -n 1 | awk "{ print \$$1 }"') && \
 	rsync --rsync-path="sudo rsync" -e '$(SSH_CMD)' core@$(MASTER_HOST):/var/lib/docker/containers/$${full_container_id}/$${full_container_id}-json.log .
 
+.PHONY: show-log
+show-log:
+	$(SSH_CMD) core@$(MASTER_HOST) 'sh -c "container_id=$$(docker ps -a | grep $(DOCKER_TAG_SANITIZED) | head -n 1 | cut -d" " -f 1); docker logs -f \$$container_id"'
+
 .PHONY: sh
 sh:
 	docker run -it --rm -v $(KUBE_AWS_ASSETS):/kube $(DOCKER_TAG_SANITIZED) sh

--- a/e2e/kubernetes/Makefile
+++ b/e2e/kubernetes/Makefile
@@ -33,7 +33,7 @@ run-remotely:
 
 .PHONY: get-log
 get-log:
-	full_container_id=$$($(SSH_CMD) core@$(MASTER_HOST) 'docker ps --no-trunc | grep $(DOCKER_TAG_SANITIZED) | tee /dev/stderr | awk "{ print \$$1 }"') && \
+	full_container_id=$$($(SSH_CMD) core@$(MASTER_HOST) 'docker ps -a --no-trunc | grep $(DOCKER_TAG_SANITIZED) | tee /dev/stderr | head -n 1 | awk "{ print \$$1 }"') && \
 	rsync --rsync-path="sudo rsync" -e '$(SSH_CMD)' core@$(MASTER_HOST):/var/lib/docker/containers/$${full_container_id}/$${full_container_id}-json.log .
 
 .PHONY: sh

--- a/e2e/kubernetes/Makefile
+++ b/e2e/kubernetes/Makefile
@@ -24,8 +24,12 @@ run-locally:
 ssh:
 	ssh -i $(SSH_PRIVATE_KEY) core@$(MASTER_HOST)
 
-# usage:
-#   DOCKER_REPO=mumoshu/ MASTER_HOST=**.**.**.** SSH_PRIVATE_KEY=path/to/key KUBE_AWS_ASSETS=path/to/where/kube-aws/run sh -c 'make build && make publish && make run-remotely'
+# example usage:
+#   FOCUS='\[HPA\].*\[Conformance\]' DOCKER_REPO=quay.io/mumoshu/ MASTER_HOST=**.**.**.** SSH_PRIVATE_KEY=path/to/key KUBE_AWS_ASSETS=path/to/where/kube-aws/run sh -c 'make build && make publish && make run-remotely'
+#
+#   FOCUS:
+#     a regexp to selectively run e2e tests. Default: \[Conformance\]
+#     see https://github.com/kubernetes/kubernetes/blob/master/docs/devel/e2e-tests.md#conformance-tests for more examples and description
 .PHONY: run-remotely
 run-remotely:
 	rsync -a -e 'ssh -i $(SSH_PRIVATE_KEY)' $(KUBE_AWS_ASSETS)/ core@$(MASTER_HOST):/home/core/kube

--- a/e2e/kubernetes/Makefile
+++ b/e2e/kubernetes/Makefile
@@ -1,0 +1,40 @@
+KUBERNETES_VERSION ?= v1.4.3+coreos.0
+DOCKER_REPO ?=
+DOCKER_TAG ?= $(DOCKER_REPO)kube-e2e:$(KUBERNETES_VERSION)
+DOCKER_TAG_SANITIZED ?= $(shell echo $(DOCKER_TAG) | sed -e 's/+/_/')
+KUBE_AWS_ASSETS ?= /missing-kube-aws-assets
+SSH_PRIVATE_KEY ?=
+SSH_CMD ?= ssh -i $(SSH_PRIVATE_KEY)
+MASTER_HOST ?=
+
+.PHONY: build
+build:
+	docker build --build-arg KUBERNETES_VERSION=$(KUBERNETES_VERSION) -t $(DOCKER_TAG_SANITIZED) .
+
+.PHONY: publish
+publish:
+	docker push $(DOCKER_TAG_SANITIZED)
+
+.PHONY: run-locally
+run-locally:
+	docker run --rm -v $(KUBE_AWS_ASSETS):/kube $(DOCKER_TAG_SANITIZED)
+
+.PHONY: ssh
+ssh:
+	ssh -i $(SSH_PRIVATE_KEY) core@$(MASTER_HOST)
+
+# usage:
+#   DOCKER_REPO=mumoshu/ MASTER_HOST=**.**.**.** SSH_PRIVATE_KEY=path/to/key KUBE_AWS_ASSETS=path/to/where/kube-aws/run sh -c 'make build && make publish && make run-remotely'
+.PHONY: run-remotely
+run-remotely:
+	rsync -a -e 'ssh -i $(SSH_PRIVATE_KEY)' $(KUBE_AWS_ASSETS)/ core@$(MASTER_HOST):/home/core/kube
+	ssh -i $(SSH_PRIVATE_KEY) core@$(MASTER_HOST) 'sh -c "docker pull $(DOCKER_TAG_SANITIZED) && container_id=$$(docker run -d -v /home/core/kube:/kube $(DOCKER_TAG_SANITIZED)) && echo \$$container_id && docker logs -f \$$container_id"'
+
+.PHONY: get-log
+get-log:
+	full_container_id=$$($(SSH_CMD) core@$(MASTER_HOST) 'docker ps --no-trunc | grep $(DOCKER_TAG_SANITIZED) | tee /dev/stderr | awk "{ print \$$1 }"') && \
+	rsync --rsync-path="sudo rsync" -e '$(SSH_CMD)' core@$(MASTER_HOST):/var/lib/docker/containers/$${full_container_id}/$${full_container_id}-json.log .
+
+.PHONY: sh
+sh:
+	docker run -it --rm -v $(KUBE_AWS_ASSETS):/kube $(DOCKER_TAG_SANITIZED) sh

--- a/e2e/kubernetes/conformance.sh
+++ b/e2e/kubernetes/conformance.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -eu
+
+if [ ! -d /kube ]; then
+  echo /kube does not exist. run this docker container like '`docker run -v path-to-kube-assets:/kube image-name`' 1>&2
+  exit 1
+fi
+
+DIR=/kube-temp
+
+mkdir ${DIR}
+
+cp -R /kube/* ${DIR}/
+
+export KUBECONFIG=${DIR}/kubeconfig
+
+sed -i -e "s#credentials/#${DIR}/credentials/#g" ${KUBECONFIG}
+
+go run hack/e2e.go -v --test -check_version_skew=false -check_node_count=true --test_args="ginkgo.focus='\[Conformance\]'"

--- a/e2e/kubernetes/conformance.sh
+++ b/e2e/kubernetes/conformance.sh
@@ -17,4 +17,12 @@ export KUBECONFIG=${DIR}/kubeconfig
 
 sed -i -e "s#credentials/#${DIR}/credentials/#g" ${KUBECONFIG}
 
-go run hack/e2e.go -v --test -check_version_skew=false -check_node_count=true --test_args="ginkgo.focus='\[Conformance\]'"
+set -vx
+
+if [ "$FOCUS" != "" ]; then
+  FOCUS=$(echo $FOCUS | sed -e 's/\[/\\[/' -e 's/\]/\\]/')
+fi
+
+FOCUS=${FOCUS:-\[Conformance\]}
+
+go run hack/e2e.go -v --test -check_version_skew=false -check_node_count=true --test_args="--ginkgo.focus=$FOCUS"

--- a/e2e/run
+++ b/e2e/run
@@ -1,0 +1,171 @@
+#!/bin/bash
+
+KUBE_AWS_CMD=${KUBE_AWS_CMD:-$GOPATH/src/github.com/coreos/kube-aws/bin/kube-aws}
+E2E_DIR=$(cd $(dirname $0); pwd)
+WORK_DIR=${E2E_DIR}/assets/${KUBE_AWS_CLUSTER_NAME}
+KUBECONFIG=${WORK_DIR}/kubeconfig
+
+export KUBECONFIG
+
+USAGE_EXAMPLE="KUBE_AWS_CLUSTER_NAME=kubeawstest1 KUBE_AWS_KEY_NAME=name/of/ec2/key KUBE_AWS_KMS_KEY_ARN=arn:aws:kms:us-west-1:<account id>:key/your-key KUBE_AWS_REGION=us-west-1 KUBE_AWS_AVAILABILITY_ZONE=us-west-1b ./$0 [prepare|configure|start|all]"
+
+if [ "${KUBE_AWS_CLUSTER_NAME}" == "" ]; then
+  echo KUBE_AWS_CLUSTER_NAME is not set. Run this command like $USAGE_EXAMPLE 1>&2
+  exit 1
+fi
+
+if [ "${KUBE_AWS_KEY_NAME}" == "" ]; then
+  echo KUBE_AWS_KEY_NAME is not set. Run this command like $USAGE_EXAMPLE 1>&2
+  exit 1
+fi
+
+if [ "${KUBE_AWS_REGION}" == "" ]; then
+  echo KUBE_AWS_REGION is not set. Run this command like $USAGE_EXAMPLE 1>&2
+  exit 1
+fi
+
+if [ "${KUBE_AWS_AVAILABILITY_ZONE}" == "" ]; then
+  echo KUBE_AWS_REGION is not set. Run this command like $USAGE_EXAMPLE 1>&2
+  exit 1
+fi
+
+if [ ! -e "${KUBE_AWS_CMD}" ]; then
+  echo ${KUBE_AWS_CMD} does not exist. 1>&2
+  exit 1
+fi
+
+KUBE_AWS_VERSION=$($KUBE_AWS_CMD version)
+echo Using the kube-aws command at ${KUBE_AWS_CMD}"($KUBE_AWS_VERSION)". Set KUBE_AWS_CMD=path/to/kube-aws to override.
+
+EXTERNAL_DNS_NAME=${KUBE_AWS_CLUSTER_NAME}.${KUBE_AWS_DOMAIN}
+echo The kubernetes API would be accessible via ${EXTERNAL_DNS_NAME}
+
+prepare() {
+  echo Creating or ensuring existence of the kube-aws assets directory ${WORK_DIR}
+  mkdir -p ${WORK_DIR}
+}
+
+configure() {
+  cd ${WORK_DIR}
+
+  ${KUBE_AWS_CMD} init \
+    --cluster-name ${KUBE_AWS_CLUSTER_NAME} \
+    --external-dns-name ${EXTERNAL_DNS_NAME} \
+    --region ${KUBE_AWS_REGION} \
+    --availability-zone ${KUBE_AWS_AVAILABILITY_ZONE} \
+    --key-name ${KUBE_AWS_KEY_NAME} \
+    --kms-key-arn ${KUBE_AWS_KMS_KEY_ARN}
+
+  echo "hostedZoneId: ${KUBE_AWS_HOSTED_ZONE_ID}" >> cluster.yaml
+  echo 'createRecordSet: true' >> cluster.yaml
+
+  # required to run kube-aws update
+  echo 'workerCount: 4' >> cluster.yaml
+  echo 'controllerCount: 2' >> cluster.yaml
+
+  ${KUBE_AWS_CMD} render
+
+  ${KUBE_AWS_CMD} validate
+
+  echo Generated configuration files in ${WORK_DIR}:
+  find .
+}
+
+clean() {
+  cd ${WORK_DIR}/..
+  if [ -d "${KUBE_AWS_CLUSTER_NAME}" ]; then
+    echo Removing the directory "${WORK_DIR}"
+    rm -Rf ./${KUBE_AWS_CLUSTER_NAME}/*
+  fi
+}
+
+up() {
+  cd ${WORK_DIR}
+
+  ${KUBE_AWS_CMD} up
+
+  printf 'Waiting for the Kubernetes API to be accessible'
+
+  while ! kubectl get no 2>/dev/null; do
+    sleep 10
+    printf '.'
+  done
+  echo done
+}
+
+destroy() {
+  aws cloudformation delete-stack --stack-name ${KUBE_AWS_CLUSTER_NAME}
+  aws cloudformation wait stack-delete-complete --stack-name ${KUBE_AWS_CLUSTER_NAME}
+}
+
+test-upgrade() {
+  SED_CMD="sed -e 's/workerCount: 2/workerCount: 4/' -e 's/controllerCount: 2/controllerCount: 3/'"
+  diff --unified cluster.yaml <(cat cluster.yaml | sh -c "${SED_CMD}")
+  sh -c "${SED_CMD} -i bak cluster.yaml"
+  ${KUBE_AWS_CMD} update
+  aws cloudformation wait stack-update-complete --stack-name ${KUBE_AWS_CLUSTER_NAME}
+}
+
+test-destruction() {
+  aws cloudformation wait stack-delete-complete --stack-name ${KUBE_AWS_CLUSTER_NAME}
+}
+
+# Usage: DOCKER_REPO=quay.io/mumoshu/ SSH_PRIVATE_KEY=path/to/private/key ./e2e run conformance
+conformance() {
+  cd ${E2E_DIR}/kubernetes
+
+  if [ "$DOCKER_REPO" == "" ]; then
+    echo DOCKER_REPO is not set.
+    exit 1
+  fi
+
+  if [ "$SSH_PRIVATE_KEY" == "" ]; then
+    echo SSH_PRIVATE_KEY is not set.
+    exit 1
+  fi
+
+  if [ ! -f "$SSH_PRIVATE_KEY" ]; then
+    echo ${SSH_PRIVATE_KEY} does not exist.
+    exit 1
+  fi
+
+  master_host=$(aws ec2 describe-instances --output json --query "Reservations[].Instances[]
+    | [?Tags[?Key==\`aws:cloudformation:stack-name\`].Value|[0]==\`${KUBE_AWS_CLUSTER_NAME}\`]
+    | [?Tags[?Key==\`aws:cloudformation:logical-id\`].Value|[0]==\`AutoScaleController\`][]
+    | []" | jq -r 'map({InstanceId: .InstanceId, PublicIpAddress: .PublicIpAddress}) | first | .PublicIpAddress'
+  )
+
+  echo Connecting to $master_host via SSH
+
+  KUBE_AWS_ASSETS=${WORK_DIR} MASTER_HOST=$master_host make run-remotely
+}
+
+conformance_result() {
+  cd ${E2E_DIR}/kubernetes
+
+  master_host=$(aws ec2 describe-instances --output json --query "Reservations[].Instances[]
+    | [?Tags[?Key==\`aws:cloudformation:stack-name\`].Value|[0]==\`${KUBE_AWS_CLUSTER_NAME}\`]
+    | [?Tags[?Key==\`aws:cloudformation:logical-id\`].Value|[0]==\`AutoScaleController\`][]
+    | []" | jq -r 'map({InstanceId: .InstanceId, PublicIpAddress: .PublicIpAddress}) | first | .PublicIpAddress'
+  )
+
+  echo Connecting to $master_host via SSH
+
+  KUBE_AWS_ASSETS=${WORK_DIR} MASTER_HOST=$master_host make show-log
+}
+
+all() {
+  prepare
+  configure
+  up
+  conformance
+}
+
+if [ "$1" == "" ]; then
+  echo Usage: $USAGE_EXAMPLE
+  exit 1
+fi
+
+set -vxe
+
+"$@"


### PR DESCRIPTION
I'd like to add a set of Dockerfile, Makefile, and a shell script to easily build docker images to run the k8s e2e test suite including conformance tests, run it locally or remotely(on k8s controller nodes with manually modified controller security group with 10250 opened, to fully test things like e.g. cAdvisor/Prometeus related ones)

Beware that you should be running at least 4 m3.medium instances for k8s worker nodes to pass tests related to the horizontal pod autoscaler
