### PR TITLE
fix build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *~
 /config/templates.go
 .idea/
+/_gopath-kube-aws
+/_gopath-vendor

--- a/build
+++ b/build
@@ -16,6 +16,21 @@ if [ -n "$(git diff --shortstat 2> /dev/null | tail -n1)" ]; then
     VERSION="${VERSION}+dirty"
 fi
 
+GOPATH_VENDOR="$(pwd)/_gopath-vendor"
+GOPATH_KUBE_AWS="$(pwd)/_gopath-kube-aws"
+KUBE_AWS_DIR="${GOPATH_KUBE_AWS}/src/github.com/coreos/kube-aws"
+
+rm -rf "$GOPATH_VENDOR" "$GOPATH_KUBE_AWS"
+
+mkdir -p "$GOPATH_VENDOR"
+mkdir -p "$(dirname "$KUBE_AWS_DIR")"
+
+ln -s "$(pwd)"/vendor "$GOPATH_VENDOR"/src
+ln -s "$(pwd)" "$KUBE_AWS_DIR"
+
+export GOPATH="${GOPATH_VENDOR}:${GOPATH_KUBE_AWS}"
+cd "$KUBE_AWS_DIR"
+
 echo Building kube-aws ${VERSION}
 
 go generate ./config


### PR DESCRIPTION
```
$ ./build
Building kube-aws v0.9.0-rc.1
cmd/kube-aws/command_destroy.go:8:2: cannot find package "github.com/coreos/kube-aws/cluster" in any of:
        /usr/local/Cellar/go/1.7.1/libexec/src/github.com/coreos/kube-aws/cluster (from $GOROOT)
        /Users/hanfei/workspace/go/src/github.com/coreos/kube-aws/cluster (from $GOPATH)
cmd/kube-aws/command_destroy.go:9:2: cannot find package "github.com/coreos/kube-aws/config" in any of:
        /usr/local/Cellar/go/1.7.1/libexec/src/github.com/coreos/kube-aws/config (from $GOROOT)
        /Users/hanfei/workspace/go/src/github.com/coreos/kube-aws/config (from $GOPATH)
cmd/kube-aws/command_render.go:16:2: cannot find package "github.com/coreos/kube-aws/tlsutil" in any of:
        /usr/local/Cellar/go/1.7.1/libexec/src/github.com/coreos/kube-aws/tlsutil (from $GOROOT)
        /Users/hanfei/workspace/go/src/github.com/coreos/kube-aws/tlsutil (from $GOPATH)
cmd/kube-aws/command_destroy.go:6:2: cannot find package "github.com/spf13/cobra" in any of:
        /usr/local/Cellar/go/1.7.1/libexec/src/github.com/spf13/cobra (from $GOROOT)
        /Users/hanfei/workspace/go/src/github.com/spf13/cobra (from $GOPATH)
```