### PR TITLE
fix MapPublicIPs in stack template

### DIFF
--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -341,7 +341,7 @@
         "KeyName": "{{$.KeyName}}",
         "NetworkInterfaces": [
           {
-            "AssociatePublicIpAddress": {{.MapPublicIPs}},
+            "AssociatePublicIpAddress": {{$.MapPublicIPs}},
             "DeleteOnTermination": true,
             "DeviceIndex": "0",
             "GroupSet": [
@@ -799,7 +799,7 @@
       "Properties": {
         "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
         "CidrBlock": "{{$subnet.InstanceCIDR}}",
-        "MapPublicIpOnLaunch": {{.MapPublicIPs}},
+        "MapPublicIpOnLaunch": {{$.MapPublicIPs}},
         "Tags": [
           {
             "Key": "KubernetesCluster",


### PR DESCRIPTION
```
$ ../bin/kube-aws validate
Validating UserData...
UserData is valid.

Validating stack template...
Error: Failed to render stack template: template: stack-template.json:344:42: executing "stack-template.json" at <.MapPublicIPs>: can't evaluate field MapPublicIPs in type config.etcdInstance
```

```
$ ../bin/kube-aws validate
Validating UserData...
UserData is valid.

Validating stack template...
Error: Failed to render stack template: template: stack-template.json:802:33: executing "stack-template.json" at <.MapPublicIPs>: can't evaluate field MapPublicIPs in type string
```