### PR TITLE
allow to override the ami id of coreos

### DIFF
--- a/cmd/kube-aws/command_init.go
+++ b/cmd/kube-aws/command_init.go
@@ -31,6 +31,7 @@ func init() {
 	cmdInit.Flags().StringVar(&initOpts.AvailabilityZone, "availability-zone", "", "The AWS availability-zone to deploy to")
 	cmdInit.Flags().StringVar(&initOpts.KeyName, "key-name", "", "The AWS key-pair for ssh access to nodes")
 	cmdInit.Flags().StringVar(&initOpts.KMSKeyARN, "kms-key-arn", "", "The ARN of the AWS KMS key for encrypting TLS assets")
+	cmdInit.Flags().StringVar(&initOpts.AmiId, "ami-id", "", "The AMI ID of CoreOS")
 }
 
 func runCmdInit(cmd *cobra.Command, args []string) error {

--- a/config/config.go
+++ b/config/config.go
@@ -132,6 +132,7 @@ type Cluster struct {
 	Region                   string            `yaml:"region,omitempty"`
 	AvailabilityZone         string            `yaml:"availabilityZone,omitempty"`
 	ReleaseChannel           string            `yaml:"releaseChannel,omitempty"`
+	AmiId                    string            `yaml:"amiId,omitempty"`
 	ControllerCount          int               `yaml:"controllerCount,omitempty"`
 	ControllerInstanceType   string            `yaml:"controllerInstanceType,omitempty"`
 	ControllerRootVolumeType string            `yaml:"controllerRootVolumeType,omitempty"`
@@ -225,9 +226,13 @@ func (c Cluster) Config() (*Config, error) {
 		}
 	}
 
-	var err error
-	if config.AMI, err = getAMI(config.Region, config.ReleaseChannel); err != nil {
-		return nil, fmt.Errorf("failed getting AMI for config: %v", err)
+	if c.AmiId == "" {
+		var err error
+		if config.AMI, err = getAMI(config.Region, config.ReleaseChannel); err != nil {
+			return nil, fmt.Errorf("failed getting AMI for config: %v", err)
+		}
+	} else {
+		config.AMI = c.AmiId
 	}
 
 	//Set logical name constants

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -13,6 +13,10 @@ externalDNSName: {{.ExternalDNSName}}
 # See coreos.com/releases for more information
 #releaseChannel: stable
 
+# The AMI ID of CoreOS.
+# If omitted, the latest AMI for the releaseChannel is used.
+#amiId: ""
+
 # Set to true if you want kube-aws to create a Route53 A Record for you.
 #createRecordSet: false
 


### PR DESCRIPTION
There's no official AMIs for CoreOS in China region. This PR make it possible to launch an instance by a user specified AMI.
