### PR TITLE
add a new var IsChinaRegion to fix for China Region

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -67,6 +67,7 @@ func newDefaultCluster() *Cluster {
 		Subnets:                  []*Subnet{},
 		MapPublicIPs:             true,
 		Experimental:             experimental,
+		IsChinaRegion:            false,
 	}
 }
 
@@ -171,6 +172,7 @@ type Cluster struct {
 	MapPublicIPs             bool              `yaml:"mapPublicIPs,omitempty"`
 	Experimental             Experimental      `yaml:"experimental"`
 	providedEncryptService   encryptService
+	IsChinaRegion            bool
 }
 
 type Subnet struct {
@@ -312,6 +314,8 @@ func (c Cluster) Config() (*Config, error) {
 	}
 	config.EtcdEndpoints = etcdEndpoints.String()
 	config.EtcdInitialCluster = etcdInitialCluster.String()
+
+	config.IsChinaRegion = strings.HasPrefix(config.Region, "cn")
 
 	return &config, nil
 }

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -174,7 +174,7 @@
               "Effect": "Allow",
               "Principal": {
                 "Service": [
-                  "ec2.amazonaws.com"
+                  "ec2.amazonaws.com{{if .IsChinaRegion}}.cn{{end}}"
                 ]
               }
             }
@@ -221,7 +221,7 @@
               "Effect": "Allow",
               "Principal": {
                 "Service": [
-                  "ec2.amazonaws.com"
+                  "ec2.amazonaws.com{{if .IsChinaRegion}}.cn{{end}}"
                 ]
               }
             }
@@ -286,7 +286,7 @@
               "Effect": "Allow",
               "Principal": {
                 "Service": [
-                  "ec2.amazonaws.com"
+                  "ec2.amazonaws.com{{if .IsChinaRegion}}.cn{{end}}"
                 ]
               }
             }


### PR DESCRIPTION
The `Service` in IAM profile is different in Global regions and China region. It's a little bit ugly to expose a var named `IsChinaRegion`, but I don't know whether there is a better way to fix this.
