### PR TITLE
Add option to mount existing Amazon EFS volume.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -169,7 +169,7 @@ type Cluster struct {
 	UseCalico                bool              `yaml:"useCalico,omitempty"`
 	Subnets                  []*Subnet         `yaml:"subnets,omitempty"`
 	MapPublicIPs             bool              `yaml:"mapPublicIPs,omitempty"`
-	ElasticFileSystem        string            `yaml:"elasticFileSystem,omitempty"`
+	ElasticFileSystemID      string            `yaml:"elasticFileSystemId,omitempty"`
 	Experimental             Experimental      `yaml:"experimental"`
 	providedEncryptService   encryptService
 }

--- a/config/config.go
+++ b/config/config.go
@@ -169,6 +169,7 @@ type Cluster struct {
 	UseCalico                bool              `yaml:"useCalico,omitempty"`
 	Subnets                  []*Subnet         `yaml:"subnets,omitempty"`
 	MapPublicIPs             bool              `yaml:"mapPublicIPs,omitempty"`
+	ElasticFileSystem        string            `yaml:"elasticFileSystem,omitempty"`
 	Experimental             Experimental      `yaml:"experimental"`
 	providedEncryptService   encryptService
 }

--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -186,6 +186,23 @@ coreos:
         ExecStart=/opt/bin/install-calico-system
 {{ end }}
 
+{{ if $.ElasticFileSystem }}
+    - name: rpc-statd.service
+      command: start
+      enable: true
+    - name: efs.service
+      command: start
+      content: |
+        [Service]
+        ExecStartPre=-/usr/bin/mkdir -p /efs
+        ExecStart=/bin/sh -c 'grep -qs /efs /proc/mounts || /usr/bin/mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 $(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone).{{ $.ElasticFileSystem }}.efs.{{ $.Region }}.amazonaws.com:/ /efs'
+        Restart=always
+        RestartSec=60
+        [Install]
+        WantedBy=kubelet.service
+{{ end }}
+
+
 write_files:
   - path: /opt/bin/install-kube-system
     permissions: 0700

--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -186,7 +186,7 @@ coreos:
         ExecStart=/opt/bin/install-calico-system
 {{ end }}
 
-{{ if $.ElasticFileSystem }}
+{{ if $.ElasticFileSystemID }}
     - name: rpc-statd.service
       command: start
       enable: true
@@ -195,7 +195,7 @@ coreos:
       content: |
         [Service]
         ExecStartPre=-/usr/bin/mkdir -p /efs
-        ExecStart=/bin/sh -c 'grep -qs /efs /proc/mounts || /usr/bin/mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 $(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone).{{ $.ElasticFileSystem }}.efs.{{ $.Region }}.amazonaws.com:/ /efs'
+        ExecStart=/bin/sh -c 'grep -qs /efs /proc/mounts || /usr/bin/mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 $(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone).{{ $.ElasticFileSystemID }}.efs.{{ $.Region }}.amazonaws.com:/ /efs'
         Restart=always
         RestartSec=60
         [Install]

--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -198,8 +198,6 @@ coreos:
         ExecStartPre=-/usr/bin/mkdir -p /efs
         ExecStart=/bin/sh -c 'grep -qs /efs /proc/mounts || /usr/bin/mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 $(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone).{{ $.ElasticFileSystemID }}.efs.{{ $.Region }}.amazonaws.com:/ /efs'
         ExecStop=/usr/bin/umount /efs
-        Restart=always
-        RestartSec=60
         RemainAfterExit=yes
         [Install]
         WantedBy=kubelet.service

--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -194,10 +194,13 @@ coreos:
       command: start
       content: |
         [Service]
+        Type=oneshot
         ExecStartPre=-/usr/bin/mkdir -p /efs
         ExecStart=/bin/sh -c 'grep -qs /efs /proc/mounts || /usr/bin/mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 $(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone).{{ $.ElasticFileSystemID }}.efs.{{ $.Region }}.amazonaws.com:/ /efs'
+        ExecStop=/usr/bin/umount /efs
         Restart=always
         RestartSec=60
+        RemainAfterExit=yes
         [Install]
         WantedBy=kubelet.service
 {{ end }}

--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -172,6 +172,21 @@ coreos:
         [Install]
         RequiredBy=kubelet.service
     {{ end }}
+{{ if $.ElasticFileSystem }}
+    - name: rpc-statd.service
+      command: start
+      enable: true
+    - name: efs.service
+      command: start
+      content: |
+        [Service]
+        ExecStartPre=-/usr/bin/mkdir -p /efs
+        ExecStart=/bin/sh -c 'grep -qs /efs /proc/mounts || /usr/bin/mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 $(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone).{{ $.ElasticFileSystem }}.efs.{{ $.Region }}.amazonaws.com:/ /efs'
+        Restart=always
+        RestartSec=60
+        [Install]
+        WantedBy=kubelet.service
+{{ end }}
 
 write_files:
   - path: /etc/kubernetes/cni/docker_opts_cni.env

--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -180,10 +180,13 @@ coreos:
       command: start
       content: |
         [Service]
+        Type=oneshot
         ExecStartPre=-/usr/bin/mkdir -p /efs
         ExecStart=/bin/sh -c 'grep -qs /efs /proc/mounts || /usr/bin/mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 $(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone).{{ $.ElasticFileSystemID }}.efs.{{ $.Region }}.amazonaws.com:/ /efs'
+        ExecStop=/usr/bin/umount /efs
         Restart=always
         RestartSec=60
+        RemainAfterExit=yes
         [Install]
         WantedBy=kubelet.service
 {{ end }}

--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -172,7 +172,7 @@ coreos:
         [Install]
         RequiredBy=kubelet.service
     {{ end }}
-{{ if $.ElasticFileSystem }}
+{{ if $.ElasticFileSystemID }}
     - name: rpc-statd.service
       command: start
       enable: true
@@ -181,7 +181,7 @@ coreos:
       content: |
         [Service]
         ExecStartPre=-/usr/bin/mkdir -p /efs
-        ExecStart=/bin/sh -c 'grep -qs /efs /proc/mounts || /usr/bin/mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 $(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone).{{ $.ElasticFileSystem }}.efs.{{ $.Region }}.amazonaws.com:/ /efs'
+        ExecStart=/bin/sh -c 'grep -qs /efs /proc/mounts || /usr/bin/mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 $(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone).{{ $.ElasticFileSystemID }}.efs.{{ $.Region }}.amazonaws.com:/ /efs'
         Restart=always
         RestartSec=60
         [Install]

--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -184,8 +184,6 @@ coreos:
         ExecStartPre=-/usr/bin/mkdir -p /efs
         ExecStart=/bin/sh -c 'grep -qs /efs /proc/mounts || /usr/bin/mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 $(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone).{{ $.ElasticFileSystemID }}.efs.{{ $.Region }}.amazonaws.com:/ /efs'
         ExecStop=/usr/bin/umount /efs
-        Restart=always
-        RestartSec=60
         RemainAfterExit=yes
         [Install]
         WantedBy=kubelet.service

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -152,7 +152,7 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #
 # You can create a new EFS volume using the CLI:
 # $ aws efs create-file-system --creation-token $(uuidgen)
-#elasticFileSystem: fs-47a2c22e
+#elasticFileSystemId: fs-47a2c22e
 
 # Determines the container runtime for kubernetes to use. Accepts 'docker' or 'rkt'.
 # containerRuntime: docker

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -147,6 +147,13 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # Use Calico for network policy.
 # useCalico: false
 
+# Create MountTargets for a pre-existing Elastic File System (Amazon EFS). Enter the resource id, eg "fs-47a2c22e"
+# This is a NFS share that will be available across the entire cluster through a hostPath volume on the "/efs" mountpoint
+#
+# You can create a new EFS volume using the CLI:
+# $ aws efs create-file-system --creation-token $(uuidgen)
+#elasticFileSystem: fs-47a2c22e
+
 # Determines the container runtime for kubernetes to use. Accepts 'docker' or 'rkt'.
 # containerRuntime: docker
 

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -792,7 +792,7 @@
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
     }
-    {{if $.ElasticFileSystem}}
+    {{if $.ElasticFileSystemID}}
     ,
     "SecurityGroupMountTarget": {
       "Properties": {
@@ -842,11 +842,11 @@
       },
       "Type": "AWS::EC2::Subnet"
     }
-    {{if $.ElasticFileSystem}}
+    {{if $.ElasticFileSystemID}}
     ,
     "{{$subnetLogicalName}}MountTarget": {
       "Properties" : {
-        "FileSystemId": "{{$.ElasticFileSystem}}",
+        "FileSystemId": "{{$.ElasticFileSystemID}}",
         "SubnetId": { "Ref": "{{$subnetLogicalName}}" },
         "SecurityGroups": [ { "Ref": "SecurityGroupMountTarget" } ]
       },

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -792,6 +792,38 @@
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
     }
+    {{if $.ElasticFileSystem}}
+    ,
+    "SecurityGroupMountTarget": {
+      "Properties": {
+        "GroupDescription": {
+          "Ref": "AWS::StackName"
+        },
+        "SecurityGroupIngress": [
+          {
+            "SourceSecurityGroupId": { "Ref": "SecurityGroupWorker" },
+            "FromPort": 2049,
+            "IpProtocol": "tcp",
+            "ToPort": 2049
+          },
+          {
+            "SourceSecurityGroupId": { "Ref": "SecurityGroupController" },
+            "FromPort": 2049,
+            "IpProtocol": "tcp",
+            "ToPort": 2049
+          }
+        ],
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "Value": "{{.ClusterName}}"
+          }
+        ],
+        "VpcId": {{.VPCRef}}
+      },
+      "Type": "AWS::EC2::SecurityGroup"
+    }
+    {{end}}
     {{range $index, $subnet := .Subnets}}
     {{with $subnetLogicalName := printf "Subnet%d" $index}}
     ,
@@ -810,6 +842,17 @@
       },
       "Type": "AWS::EC2::Subnet"
     }
+    {{if $.ElasticFileSystem}}
+    ,
+    "{{$subnetLogicalName}}MountTarget": {
+      "Properties" : {
+        "FileSystemId": "{{$.ElasticFileSystem}}",
+        "SubnetId": { "Ref": "{{$subnetLogicalName}}" },
+        "SecurityGroups": [ { "Ref": "SecurityGroupMountTarget" } ]
+      },
+      "Type" : "AWS::EFS::MountTarget"
+    }
+    {{end}}
     {{end}}
     {{end}}
     {{if not .VPCID}}


### PR DESCRIPTION
This still needs some work but i think it currently qualifies and fills a need.

Creating (and later finding) an EFS volume through cloudformation is more trouble than it's worth so the option currently requires an existing EFS-id. We can later turn this into an option which requires a unique id for creating the volume. We'd need to create the volume before we evaluate the stack-template though and my Go skills are still quite rusty so i think it's better to do that in a separate PR.

(nearly) fixes #10