### PR TITLE
Don't overwrite the CA by default on deprecated 'render' command

### DIFF
--- a/cmd/kube-aws/command_render.go
+++ b/cmd/kube-aws/command_render.go
@@ -64,7 +64,10 @@ func runCmdRender(cmd *cobra.Command, args []string) error {
 	if len(args) != 0 {
 		return fmt.Errorf("render takes no arguments\n")
 	}
-	renderCredentialsOpts.generateCA = true
+
+	if _, err := os.Stat(renderCredentialsOpts.caKeyPath); os.IsNotExist(err) {
+		renderCredentialsOpts.generateCA = true
+	}
 	if err := runCmdRenderCredentials(cmdRenderCredentials, args); err != nil {
 		return err
 	}


### PR DESCRIPTION
Note that it will overwrite all the other TLS assets. I think this is okay or maybe even desired. This will at least prevent some harm..

fixes #16