### PR TITLE
[build] only set target os/arch for compile

### DIFF
--- a/build
+++ b/build
@@ -19,4 +19,11 @@ fi
 echo Building kube-aws ${VERSION}
 
 go generate ./config
+
+if [[ ! "${BUILD_GOOS:-}" == "" ]];then
+  export GOOS=$BUILD_GOOS
+fi
+if [[ ! "${BUILD_GOARCH:-}" == "" ]];then
+  export GOARCH=$BUILD_GOARCH
+fi
 go build -ldflags "-X github.com/coreos/kube-aws/cluster.VERSION=${VERSION}" -a -tags netgo -installsuffix netgo -o "$OUTPUT_PATH" ./cmd/kube-aws

--- a/build-release-binaries
+++ b/build-release-binaries
@@ -12,7 +12,7 @@ for os in linux darwin;do
 	rm -rf "$output_folder"
 	mkdir "$output_folder"
 	echo "Building kube-aws for GOOS=${os} GOARCH=${arch}"
-	OUTPUT_PATH="$output_folder/kube-aws" GOOS=$os GOARCH=$arch ./build
+	OUTPUT_PATH="$output_folder/kube-aws" BUILD_GOOS=$os BUILD_GOARCH=$arch ./build
 
 	releaseTar=kube-aws-"${os}-${arch}".tar.gz
 	rm -rf "$releaseTar"


### PR DESCRIPTION
Having `GOOS=darwin` on my fedora box causes `go generate` to fail with a weird error. This fixes that problem (encountered when building release binaries).

\cc @mumoshu 