### PR TITLE
Feature/external etcd

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -225,7 +225,7 @@ func (c *Cluster) createStack(cfSvc cloudformationService, stackBody string) (*c
 	}
 
 	var creq *cloudformation.CreateStackInput
-	if(c.EtcdLoadBalancer == "") {
+	if c.EtcdLoadBalancer == "" {
 		creq = &cloudformation.CreateStackInput{
 			StackName:    aws.String(c.ClusterName),
 			OnFailure:    aws.String(cloudformation.OnFailureDoNothing),
@@ -335,7 +335,7 @@ func (c *Cluster) Update(stackBody string) (string, error) {
 
 	cfSvc := cloudformation.New(c.session)
 	var err error
-	if(c.EtcdLoadBalancer == "") {
+	if c.EtcdLoadBalancer == "" {
 		if stackBody, err = c.lockEtcdResources(cfSvc, stackBody); err != nil {
 			return "", err
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -283,7 +283,7 @@ func (c Cluster) Config() (*Config, error) {
 			nextAddr := incrementIP(*subnet.lastAllocatedAddr)
 			subnet.lastAllocatedAddr = &nextAddr
 			instance := etcdInstance{
-				IPAddress:	 *subnet.lastAllocatedAddr,
+				IPAddress:   *subnet.lastAllocatedAddr,
 				SubnetIndex: subnetIndex,
 			}
 

--- a/config/config.go
+++ b/config/config.go
@@ -253,7 +253,7 @@ func (c Cluster) Config() (*Config, error) {
 
 	// Use custom etcd cluster if etcdLoadBalancer is set. TODO some minimal URL validation.
 	if config.EtcdLoadBalancer != "" {
-		config.EtcdEndpoints = fmt.Sprintf("%q", config.EtcdLoadBalancer)
+		config.EtcdEndpoints = config.EtcdLoadBalancer
 		// Keep EtcdInitialCluster empty as sign for the template engine to skip etcd node creation
 		config.EtcdInitialCluster = ""
 	} else {

--- a/config/config.go
+++ b/config/config.go
@@ -146,6 +146,7 @@ type Cluster struct {
 	WorkerRootVolumeSize     int               `yaml:"workerRootVolumeSize,omitempty"`
 	WorkerSpotPrice          string            `yaml:"workerSpotPrice,omitempty"`
 	EtcdLoadBalancer         string            `yaml:"etcdLoadBalancer,omitempty"`
+	EtcdSecurityGroups       []string          `yaml:"etcdSecurityGroups,omitempty"`
 	EtcdCount                int               `yaml:"etcdCount"`
 	EtcdInstanceType         string            `yaml:"etcdInstanceType,omitempty"`
 	EtcdRootVolumeSize       int               `yaml:"etcdRootVolumeSize,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -145,6 +145,7 @@ type Cluster struct {
 	WorkerRootVolumeIOPS     int               `yaml:"workerRootVolumeIOPS,omitempty"`
 	WorkerRootVolumeSize     int               `yaml:"workerRootVolumeSize,omitempty"`
 	WorkerSpotPrice          string            `yaml:"workerSpotPrice,omitempty"`
+	EtcdLoadBalancer         string            `yaml:"etcdLoadBalancer,omitempty"`
 	EtcdCount                int               `yaml:"etcdCount"`
 	EtcdInstanceType         string            `yaml:"etcdInstanceType,omitempty"`
 	EtcdRootVolumeSize       int               `yaml:"etcdRootVolumeSize,omitempty"`
@@ -250,76 +251,83 @@ func (c Cluster) Config() (*Config, error) {
 		config.VPCRef = fmt.Sprintf("%q", config.VPCID)
 	}
 
-	config.EtcdInstances = make([]etcdInstance, config.EtcdCount)
-	var etcdEndpoints, etcdInitialCluster bytes.Buffer
-	for etcdIndex := 0; etcdIndex < config.EtcdCount; etcdIndex++ {
+	// Use custom etcd cluster if etcdLoadBalancer is set. TODO some minimal URL validation.
+	if config.EtcdLoadBalancer != "" {
+		config.EtcdEndpoints = fmt.Sprintf("%q", config.EtcdLoadBalancer)
+		// Keep EtcdInitialCluster empty as sign for the template engine to skip etcd node creation
+		config.EtcdInitialCluster = ""
+	} else {
+		config.EtcdInstances = make([]etcdInstance, config.EtcdCount)
+		var etcdEndpoints, etcdInitialCluster bytes.Buffer
+		for etcdIndex := 0; etcdIndex < config.EtcdCount; etcdIndex++ {
 
-		//Round-robbin etcd instances across all available subnets
-		subnetIndex := etcdIndex % len(config.Subnets)
-		subnet := config.Subnets[subnetIndex]
+			//Round-robbin etcd instances across all available subnets
+			subnetIndex := etcdIndex % len(config.Subnets)
+			subnet := config.Subnets[subnetIndex]
 
-		_, subnetCIDR, err := net.ParseCIDR(subnet.InstanceCIDR)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing subnet instance cidr %s: %v", subnet.InstanceCIDR, err)
-		}
-
-		if subnet.lastAllocatedAddr == nil {
-			ip := subnetCIDR.IP
-			//TODO:(chom) this is sloppy, but "soon-ish" etcd with be self-hosted so we'll leave this be
-			for i := 0; i < 3; i++ {
-				ip = incrementIP(ip)
+			_, subnetCIDR, err := net.ParseCIDR(subnet.InstanceCIDR)
+			if err != nil {
+				return nil, fmt.Errorf("error parsing subnet instance cidr %s: %v", subnet.InstanceCIDR, err)
 			}
-			subnet.lastAllocatedAddr = &ip
+
+			if subnet.lastAllocatedAddr == nil {
+				ip := subnetCIDR.IP
+				//TODO:(chom) this is sloppy, but "soon-ish" etcd with be self-hosted so we'll leave this be
+				for i := 0; i < 3; i++ {
+					ip = incrementIP(ip)
+				}
+				subnet.lastAllocatedAddr = &ip
+			}
+
+			nextAddr := incrementIP(*subnet.lastAllocatedAddr)
+			subnet.lastAllocatedAddr = &nextAddr
+			instance := etcdInstance{
+				IPAddress:	 *subnet.lastAllocatedAddr,
+				SubnetIndex: subnetIndex,
+			}
+
+			//TODO(chom): validate we're not overflowing the address space
+			//This is complicated, must also factor in DHCP addresses
+			//for ASG components
+
+			//Punt on this- we're going to have an answer for dynamic etcd clusters at some point. Then we can either throw
+			//the instances in an ASG and use DHCP like all other instances, or simply self-host on cluster
+
+			config.EtcdInstances[etcdIndex] = instance
+
+			//TODO: ipv6 support
+			if len(instance.IPAddress) != 4 {
+				return nil, fmt.Errorf("Non ipv4 address for etcd node: %v", instance.IPAddress)
+			}
+
+			//http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#concepts-private-addresses
+
+			var dnsSuffix string
+			if config.Region == "us-east-1" {
+				// a special DNS suffix for the original AWS region!
+				dnsSuffix = "ec2.internal"
+			} else {
+				dnsSuffix = fmt.Sprintf("%s.compute.internal", config.Region)
+			}
+
+			hostname := fmt.Sprintf("ip-%d-%d-%d-%d.%s",
+				instance.IPAddress[0],
+				instance.IPAddress[1],
+				instance.IPAddress[2],
+				instance.IPAddress[3],
+				dnsSuffix,
+			)
+
+			fmt.Fprintf(&etcdEndpoints, "https://%s:2379", hostname)
+			fmt.Fprintf(&etcdInitialCluster, "%s=https://%s:2380", hostname, hostname)
+			if etcdIndex < config.EtcdCount-1 {
+				fmt.Fprintf(&etcdEndpoints, ",")
+				fmt.Fprintf(&etcdInitialCluster, ",")
+			}
 		}
-
-		nextAddr := incrementIP(*subnet.lastAllocatedAddr)
-		subnet.lastAllocatedAddr = &nextAddr
-		instance := etcdInstance{
-			IPAddress:   *subnet.lastAllocatedAddr,
-			SubnetIndex: subnetIndex,
-		}
-
-		//TODO(chom): validate we're not overflowing the address space
-		//This is complicated, must also factor in DHCP addresses
-		//for ASG components
-
-		//Punt on this- we're going to have an answer for dynamic etcd clusters at some point. Then we can either throw
-		//the instances in an ASG and use DHCP like all other instances, or simply self-host on cluster
-
-		config.EtcdInstances[etcdIndex] = instance
-
-		//TODO: ipv6 support
-		if len(instance.IPAddress) != 4 {
-			return nil, fmt.Errorf("Non ipv4 address for etcd node: %v", instance.IPAddress)
-		}
-
-		//http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#concepts-private-addresses
-
-		var dnsSuffix string
-		if config.Region == "us-east-1" {
-			// a special DNS suffix for the original AWS region!
-			dnsSuffix = "ec2.internal"
-		} else {
-			dnsSuffix = fmt.Sprintf("%s.compute.internal", config.Region)
-		}
-
-		hostname := fmt.Sprintf("ip-%d-%d-%d-%d.%s",
-			instance.IPAddress[0],
-			instance.IPAddress[1],
-			instance.IPAddress[2],
-			instance.IPAddress[3],
-			dnsSuffix,
-		)
-
-		fmt.Fprintf(&etcdEndpoints, "https://%s:2379", hostname)
-		fmt.Fprintf(&etcdInitialCluster, "%s=https://%s:2380", hostname, hostname)
-		if etcdIndex < config.EtcdCount-1 {
-			fmt.Fprintf(&etcdEndpoints, ",")
-			fmt.Fprintf(&etcdInitialCluster, ",")
-		}
+		config.EtcdEndpoints = etcdEndpoints.String()
+		config.EtcdInitialCluster = etcdInitialCluster.String()
 	}
-	config.EtcdEndpoints = etcdEndpoints.String()
-	config.EtcdInitialCluster = etcdInitialCluster.String()
 
 	config.IsChinaRegion = strings.HasPrefix(config.Region, "cn")
 

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -84,6 +84,9 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 ## during a cluster upgrade, due to concerns over data loss.
 ## This situation is being rectified with work towards automated management of etcd clusters
 
+# Set this value to the full HTTP/HTTPS endpoint of your existing etcd cluster or leave commented to build a new cluster as part of this stack.
+#etcdLoadBalancer: "http://my.etcd.cluster.local:2379"
+
 # Number of etcd nodes
 # (Set to an odd number >= 3 for HA control plane)
 # etcdCount: 1

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -86,6 +86,7 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 
 # Set this value to the full HTTP/HTTPS endpoint of your existing etcd cluster or leave commented to build a new cluster as part of this stack.
 #etcdLoadBalancer: "http://my.etcd.cluster.local:2379"
+#etcdSecurityGroups: [ "sg-abcdefg", "sg-1234567" ]
 
 # Number of etcd nodes
 # (Set to an odd number >= 3 for HA control plane)

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -804,6 +804,37 @@
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
     }
+    {{else}}
+    {{range $index, $securitygroup := .EtcdSecurityGroups}}
+    {{with $securityGroupLogicalName := printf "etcdSecurityGroup%d" $index}}
+    ,
+    "{{$securityGroupLogicalName}}FromWorker": {
+      "Properties": {
+        "FromPort": 2379,
+        "GroupId": "{{$securitygroup}}",
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "ToPort": 2379
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "{{$securityGroupLogicalName}}FromWorker": {
+      "Properties": {
+        "FromPort": 2379,
+        "GroupId": "{{$securitygroup}}",
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "ToPort": 2379
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    }
+    {{end}}
+    {{end}}
+    {{end}}
     {{if $.ElasticFileSystemID}}
     ,
     "SecurityGroupMountTarget": {
@@ -835,36 +866,6 @@
       },
       "Type": "AWS::EC2::SecurityGroup"
     }
-    {{else}}
-    {{range $index, $securitygroup := .EtcdSecurityGroups}}
-    {{with $securityGroupLogicalName := printf "etcdSecurityGroup%d" $index}}
-    ,
-    "{{$securityGroupLogicalName}}FromWorker": {
-      "Properties": {
-        "FromPort": 2379,
-        "GroupId": "{{$securitygroup}}",
-        "IpProtocol": "tcp",
-        "SourceSecurityGroupId": {
-          "Ref": "SecurityGroupWorker"
-        },
-        "ToPort": 2379
-      },
-      "Type": "AWS::EC2::SecurityGroupIngress"
-    },
-    "{{$securityGroupLogicalName}}FromWorker": {
-      "Properties": {
-        "FromPort": 2379,
-        "GroupId": "{{$securitygroup}}",
-        "IpProtocol": "tcp",
-        "SourceSecurityGroupId": {
-          "Ref": "SecurityGroupController"
-        },
-        "ToPort": 2379
-      },
-      "Type": "AWS::EC2::SecurityGroupIngress"
-    }
-    {{end}}
-    {{end}}
     {{end}}
     {{range $index, $subnet := .Subnets}}
     {{with $subnetLogicalName := printf "Subnet%d" $index}}

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -1,6 +1,7 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
   "Description": "kube-aws Kubernetes cluster {{.ClusterName}}",
+  {{if .EtcdInitialCluster}}
   "Mappings" : {
     "EtcdInstanceParams" : {
       "UserData" : {
@@ -8,6 +9,7 @@
       }
     }
   },
+  {{end}}
   "Resources": {
     "AutoScaleWorker": {
       "Properties": {
@@ -152,6 +154,7 @@
       },
       "Type": "AWS::IAM::InstanceProfile"
     },
+    {{if .EtcdInitialCluster}}
     "IAMInstanceProfileEtcd": {
       "Properties": {
         "Path": "/",
@@ -163,6 +166,7 @@
       },
       "Type": "AWS::IAM::InstanceProfile"
     },
+    {{end}}
     "IAMRoleController": {
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -275,6 +279,7 @@
       },
       "Type": "AWS::IAM::Role"
     },
+    {{if .EtcdInitialCluster}}
     "IAMRoleEtcd": {
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -369,6 +374,7 @@
       },
       "Type": "AWS::EC2::Instance"
     },
+    {{end}}
     {{end}}
     "LaunchConfigurationWorker": {
       "Properties": {
@@ -546,6 +552,7 @@
       },
       "Type": "AWS::EC2::SecurityGroup"
     },
+    {{if .EtcdInitialCluster}}
     "SecurityGroupControllerIngressFromWorkerToEtcd": {
       "Properties": {
         "FromPort": 2379,
@@ -560,6 +567,7 @@
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
     },
+    {{end}}
     "SecurityGroupWorker": {
       "Properties": {
         "GroupDescription": {
@@ -665,6 +673,7 @@
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
     },
+    {{if .EtcdInitialCluster}}
     "SecurityGroupEtcdIngressFromControllerToEtcd": {
       "Properties": {
         "FromPort": 2379,
@@ -693,6 +702,7 @@
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
     },
+    {{end}}
     "SecurityGroupWorkerIngressFromWorkerToFlannel": {
       "Properties": {
         "FromPort": 8472,
@@ -734,7 +744,9 @@
         "ToPort": 10255
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
-    },
+    }
+    {{if .EtcdInitialCluster}}
+    ,
     "SecurityGroupEtcd": {
       "Properties": {
         "GroupDescription": {

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -835,6 +835,36 @@
       },
       "Type": "AWS::EC2::SecurityGroup"
     }
+    {{else}}
+    {{range $index, $securitygroup := .EtcdSecurityGroups}}
+    {{with $securityGroupLogicalName := printf "etcdSecurityGroup%d" $index}}
+    ,
+    "{{$securityGroupLogicalName}}FromWorker": {
+      "Properties": {
+        "FromPort": 2379,
+        "GroupId": "{{$securitygroup}}",
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupWorker"
+        },
+        "ToPort": 2379
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
+    "{{$securityGroupLogicalName}}FromWorker": {
+      "Properties": {
+        "FromPort": 2379,
+        "GroupId": "{{$securitygroup}}",
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "ToPort": 2379
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    }
+    {{end}}
+    {{end}}
     {{end}}
     {{range $index, $subnet := .Subnets}}
     {{with $subnetLogicalName := printf "Subnet%d" $index}}


### PR DESCRIPTION
Work in progress for pointing the kube cluster to an externally managed etcd cluster.

To disable the discrete etcd cluster 'embedded' in kube-aws, set the following parameters:
```
# Set this value to the full HTTP/HTTPS endpoint of your existing etcd cluster or leave commented to build a new cluster as part of this stack.
#etcdLoadBalancer: "http://my.etcd.cluster.local:2379"
#etcdSecurityGroups: [ "sg-abcdefg", "sg-1234567" ]
```

`etcdLoadBalancer` is a stable address to find the etcd cluster on, in many cases an ELB.
One must set `etcdSecurityGroups` in order to automatically add [SecurityGroupIngress](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group-ingress.html) resources to said securitygroups, allowing the kubernetes components access on port `2379`.

This is highly volatile code. :bomb:

Ref: #27 