### PR TITLE
Remove "Restart=on-failure" from kube-node-drainer.service

### DIFF
--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -152,7 +152,6 @@ coreos:
         [Service]
         Type=oneshot
         RemainAfterExit=true
-        Restart=on-failure
         ExecStartPre=/usr/bin/systemctl is-active kubelet.service
         ExecStartPre=/usr/bin/systemctl is-active docker.service
         ExecStart=/bin/true


### PR DESCRIPTION
Systemd only allows "Restart=no" for  "Type=oneshot" services.