### PR TITLE
feat: `kube-aws up --s3-uri s3://<bucket>/<directory> to automatically avoid the 51200 bytes limitation errors of CloudFormation

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -397,7 +397,7 @@ func (c *Cluster) updateStackWithTemplateBody(cfSvc *cloudformation.CloudFormati
 
 func (c *Cluster) updateStackWithTemplateURL(cfSvc *cloudformation.CloudFormation, templateURL string) (*cloudformation.UpdateStackOutput, error) {
 	input := c.baseUpdateStackInput()
-	input.TemplateBody = aws.String(templateURL)
+	input.TemplateURL = aws.String(templateURL)
 	return cfSvc.UpdateStack(input)
 }
 

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -532,7 +532,7 @@ stackTags:
 			ExpectedTags: testCase.expectedTags,
 		}
 
-		_, err = cluster.createStack(cfSvc, "")
+		_, err = cluster.createStackFromTemplateBody(cfSvc, "")
 
 		if err != nil {
 			t.Errorf("error creating cluster: %v\nfor test case %+v", err, testCase)

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"testing"
 
+	"bytes"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/coreos/kube-aws/config"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -481,6 +483,65 @@ func (cfSvc *dummyCloudformationService) CreateStack(req *cloudformation.CreateS
 	return resp, nil
 }
 
+type dummyS3ObjectPutterService struct {
+	ExpectedBucket        string
+	ExpectedKey           string
+	ExpectedBody          string
+	ExpectedContentType   string
+	ExpectedContentLength int64
+}
+
+func (s3Svc dummyS3ObjectPutterService) PutObject(input *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
+
+	if s3Svc.ExpectedContentLength != *input.ContentLength {
+		return nil, fmt.Errorf(
+			"expected content length does not match supplied content length\nexpected=%v, supplied=%v",
+			s3Svc.ExpectedContentLength,
+			input.ContentLength,
+		)
+	}
+
+	if s3Svc.ExpectedBucket != *input.Bucket {
+		return nil, fmt.Errorf(
+			"expected bucket does not match supplied bucket\nexpected=%v, supplied=%v",
+			s3Svc.ExpectedBucket,
+			input.Bucket,
+		)
+	}
+
+	if s3Svc.ExpectedKey != *input.Key {
+		return nil, fmt.Errorf(
+			"expected key does not match supplied key\nexpected=%v, supplied=%v",
+			s3Svc.ExpectedKey,
+			*input.Key,
+		)
+	}
+
+	if s3Svc.ExpectedContentType != *input.ContentType {
+		return nil, fmt.Errorf(
+			"expected content type does not match supplied content type\nexpected=%v, supplied=%v",
+			s3Svc.ExpectedContentType,
+			input.ContentType,
+		)
+	}
+
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(input.Body)
+	suppliedBody := buf.String()
+
+	if s3Svc.ExpectedBody != suppliedBody {
+		return nil, fmt.Errorf(
+			"expected body does not match supplied body\nexpected=%v, supplied=%v",
+			s3Svc.ExpectedBody,
+			suppliedBody,
+		)
+	}
+
+	resp := &s3.PutObjectOutput{}
+
+	return resp, nil
+}
+
 func TestStackTags(t *testing.T) {
 	testCases := []struct {
 		expectedTags []*cloudformation.Tag
@@ -789,5 +850,35 @@ workerRootVolumeIOPS: 2000
 		if err := c.validateWorkerRootVolume(ec2Svc); err != nil {
 			t.Errorf("error creating cluster: %v\nfor test case %+v", err, testCase)
 		}
+	}
+}
+
+func TestUploadTemplate(t *testing.T) {
+	body := "{}"
+	s3URI := "s3://mybucket/mykey"
+	s3Svc := dummyS3ObjectPutterService{
+		ExpectedBucket:        "mybucket",
+		ExpectedKey:           "mykey/test-cluster-name.stack.json",
+		ExpectedContentLength: 2,
+		ExpectedContentType:   "application/json",
+		ExpectedBody:          body,
+	}
+
+	clusterConfig, err := config.ClusterFromBytes([]byte(defaultConfigValues(t, "")))
+	if err != nil {
+		t.Errorf("could not get valid cluster config: %v", err)
+	}
+
+	c := &Cluster{Cluster: *clusterConfig}
+
+	suppliedURL, err := c.uploadTemplate(s3Svc, s3URI, body)
+
+	if err != nil {
+		t.Errorf("error uploading template: %v", err)
+	}
+
+	expectedURL := "https://s3.amazonaws.com/mybucket/mykey/test-cluster-name.stack.json"
+	if suppliedURL != expectedURL {
+		t.Errorf("supplied template url doesn't match expected one: expected=%s, supplied=%s", expectedURL, suppliedURL)
 	}
 }

--- a/cmd/kube-aws/command_up.go
+++ b/cmd/kube-aws/command_up.go
@@ -20,6 +20,7 @@ var (
 
 	upOpts = struct {
 		awsDebug, export bool
+		s3URI            string
 	}{}
 )
 
@@ -27,6 +28,7 @@ func init() {
 	cmdRoot.AddCommand(cmdUp)
 	cmdUp.Flags().BoolVar(&upOpts.export, "export", false, "Don't create cluster, instead export cloudformation stack file")
 	cmdUp.Flags().BoolVar(&upOpts.awsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
+	cmdUp.Flags().StringVar(&upOpts.s3URI, "s3-uri", "", "When your template is bigger than the cloudformation limit of 51200 bytes, upload the template to the specified location in S3")
 }
 
 func runCmdUp(cmd *cobra.Command, args []string) error {
@@ -58,7 +60,7 @@ func runCmdUp(cmd *cobra.Command, args []string) error {
 
 	cluster := cluster.New(conf, upOpts.awsDebug)
 	fmt.Printf("Creating AWS resources. This should take around 5 minutes.\n")
-	if err := cluster.Create(string(data)); err != nil {
+	if err := cluster.Create(string(data), upOpts.s3URI); err != nil {
 		return fmt.Errorf("Error creating cluster: %v", err)
 	}
 

--- a/cmd/kube-aws/command_update.go
+++ b/cmd/kube-aws/command_update.go
@@ -19,12 +19,14 @@ var (
 
 	updateOpts = struct {
 		awsDebug bool
+		s3URI    string
 	}{}
 )
 
 func init() {
 	cmdRoot.AddCommand(cmdUpdate)
 	cmdUpdate.Flags().BoolVar(&updateOpts.awsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
+	cmdUpdate.Flags().StringVar(&updateOpts.s3URI, "s3-uri", "", "When your template is bigger than the cloudformation limit of 51200 bytes, upload the template to the specified location in S3")
 }
 
 func runCmdUpdate(cmd *cobra.Command, args []string) error {
@@ -44,7 +46,7 @@ func runCmdUpdate(cmd *cobra.Command, args []string) error {
 
 	cluster := cluster.New(conf, updateOpts.awsDebug)
 
-	report, err := cluster.Update(string(data))
+	report, err := cluster.Update(string(data), updateOpts.s3URI)
 	if err != nil {
 		return fmt.Errorf("Error updating cluster: %v", err)
 	}

--- a/cmd/kube-aws/command_validate.go
+++ b/cmd/kube-aws/command_validate.go
@@ -20,6 +20,7 @@ var (
 
 	validateOpts = struct {
 		awsDebug bool
+		s3URI string
 	}{}
 )
 
@@ -30,6 +31,12 @@ func init() {
 		"aws-debug",
 		false,
 		"Log debug information from aws-sdk-go library",
+	)
+	cmdValidate.Flags().StringVar(
+		&validateOpts.s3URI,
+		"s3-uri",
+		"",
+		"When your template is bigger than the cloudformation limit of 51200 bytes, upload the template to the specified location in S3",
 	)
 }
 
@@ -52,7 +59,7 @@ func runCmdValidate(cmd *cobra.Command, args []string) error {
 	}
 
 	cluster := cluster.New(cfg, validateOpts.awsDebug)
-	report, err := cluster.ValidateStack(string(data))
+	report, err := cluster.ValidateStack(string(data), validateOpts.s3URI)
 	if report != "" {
 		fmt.Fprintf(os.Stderr, "Validation Report: %s\n", report)
 	}

--- a/cmd/kube-aws/command_validate.go
+++ b/cmd/kube-aws/command_validate.go
@@ -20,7 +20,7 @@ var (
 
 	validateOpts = struct {
 		awsDebug bool
-		s3URI string
+		s3URI    string
 	}{}
 )
 

--- a/e2e/run
+++ b/e2e/run
@@ -110,8 +110,8 @@ destroy() {
 update() {
   cd ${WORK_DIR}
   SED_CMD="sed -e 's/workerCount: 4/workerCount: 5/' -e 's/controllerCount: 2/controllerCount: 3/'"
-  diff --unified cluster.yaml <(cat cluster.yaml | sh -c "${SED_CMD}")
-  ${SED_CMD} -i bak cluster.yaml
+  diff --unified cluster.yaml <(cat cluster.yaml | sh -c "${SED_CMD}") || true
+  sh -c '${SED_CMD} -i bak cluster.yaml' || true
   ${KUBE_AWS_CMD} update --s3-uri ${KUBE_AWS_S3_URI}
   aws cloudformation wait stack-update-complete --stack-name ${KUBE_AWS_CLUSTER_NAME}
 

--- a/e2e/run
+++ b/e2e/run
@@ -3,6 +3,7 @@
 KUBE_AWS_CMD=${KUBE_AWS_CMD:-$GOPATH/src/github.com/coreos/kube-aws/bin/kube-aws}
 E2E_DIR=$(cd $(dirname $0); pwd)
 WORK_DIR=${E2E_DIR}/assets/${KUBE_AWS_CLUSTER_NAME}
+SRC_DIR=$(cd $(dirname $0); cd ..; pwd)
 KUBECONFIG=${WORK_DIR}/kubeconfig
 
 export KUBECONFIG
@@ -39,6 +40,12 @@ echo Using the kube-aws command at ${KUBE_AWS_CMD}"($KUBE_AWS_VERSION)". Set KUB
 
 EXTERNAL_DNS_NAME=${KUBE_AWS_CLUSTER_NAME}.${KUBE_AWS_DOMAIN}
 echo The kubernetes API would be accessible via ${EXTERNAL_DNS_NAME}
+
+build() {
+  echo Building kube-aws
+  cd ${SRC_DIR}
+  ./build
+}
 
 prepare() {
   echo Creating or ensuring existence of the kube-aws assets directory ${WORK_DIR}
@@ -167,6 +174,7 @@ conformance_result() {
 }
 
 all() {
+  build
   prepare
   configure
   up

--- a/e2e/run
+++ b/e2e/run
@@ -67,7 +67,7 @@ configure() {
 
   ${KUBE_AWS_CMD} render
 
-  ${KUBE_AWS_CMD} validate
+  ${KUBE_AWS_CMD} validate --s3-uri ${KUBE_AWS_S3_URI}
 
   echo Generated configuration files in ${WORK_DIR}:
   find .
@@ -84,7 +84,7 @@ clean() {
 up() {
   cd ${WORK_DIR}
 
-  ${KUBE_AWS_CMD} up
+  ${KUBE_AWS_CMD} up --s3-uri ${KUBE_AWS_S3_URI}
 
   printf 'Waiting for the Kubernetes API to be accessible'
 
@@ -100,12 +100,20 @@ destroy() {
   aws cloudformation wait stack-delete-complete --stack-name ${KUBE_AWS_CLUSTER_NAME}
 }
 
-test-upgrade() {
-  SED_CMD="sed -e 's/workerCount: 2/workerCount: 4/' -e 's/controllerCount: 2/controllerCount: 3/'"
+update() {
+  cd ${WORK_DIR}
+  SED_CMD="sed -e 's/workerCount: 4/workerCount: 5/' -e 's/controllerCount: 2/controllerCount: 3/'"
   diff --unified cluster.yaml <(cat cluster.yaml | sh -c "${SED_CMD}")
-  sh -c "${SED_CMD} -i bak cluster.yaml"
-  ${KUBE_AWS_CMD} update
+  ${SED_CMD} -i bak cluster.yaml
+  ${KUBE_AWS_CMD} update --s3-uri ${KUBE_AWS_S3_URI}
   aws cloudformation wait stack-update-complete --stack-name ${KUBE_AWS_CLUSTER_NAME}
+
+  printf 'Waiting for the Kubernetes API to be accessible'
+  while ! kubectl get no 2>/dev/null; do
+    sleep 10
+    printf '.'
+  done
+  echo done
 }
 
 test-destruction() {
@@ -162,6 +170,7 @@ all() {
   prepare
   configure
   up
+  update
   conformance
 }
 


### PR DESCRIPTION
If you are hit by the cloudformation limit, `kube-aws up` now fail with a specific error explaining the limit and how to work-around it:

```
$ kube-aws up
Creating AWS resources. This should take around 5 minutes.
Error: Error creating cluster: stack-template.json size(=51673) exceeds the 51200 bytes limit of cloudformation. `--s3-uri s3://<bucket>/path/to/dir` must be specified to upload it to S3 beforehand
```

As the error message says, if you provide the `--s3-uri` option composed of a s3 bucket's name and a path to directory, `kube-aws` uploads your template to s3 if necessary:

```
$ kube-aws up --s3-uri s3://mybucket/mydir
```

resolves #38 (for now)