### PR TITLE
build: fix up containerized release build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .envrc
 coverage.txt
 profile.out
+/.glide

--- a/containerized-build-release-binaries
+++ b/containerized-build-release-binaries
@@ -2,9 +2,15 @@
 set -euo pipefail
 
 COREOS_KUBERNETES_ROOT=$(git rev-parse --show-toplevel)
-sudo rkt run \
-    --volume bk,kind=host,source=${COREOS_KUBERNETES_ROOT} \
-    --mount volume=bk,target=/go/src/github.com/coreos/kube-aws \
-    --insecure-options=image docker://golang:1.6.3 --exec /bin/bash -- -c \
-    "cd /go/src/github.com/coreos/kube-aws && ./build-release-binaries"
+KUBERNETES_MOUNT_DIR="/go/src/github.com/coreos/kube-aws"
 
+docker run --rm -i \
+    -v "${COREOS_KUBERNETES_ROOT}:${KUBERNETES_MOUNT_DIR}:z" -w ${KUBERNETES_MOUNT_DIR} \
+    --entrypoint /bin/bash golang:1.7.3  <<EOF
+#!/bin/bash
+set -euo pipefail
+wget -O /tmp/glide.tgz https://github.com/Masterminds/glide/releases/download/v0.12.3/glide-v0.12.3-linux-amd64.tar.gz
+tar -zxvf /tmp/glide.tgz -C /tmp
+mv /tmp/linux-amd64/glide /usr/local/bin
+./build-release-binaries
+EOF


### PR DESCRIPTION
`rkt run` was doing some weird stuff on fedora machines with SELinux in enforcing mode, so we're back to docker for the containerized build wrapper.

After this, we'll be ready to cut `v0.9.1`.

\cc @mumoshu 