### PR TITLE
Replace docker with rkt in "kube-node-drainer.service".

### DIFF
--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -144,27 +144,32 @@ coreos:
     {{ if .Experimental.NodeDrainer.Enabled }}
     - name: kube-node-drainer.service
       enable: true
+      command: start
+      runtime: true
       content: |
         [Unit]
         Description=drain this k8s node to make running pods time to gracefully shut down before stopping kubelet
-        Wants=kubelet.service docker.service
+        After=multi-user.target
 
         [Service]
         Type=oneshot
         RemainAfterExit=true
-        ExecStartPre=/usr/bin/systemctl is-active kubelet.service
-        ExecStartPre=/usr/bin/systemctl is-active docker.service
         ExecStart=/bin/true
-        ExecStop=/bin/sh -c '/usr/bin/docker run --rm -v /etc/kubernetes:/etc/kubernetes {{.HyperkubeImageRepo}}:{{.K8sVer}} \
-          /hyperkube kubectl \
+        TimeoutStopSec=30s
+        ExecStop=/bin/sh -c '/usr/bin/rkt run \
+        --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
+        --mount=volume=kube,target=/etc/kubernetes \
+        --net=host \
+        {{.HyperkubeImageRepo}}:{{.K8sVer}} \
+          --exec=/kubectl -- \
           --server=https://{{.ExternalDNSName}}:443 \
           --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
-          drain $$(hostname) \
+          drain $(hostname) \
           --ignore-daemonsets \
           --force'
 
         [Install]
-        RequiredBy=kubelet.service
+        WantedBy=multi-user.target
     {{ end }}
 {{ if $.ElasticFileSystemID }}
     - name: rpc-statd.service


### PR DESCRIPTION
Fix `kube-node-drainer.service` `ExecStart` and `ExecStop` errors . #40 