### PR TITLE
Add cloudformation helper scripts to the `quay.io/coreos/awscli:edge` docker image

### DIFF
--- a/docker-images/awscli/Dockerfile
+++ b/docker-images/awscli/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.4
+
+RUN apk --no-cache --update add bash curl less groff jq python py-pip && \
+  pip install --no-cache-dir --upgrade pip && \
+  pip install --no-cache-dir awscli s3cmd https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz && \
+  apk del py-pip && \
+  mkdir /root/.aws

--- a/docker-images/awscli/Makefile
+++ b/docker-images/awscli/Makefile
@@ -1,0 +1,2 @@
+docker-build:
+	docker build --tag quay.io/coreos/awscli:edge .


### PR DESCRIPTION
This is the first step to put `quay.io/coreos/awscli` docker images under control of kube-aws.