### PR TITLE
Easily manage etcd cluster with env vars

### DIFF
--- a/config/templates/cloud-config-etcd
+++ b/config/templates/cloud-config-etcd
@@ -31,6 +31,7 @@ coreos:
             Environment=ETCD_LISTEN_PEER_URLS=https://%H:2380
             Environment=ETCD_INITIAL_ADVERTISE_PEER_URLS=https://%H:2380
             PermissionsStartOnly=true
+            ExecStartPre=/usr/bin/bash -c "sed -i \"s/^ETCDCTL_ENDPOINT.*$/ETCDCTL_ENDPOINT=https:\/\/$(hostname):2379/\" /etc/environment"
             ExecStartPre=/usr/bin/chown -R etcd:etcd /var/lib/etcd2
       enable: true
       command: start
@@ -86,6 +87,17 @@ coreos:
 
 
 write_files:
+
+  - path: /etc/environment
+    permissions: 0644
+    content: |
+      COREOS_PUBLIC_IPV4=$public_ipv4
+      COREOS_PRIVATE_IPV4=$private_ipv4
+      ETCDCTL_CA_FILE=/etc/etcd2/ssl/ca.pem
+      ETCDCTL_CERT_FILE=/etc/etcd2/ssl/etcd-client.pem
+      ETCDCTL_KEY_FILE=/etc/etcd2/ssl/etcd-client-key.pem
+      ETCDCTL_ENDPOINT=
+
   - path: /opt/bin/ext4-format-volume-once
     permissions: 0700
     owner: root:root
@@ -120,3 +132,11 @@ write_files:
   - path: /etc/etcd2/ssl/etcd.pem.enc
     encoding: gzip+base64
     content: {{.TLSConfig.EtcdCert}}
+
+  - path: /etc/etcd2/ssl/etcd-client.pem.enc
+    encoding: gzip+base64
+    content: {{.TLSConfig.EtcdClientCert}}
+
+  - path: /etc/etcd2/ssl/etcd-client-key.pem.enc
+    encoding: gzip+base64
+    content: {{.TLSConfig.EtcdClientKey}}


### PR DESCRIPTION
Exporting  etcdctl environment variables, allow cluster managers to run etcdctl commands without providing arguments.

Currently when you logging in the etcd cluster you can't run etcdctl commands except you provide all the args.  

```
$ etcdctl --cert-file=/etc/etcd2/ssl/etcd-client.pem --ca-file=/etc/etcd2/ssl/ca.pem --key-file=/etc/etcd2/ssl/etcd-client-key.pem  --endpoints=https://ip-10-0-0-5.eu-west-1.compute.internal:2379 cluster-health
member f5654f631de6e415 is healthy: got healthy result from https://ip-10-0-0-5.eu-west-1.compute.internal:2379
cluster is healthy
```

After this PR will be easy for run etcdctl commands

```
$ etcdctl cluster-health
member f5654f631de6e415 is healthy: got healthy result from https://ip-10-0-0-5.eu-west-1.compute.internal:2379
cluster is healthy
```

Also this is important on #49 and signaling cloudformation when the etcd cluster is healthy.