### PR TITLE
Add experimental feature "awsEnvironment".

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,9 @@ func newDefaultCluster() *Cluster {
 		NodeDrainer{
 			Enabled: false,
 		},
+		AwsEnvironment{
+			Enabled: false,
+		},
 	}
 
 	return &Cluster{
@@ -184,11 +187,17 @@ type Subnet struct {
 }
 
 type Experimental struct {
-	NodeDrainer NodeDrainer `yaml:"nodeDrainer"`
+	NodeDrainer    NodeDrainer    `yaml:"nodeDrainer"`
+	AwsEnvironment AwsEnvironment `yaml:"awsEnvironment"`
 }
 
 type NodeDrainer struct {
 	Enabled bool `yaml:"enabled"`
+}
+
+type AwsEnvironment struct {
+	Enabled     bool              `yaml:"enabled"`
+	Environment map[string]string `yaml:"environment"`
 }
 
 const (

--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -11,6 +11,31 @@ coreos:
     etcd_keyfile: /etc/kubernetes/ssl/etcd-client-key.pem
 
   units:
+{{if .Experimental.AwsEnvironment.Enabled}}
+    - name: set-aws-environment.service
+      enable: true
+      command: start
+      runtime: true
+      content: |
+        [Unit]
+        Description=Set AWS environment variables in /etc/aws-environment
+        After=network-online.target
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        ExecStartPre=/bin/touch /etc/aws-environment
+        ExecStart=/usr/bin/rkt run \
+          --uuid-file-save=/var/run/coreos/cfn-init.uuid \
+          --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
+          --volume=awsenv,kind=host,source=/etc/aws-environment,readOnly=false --mount volume=awsenv,target=/etc/aws-environment \
+          --net=host \
+          --trust-keys-from-https \
+          quay.io/coreos/awscli:edge -- cfn-init -v \
+              --region {{.Region}} \
+              --resource LaunchConfigurationController \
+              --stack {{.ClusterName}}
+{{end}}
     - name: docker.service
       drop-ins:
         - name: 40-flannel.conf

--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -141,7 +141,7 @@ coreos:
         WantedBy=multi-user.target
 {{ end }}
 
-    {{ if .Experimental.NodeDrainer.Enabled }}
+{{ if .Experimental.NodeDrainer.Enabled }}
     - name: kube-node-drainer.service
       enable: true
       command: start
@@ -170,7 +170,34 @@ coreos:
 
         [Install]
         WantedBy=multi-user.target
-    {{ end }}
+{{ end }}
+
+{{if .Experimental.AwsEnvironment.Enabled}}
+    - name: set-aws-environment.service
+      enable: true
+      command: start
+      runtime: true
+      content: |
+        [Unit]
+        Description=Set AWS environment variables in /etc/aws-environment
+        After=network-online.target
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        ExecStartPre=/bin/touch /etc/aws-environment
+        ExecStart=/usr/bin/rkt run \
+          --uuid-file-save=/var/run/coreos/cfn-init.uuid \
+          --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
+          --volume=awsenv,kind=host,source=/etc/aws-environment,readOnly=false --mount volume=awsenv,target=/etc/aws-environment \
+          --net=host \
+          --trust-keys-from-https \
+          quay.io/coreos/awscli:edge -- cfn-init -v \
+              --region {{.Region}} \
+              --resource LaunchConfigurationWorker \
+              --stack {{.ClusterName}}
+{{end}}
+
 {{ if $.ElasticFileSystemID }}
     - name: rpc-statd.service
       command: start

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -165,8 +165,12 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # experimental:
 #   nodeDrainer:
 #     enabled: true
+#   awsEnvironment:
+#     enabled: true
+#     environment:
+#       CFNSTACK: '{ "Ref" : "AWS::StackId" }'
 
-# AWS Tags for cloudformation stack resources 
+# AWS Tags for cloudformation stack resources
 #stackTags:
 #  Name: "Kubernetes"
 #  Environment: "Production"

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -413,6 +413,23 @@
         {{end}}
         "UserData": "{{ .UserDataWorker }}"
       },
+{{ if .Experimental.AwsEnvironment.Enabled }}
+      "Metadata" : {
+        "AWS::CloudFormation::Init" : {
+          "config" : {
+            "commands": {
+              "write-environment": {
+                "command": { "Fn::Join" : ["", [ "echo '",
+{{range $variable, $function := .Experimental.AwsEnvironment.Environment}}
+"{{$variable}}=", {{$function}} , "\n",
+{{end}}
+"' > /etc/aws-environment" ] ] }
+              }
+            }
+          }
+        }
+      },
+{{end}}
       "Type": "AWS::AutoScaling::LaunchConfiguration"
     },
     "LaunchConfigurationController": {
@@ -438,6 +455,23 @@
         ],
         "UserData": "{{ .UserDataController }}"
       },
+  {{ if .Experimental.AwsEnvironment.Enabled }}
+      "Metadata" : {
+        "AWS::CloudFormation::Init" : {
+          "config" : {
+            "commands": {
+              "write-environment": {
+                "command": { "Fn::Join" : ["", [ "echo '",
+{{range $variable, $function := .Experimental.AwsEnvironment.Environment}}
+"{{$variable}}=", {{$function}} , "\n",
+{{end}}
+"' > /etc/aws-environment" ] ] }
+              }
+            }
+          }
+        }
+      },
+  {{end}}
       "Type": "AWS::AutoScaling::LaunchConfiguration"
     },
     "ElbAPIServer" : {


### PR DESCRIPTION
This enables users to to pass AWS cloudformation stack references in environment variables to custom scripts.

Use 'EnvironmentFile=/etc/aws-environment` in systemd units to consume the variables.

Fixes #29