### PR TITLE
cmd/kubeaws: Add S3 location format to help flag

### DIFF
--- a/cmd/kube-aws/command_up.go
+++ b/cmd/kube-aws/command_up.go
@@ -28,7 +28,7 @@ func init() {
 	cmdRoot.AddCommand(cmdUp)
 	cmdUp.Flags().BoolVar(&upOpts.export, "export", false, "Don't create cluster, instead export cloudformation stack file")
 	cmdUp.Flags().BoolVar(&upOpts.awsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
-	cmdUp.Flags().StringVar(&upOpts.s3URI, "s3-uri", "", "When your template is bigger than the cloudformation limit of 51200 bytes, upload the template to the specified location in S3")
+	cmdUp.Flags().StringVar(&upOpts.s3URI, "s3-uri", "", "When your template is bigger than the cloudformation limit of 51200 bytes, upload the template to the specified location in S3. S3 location expressed as s3://<bucket>/path/to/dir")
 }
 
 func runCmdUp(cmd *cobra.Command, args []string) error {

--- a/cmd/kube-aws/command_update.go
+++ b/cmd/kube-aws/command_update.go
@@ -26,7 +26,7 @@ var (
 func init() {
 	cmdRoot.AddCommand(cmdUpdate)
 	cmdUpdate.Flags().BoolVar(&updateOpts.awsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
-	cmdUpdate.Flags().StringVar(&updateOpts.s3URI, "s3-uri", "", "When your template is bigger than the cloudformation limit of 51200 bytes, upload the template to the specified location in S3")
+	cmdUpdate.Flags().StringVar(&updateOpts.s3URI, "s3-uri", "", "When your template is bigger than the cloudformation limit of 51200 bytes, upload the template to the specified location in S3. S3 location expressed as s3://<bucket>/path/to/dir")
 }
 
 func runCmdUpdate(cmd *cobra.Command, args []string) error {

--- a/cmd/kube-aws/command_validate.go
+++ b/cmd/kube-aws/command_validate.go
@@ -36,7 +36,7 @@ func init() {
 		&validateOpts.s3URI,
 		"s3-uri",
 		"",
-		"When your template is bigger than the cloudformation limit of 51200 bytes, upload the template to the specified location in S3",
+		"When your template is bigger than the cloudformation limit of 51200 bytes, upload the template to the specified location in S3. S3 location expressed as s3://<bucket>/path/to/dir",
 	)
 }
 


### PR DESCRIPTION
- kube-aws up, update, and validate all feature the --s3-location flag.
  Users would benefit from knowing the format expected when specifying
  their S3 bucket. This commit adds an example to each instance of the
  flag.