### PR TITLE
Send sucesss signal to cloudformation when controllers and workers are ready

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -49,11 +49,13 @@ func newDefaultCluster() *Cluster {
 		TLSCertDurationDays:      365,
 		ContainerRuntime:         "docker",
 		ControllerCount:          1,
+		ControllerCreateTimeout:  "PT15M",
 		ControllerInstanceType:   "m3.medium",
 		ControllerRootVolumeType: "gp2",
 		ControllerRootVolumeIOPS: 0,
 		ControllerRootVolumeSize: 30,
 		WorkerCount:              1,
+		WorkerCreateTimeout:      "PT15M",
 		WorkerInstanceType:       "m3.medium",
 		WorkerRootVolumeType:     "gp2",
 		WorkerRootVolumeIOPS:     0,
@@ -135,11 +137,13 @@ type Cluster struct {
 	ReleaseChannel           string            `yaml:"releaseChannel,omitempty"`
 	AmiId                    string            `yaml:"amiId,omitempty"`
 	ControllerCount          int               `yaml:"controllerCount,omitempty"`
+	ControllerCreateTimeout  string            `yaml:"controllerCreateTimeout,omitempty"`
 	ControllerInstanceType   string            `yaml:"controllerInstanceType,omitempty"`
 	ControllerRootVolumeType string            `yaml:"controllerRootVolumeType,omitempty"`
 	ControllerRootVolumeIOPS int               `yaml:"controllerRootVolumeIOPS,omitempty"`
 	ControllerRootVolumeSize int               `yaml:"controllerRootVolumeSize,omitempty"`
 	WorkerCount              int               `yaml:"workerCount,omitempty"`
+	WorkerCreateTimeout      string            `yaml:"workerCreateTimeout,omitempty"`
 	WorkerInstanceType       string            `yaml:"workerInstanceType,omitempty"`
 	WorkerRootVolumeType     string            `yaml:"workerRootVolumeType,omitempty"`
 	WorkerRootVolumeIOPS     int               `yaml:"workerRootVolumeIOPS,omitempty"`

--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -205,6 +205,28 @@ coreos:
         WantedBy=kubelet.service
 {{ end }}
 
+    - name: cfn-signal.service
+      command: start
+      content: |
+        [Unit]
+        Wants=kubelet.service docker.service
+        After=kubelet.service
+
+        [Service]
+        Type=oneshot
+        ExecStartPre=/usr/bin/bash -c "while sleep 1; do if /usr/bin/curl -s -m 20 -f  http://127.0.0.1:8080/healthz > /dev/null &&  /usr/bin/curl -s -m 20 -f  http://127.0.0.1:10252/healthz > /dev/null && /usr/bin/curl -s -m 20 -f  http://127.0.0.1:10251/healthz > /dev/null &&  /usr/bin/curl --insecure -s -m 20 -f  https://127.0.0.1:10250/healthz > /dev/null ; then break ; fi;  done"
+        {{ if .UseCalico }}
+        ExecStartPre=/usr/bin/systemctl is-active calico-node
+        {{ end }}
+        ExecStart=/usr/bin/rkt run \
+          --uuid-file-save=/var/run/coreos/cfn-signal.uuid \
+          --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
+          --net=host \
+          --trust-keys-from-https \
+          quay.io/coreos/awscli:edge -- cfn-signal -e 0 \
+              --region {{.Region}} \
+              --resource AutoScaleController \
+              --stack {{.ClusterName}}
 
 write_files:
   - path: /opt/bin/install-kube-system

--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -194,6 +194,29 @@ coreos:
         WantedBy=kubelet.service
 {{ end }}
 
+    - name: cfn-signal.service
+      command: start
+      content: |
+        [Unit]
+        Wants=kubelet.service docker.service
+        After=kubelet.service
+
+        [Service]
+        Type=oneshot
+        ExecStartPre=/usr/bin/bash -c "while sleep 1; do if /usr/bin/curl  --insecure -s -m 20 -f  https://127.0.0.1:10250/healthz > /dev/null ; then break ; fi;  done"
+        {{ if .UseCalico }}
+        ExecStartPre=/usr/bin/systemctl is-active calico-node
+        {{ end }}
+        ExecStart=/usr/bin/rkt run \
+          --uuid-file-save=/var/run/coreos/cfn-signal.uuid \
+          --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
+          --net=host \
+          --trust-keys-from-https \
+          quay.io/coreos/awscli:edge -- cfn-signal -e 0 \
+              --region {{.Region}} \
+              --resource AutoScaleWorker \
+              --stack {{.ClusterName}}
+
 write_files:
   - path: /etc/kubernetes/cni/docker_opts_cni.env
     content: |

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -49,6 +49,9 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # Number of controller nodes to create
 #controllerCount: 1
 
+# Maximum time to wait for controller creation
+#controlerCreateTimeout: PT15M
+
 # Instance type for controller node
 #controllerInstanceType: m3.medium
 
@@ -63,6 +66,9 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 
 # Number of worker nodes to create
 #workerCount: 1
+
+# Maximum time to wait for worker creation
+#workerCreateTimeout: PT15M
 
 # Instance type for worker nodes
 #workerInstanceType: m3.medium

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -49,6 +49,12 @@
         ]
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "CreationPolicy" : {
+        "ResourceSignal" : {
+          "Count" : "{{.WorkerCount}}",
+          "Timeout" : "{{.WorkerCreateTimeout}}"
+        }
+      },
       "UpdatePolicy" : {
         "AutoScalingRollingUpdate" : {
           "MinInstancesInService" :
@@ -58,7 +64,8 @@
           "{{.WorkerCount}}"
           {{end}},
           "MaxBatchSize" : "1",
-          "PauseTime" : "PT2M"
+          "PauseTime": "{{.WorkerCreateTimeout}}",
+          "WaitOnResourceSignals" : "true"
         }
       },
       "DependsOn" : ["AutoScaleController"]
@@ -106,11 +113,18 @@
 	  { "Ref" : "ElbAPIServer" }
 	]
       },
+      "CreationPolicy" : {
+        "ResourceSignal" : {
+          "Count" : "{{.ControllerCount}}",
+          "Timeout" : "{{.ControllerCreateTimeout}}"
+        }
+      },
       "UpdatePolicy" : {
         "AutoScalingRollingUpdate" : {
           "MinInstancesInService" : "{{.ControllerCount}}",
           "MaxBatchSize" : "1",
-          "PauseTime" : "PT2M"
+          "PauseTime": "{{.ControllerCreateTimeout}}",
+          "WaitOnResourceSignals" : "true"
         }
       }
     },
@@ -197,6 +211,20 @@
                   "Resource": "*"
                 },
                 {
+                  "Action": "cloudformation:SignalResource",
+                  "Effect": "Allow",
+                  "Resource":
+                    { "Fn::Join": [ "", [
+                      "arn:aws:cloudformation:",
+                      { "Ref": "AWS::Region" },
+                      ":",
+                      { "Ref": "AWS::AccountId" },
+                      ":stack/",
+                      { "Ref": "AWS::StackName" },
+                      "/*" ]
+                    ] }
+                },
+                {
                   "Action" : "kms:Decrypt",
                   "Effect" : "Allow",
                   "Resource" : "{{.KMSKeyARN}}"
@@ -265,6 +293,20 @@
                   "Action" : "kms:Decrypt",
                   "Effect" : "Allow",
                   "Resource" : "{{.KMSKeyARN}}"
+                },
+                {
+                  "Action": "cloudformation:SignalResource",
+                  "Effect": "Allow",
+                  "Resource":
+                    { "Fn::Join": [ "", [
+                      "arn:aws:cloudformation:",
+                      { "Ref": "AWS::Region" },
+                      ":",
+                      { "Ref": "AWS::AccountId" },
+                      ":stack/",
+                      { "Ref": "AWS::StackName" },
+                      "/*" ]
+                    ] }
                 },
                 {
                   "Action": [


### PR DESCRIPTION
This PR make some improvements when creating or updating cluster. #49 
When the resources are creating, cfn-signal will monitor specific services to check if they are healthy. Only after all service are healthy, it send a successful signal to Cloudformation.  The same monitoring will be applied on update command, now we have consistent status for rolling updates.

# Monitoring
On the node controller, cfn-signal will check the status for: calico if enabled, scheduler, api-server, controller-manager and kubelet. 

```
...
/usr/bin/curl -s -m 20 -f  http://127.0.0.1:8080/healthz > /dev/null &&
/usr/bin/curl -s -m 20 -f  http://127.0.0.1:10252/healthz > /dev/null && 
/usr/bin/curl -s -m 20 -f  http://127.0.0.1:10251/healthz > /dev/null &&  
/usr/bin/curl --insecure -s -m 20 -f  https://127.0.0.1:10250/healthz > /dev/null 
....
```

On Worker cfn-signal only monitor kubelet.
```...
/usr/bin/curl  --insecure -s -m 20 -f  https://127.0.0.1:10250/healthz > /dev/null 
```

I'm not totally satisfied with the worker monitoring, only watching kubelet. When upgrading a worker cluster,  there's a little downtime during the pulling images for pods and counting success probe. Suggestions are always welcome.

ps. I'm not yet watching etcd because the actual solution isn't reliable, waiting some improvement on #72  