### PR TITLE
Fix static reference to AWS region

### DIFF
--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -305,7 +305,7 @@ write_files:
            for encKey in $(find /etc/kubernetes/ssl/*.pem.enc); do \
              echo decrypting $encKey to $encKey.b64; \
              /usr/bin/aws \
-               --region ap-northeast-1 kms decrypt \
+               --region {{.Region}} kms decrypt \
                --ciphertext-blob fileb://$encKey \
                --output text \
                --query Plaintext \

--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -281,7 +281,7 @@ write_files:
            for encKey in $(find /etc/kubernetes/ssl/*.pem.enc); do \
              echo decrypting $encKey to $encKey.b64; \
              /usr/bin/aws \
-               --region ap-northeast-1 kms decrypt \
+               --region {{.Region}} kms decrypt \
                --ciphertext-blob fileb://$encKey \
                --output text \
                --query Plaintext \


### PR DESCRIPTION
PR #79 introduced a static reference to `ap-northeast-1`.