### PR TITLE
Add configuration option for AWS CLI image

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -48,6 +48,8 @@ func newDefaultCluster() *Cluster {
 		DNSServiceIP:             "10.3.0.10",
 		K8sVer:                   "v1.4.6_coreos.0",
 		HyperkubeImageRepo:       "quay.io/coreos/hyperkube",
+		AWSCliImageRepo:          "quay.io/coreos/awscli",
+		AWSCliTag:                "master",
 		TLSCADurationDays:        365 * 10,
 		TLSCertDurationDays:      365,
 		ContainerRuntime:         "docker",
@@ -162,6 +164,8 @@ type Cluster struct {
 	DNSServiceIP             string            `yaml:"dnsServiceIP,omitempty"`
 	K8sVer                   string            `yaml:"kubernetesVersion,omitempty"`
 	HyperkubeImageRepo       string            `yaml:"hyperkubeImageRepo,omitempty"`
+	AWSCliImageRepo          string            `yaml:"awsCliImageRepo,omitempty"`
+	AWSCliTag                string            `yaml:"awsCliTag,omitempty"`
 	ContainerRuntime         string            `yaml:"containerRuntime,omitempty"`
 	KMSKeyARN                string            `yaml:"kmsKeyArn,omitempty"`
 	CreateRecordSet          bool              `yaml:"createRecordSet,omitempty"`

--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -31,7 +31,7 @@ coreos:
           --volume=awsenv,kind=host,source=/etc/aws-environment,readOnly=false --mount volume=awsenv,target=/etc/aws-environment \
           --net=host \
           --trust-keys-from-https \
-          quay.io/coreos/awscli:edge -- cfn-init -v \
+          {{.AWSCliImageRepo}}:{{.AWSCliTag}} -- cfn-init -v \
               --region {{.Region}} \
               --resource LaunchConfigurationController \
               --stack {{.ClusterName}}
@@ -299,7 +299,7 @@ write_files:
         --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
         --net=host \
         --trust-keys-from-https \
-        quay.io/coreos/awscli --exec=/bin/bash -- \
+        {{.AWSCliImageRepo}}:{{.AWSCliTag}} --exec=/bin/bash -- \
           -c \
           'echo decrypting tls assets; \
            for encKey in $(find /etc/kubernetes/ssl/*.pem.enc); do \

--- a/config/templates/cloud-config-etcd
+++ b/config/templates/cloud-config-etcd
@@ -117,7 +117,7 @@ write_files:
 
       for encKey in $(find /etc/etcd2/ssl/*.pem.enc);do
         tmpPath="/tmp/$(basename $encKey).tmp"
-        docker run --net host --rm -v /etc/etcd2/ssl:/etc/etcd2/ssl --rm quay.io/coreos/awscli aws --region {{.Region}} kms decrypt --ciphertext-blob fileb://$encKey --output text --query Plaintext | base64 --decode > $tmpPath
+        docker run --net host --rm -v /etc/etcd2/ssl:/etc/etcd2/ssl --rm {{.AWSCliImageRepo}}:{{.AWSCliTag}} aws --region {{.Region}} kms decrypt --ciphertext-blob fileb://$encKey --output text --query Plaintext | base64 --decode > $tmpPath
         mv  $tmpPath /etc/etcd2/ssl/$(basename $encKey .enc)
       done
 

--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -196,7 +196,7 @@ coreos:
           --volume=awsenv,kind=host,source=/etc/aws-environment,readOnly=false --mount volume=awsenv,target=/etc/aws-environment \
           --net=host \
           --trust-keys-from-https \
-          quay.io/coreos/awscli:edge -- cfn-init -v \
+          {{.AWSCliImageRepo}}:{{.AWSCliTag}} -- cfn-init -v \
               --region {{.Region}} \
               --resource LaunchConfigurationWorker \
               --stack {{.ClusterName}}
@@ -275,7 +275,7 @@ write_files:
         --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
         --net=host \
         --trust-keys-from-https \
-        quay.io/coreos/awscli --exec=/bin/bash -- \
+        {{.AWSCliImageRepo}}:{{.AWSCliTag}} --exec=/bin/bash -- \
           -c \
           'echo decrypting tls assets; \
            for encKey in $(find /etc/kubernetes/ssl/*.pem.enc); do \

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -148,6 +148,12 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # Hyperkube image repository to use.
 # hyperkubeImageRepo: quay.io/coreos/hyperkube
 
+# AWS CLI image repository to use.
+# awsCliImageRepo: quay.io/coreos/awscli
+
+# AWS CLI image tag to use.
+# awsCliTag: master
+
 # Use Calico for network policy.
 # useCalico: false
 


### PR DESCRIPTION
Apart from the calico image users can host cluster assets themselves.

I mostly want this so i can easily test contributions to https://github.com/coreos/awscli