### PR TITLE
Shield cfn-signal behind experimental flag.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -37,6 +37,10 @@ func newDefaultCluster() *Cluster {
 		AwsEnvironment{
 			Enabled: false,
 		},
+		WaitSignal{
+			Enabled:      false,
+			MaxBatchSize: 1,
+		},
 	}
 
 	return &Cluster{
@@ -197,6 +201,7 @@ type Subnet struct {
 type Experimental struct {
 	NodeDrainer    NodeDrainer    `yaml:"nodeDrainer"`
 	AwsEnvironment AwsEnvironment `yaml:"awsEnvironment"`
+	WaitSignal     WaitSignal     `yaml:"waitSignal"`
 }
 
 type NodeDrainer struct {
@@ -206,6 +211,11 @@ type NodeDrainer struct {
 type AwsEnvironment struct {
 	Enabled     bool              `yaml:"enabled"`
 	Environment map[string]string `yaml:"environment"`
+}
+
+type WaitSignal struct {
+	Enabled      bool `yaml:"enabled"`
+	MaxBatchSize int  `yaml:"maxBatchSize"`
 }
 
 const (

--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -230,6 +230,7 @@ coreos:
         WantedBy=kubelet.service
 {{ end }}
 
+{{if .Experimental.WaitSignal.Enabled}}
     - name: cfn-signal.service
       command: start
       content: |
@@ -252,6 +253,7 @@ coreos:
               --region {{.Region}} \
               --resource AutoScaleController \
               --stack {{.ClusterName}}
+{{end}}
 
 write_files:
   - path: /opt/bin/install-kube-system

--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -221,6 +221,7 @@ coreos:
         WantedBy=kubelet.service
 {{ end }}
 
+{{ if .Experimental.WaitSignal.Enabled }}
     - name: cfn-signal.service
       command: start
       content: |
@@ -243,6 +244,7 @@ coreos:
               --region {{.Region}} \
               --resource AutoScaleWorker \
               --stack {{.ClusterName}}
+{{end}}
 
 write_files:
   - path: /etc/kubernetes/cni/docker_opts_cni.env

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -49,12 +49,14 @@
         ]
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
+      {{if .Experimental.WaitSignal.Enabled}}
       "CreationPolicy" : {
         "ResourceSignal" : {
           "Count" : "{{.WorkerCount}}",
           "Timeout" : "{{.WorkerCreateTimeout}}"
         }
       },
+      {{end}}
       "UpdatePolicy" : {
         "AutoScalingRollingUpdate" : {
           "MinInstancesInService" :
@@ -63,9 +65,14 @@
           {{else}}
           "{{.WorkerCount}}"
           {{end}},
+          {{if .Experimental.WaitSignal.Enabled}}
+          "WaitOnResourceSignals" : "true",
+          "MaxBatchSize" : "{{.Experimental.WaitSignal.MaxBatchSize}}",
+          "PauseTime": "{{.WorkerCreateTimeout}}"
+          {{else}}
           "MaxBatchSize" : "1",
-          "PauseTime": "{{.WorkerCreateTimeout}}",
-          "WaitOnResourceSignals" : "true"
+          "PauseTime": "PT2M"
+          {{end}}
         }
       },
       "DependsOn" : ["AutoScaleController"]
@@ -113,18 +120,24 @@
 	  { "Ref" : "ElbAPIServer" }
 	]
       },
+      {{if .Experimental.WaitSignal.Enabled}}
       "CreationPolicy" : {
         "ResourceSignal" : {
           "Count" : "{{.ControllerCount}}",
           "Timeout" : "{{.ControllerCreateTimeout}}"
         }
       },
+      {{end}}
       "UpdatePolicy" : {
         "AutoScalingRollingUpdate" : {
           "MinInstancesInService" : "{{.ControllerCount}}",
           "MaxBatchSize" : "1",
-          "PauseTime": "{{.ControllerCreateTimeout}}",
-          "WaitOnResourceSignals" : "true"
+          {{if .Experimental.WaitSignal.Enabled}}
+          "WaitOnResourceSignals" : "true",
+          "PauseTime": "{{.ControllerCreateTimeout}}"
+          {{else}}
+          "PauseTime": "PT2M"
+          {{end}}
         }
       }
     },
@@ -210,6 +223,7 @@
                   "Effect": "Allow",
                   "Resource": "*"
                 },
+                {{if .Experimental.WaitSignal.Enabled}}
                 {
                   "Action": "cloudformation:SignalResource",
                   "Effect": "Allow",
@@ -224,6 +238,7 @@
                       "/*" ]
                     ] }
                 },
+                {{end}}
                 {
                   "Action" : "kms:Decrypt",
                   "Effect" : "Allow",
@@ -294,6 +309,7 @@
                   "Effect" : "Allow",
                   "Resource" : "{{.KMSKeyARN}}"
                 },
+                {{if .Experimental.WaitSignal.Enabled}}
                 {
                   "Action": "cloudformation:SignalResource",
                   "Effect": "Allow",
@@ -308,6 +324,7 @@
                       "/*" ]
                     ] }
                 },
+                {{end}}
                 {
                   "Action": [
                     "ecr:GetAuthorizationToken",


### PR DESCRIPTION
In preparation for node cordoning/uncordon process 1/2

I think it's safer to have an easy way to disable this while we work on it.

Note that this reverts the PauseTime to 2 minutes and the `WorkerCreateTimeout` / `ControllerCreateTimeout` remain top level variables. 