### PR TITLE
Add additional AWS labels and annotations to node

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,9 @@ func newDefaultCluster() *Cluster {
 		NodeDrainer{
 			Enabled: false,
 		},
+		NodeLabel{
+			Enabled: false,
+		},
 		AwsEnvironment{
 			Enabled: false,
 		},
@@ -201,11 +204,16 @@ type Subnet struct {
 
 type Experimental struct {
 	NodeDrainer    NodeDrainer    `yaml:"nodeDrainer"`
+	NodeLabel      NodeLabel      `yaml:"nodeLabel"`
 	AwsEnvironment AwsEnvironment `yaml:"awsEnvironment"`
 	WaitSignal     WaitSignal     `yaml:"waitSignal"`
 }
 
 type NodeDrainer struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+type NodeLabel struct {
 	Enabled bool `yaml:"enabled"`
 }
 

--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -210,7 +210,6 @@ coreos:
         ExecStartPre=/usr/bin/curl http://127.0.0.1:8080/version
         ExecStart=/opt/bin/install-calico-system
 {{ end }}
-
 {{ if $.ElasticFileSystemID }}
     - name: rpc-statd.service
       command: start
@@ -230,7 +229,6 @@ coreos:
         [Install]
         WantedBy=kubelet.service
 {{ end }}
-
 {{if .Experimental.WaitSignal.Enabled}}
     - name: cfn-signal.service
       command: start
@@ -254,6 +252,50 @@ coreos:
               --region {{.Region}} \
               --resource AutoScaleController \
               --stack {{.ClusterName}}
+{{end}}
+{{if .Experimental.NodeLabel.Enabled }}
+    - name: kube-node-label.service
+      enable: true
+      command: start
+      runtime: true
+      content: |
+        [Unit]
+        Description=Label this kubernetes node with additional AWS parameters
+        After=kubelet.service
+        Before=cfn-signal.service
+
+        [Service]
+        Type=oneshot
+        ExecStop=/bin/true
+        RemainAfterExit=true
+        ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment INSTANCE_ID=$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/instance-id)"
+        ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment SECURITY_GROUPS=$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/security-groups | tr '\n' ',')"
+        ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment AUTOSCALINGGROUP=$(/usr/bin/docker run --rm --net=host \
+          {{.AWSCliImageRepo}}:{{.AWSCliTag}} aws \
+          autoscaling describe-auto-scaling-instances \
+          --instance-ids ${INSTANCE_ID} --region {{.Region}} \
+          --query 'AutoScalingInstances[].AutoScalingGroupName' --output text)"
+        ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment \
+          LAUNCHCONFIGURATION=$(/usr/bin/docker run --rm --net=host \
+          {{.AWSCliImageRepo}}:{{.AWSCliTag}} \
+          aws autoscaling describe-auto-scaling-groups \
+          --auto-scaling-group-name $AUTOSCALINGGROUP --region {{.Region}} \
+          --query 'AutoScalingGroups[].LaunchConfigurationName' --output text)"
+        ExecStart=/bin/sh -c "/usr/bin/curl \
+          --request PATCH \
+          -H 'Content-Type: application/strategic-merge-patch+json' \
+          -d'{ \
+          \"metadata\": { \
+            \"labels\": { \
+              \"kube-aws.coreos.com/autoscalinggroup\": \"${AUTOSCALINGGROUP}\", \
+              \"kube-aws.coreos.com/launchconfiguration\": \"${LAUNCHCONFIGURATION}\" \
+            }, \
+            \"annotations\": { \
+              \"kube-aws.coreos.com/securitygroups\": \"${SECURITY_GROUPS}\" \
+            } \
+          } \
+          }\"' \
+          http://localhost:8080/api/v1/nodes/$(hostname)"
 {{end}}
 
 {{if .SSHAuthorizedKeys}}

--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -241,10 +241,58 @@ coreos:
           --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
           --net=host \
           --trust-keys-from-https \
-          quay.io/coreos/awscli:edge -- cfn-signal -e 0 \
+          {{.AWSCliImageRepo}}:{{.AWSCliTag}} -- cfn-signal -e 0 \
               --region {{.Region}} \
               --resource AutoScaleWorker \
               --stack {{.ClusterName}}
+{{end}}
+
+{{if .Experimental.NodeLabel.Enabled }}
+    - name: kube-node-label.service
+      enable: true
+      command: start
+      runtime: true
+      content: |
+        [Unit]
+        Description=Label this kubernetes node with additional AWS parameters
+        After=kubelet.service
+        Before=cfn-signal.service
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        ExecStop=/bin/true
+        ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment INSTANCE_ID=$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/instance-id)"
+        ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment SECURITY_GROUPS=$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/security-groups | tr '\n' ',')"
+        ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment AUTOSCALINGGROUP=$(/usr/bin/docker run --rm --net=host \
+          {{.AWSCliImageRepo}}:{{.AWSCliTag}} aws \
+          autoscaling describe-auto-scaling-instances \
+          --instance-ids ${INSTANCE_ID} --region {{.Region}} \
+          --query 'AutoScalingInstances[].AutoScalingGroupName' --output text)"
+        ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment \
+          LAUNCHCONFIGURATION=$(/usr/bin/docker run --rm --net=host \
+          {{.AWSCliImageRepo}}:{{.AWSCliTag}} \
+          aws autoscaling describe-auto-scaling-groups \
+          --auto-scaling-group-name $AUTOSCALINGGROUP --region {{.Region}} \
+          --query 'AutoScalingGroups[].LaunchConfigurationName' --output text)"
+        ExecStart=/bin/sh -c "/usr/bin/curl \
+          --cert   /etc/kubernetes/ssl/worker.pem \
+          --key    /etc/kubernetes/ssl/worker-key.pem \
+          --cacert /etc/kubernetes/ssl/ca.pem  \
+          --request PATCH \
+          -H 'Content-Type: application/strategic-merge-patch+json' \
+          -d'{ \
+          \"metadata\": { \
+            \"labels\": { \
+              \"kube-aws.coreos.com/autoscalinggroup\": \"${AUTOSCALINGGROUP}\", \
+              \"kube-aws.coreos.com/launchconfiguration\": \"${LAUNCHCONFIGURATION}\" \
+            }, \
+            \"annotations\": { \
+              \"kube-aws.coreos.com/securitygroups\": \"${SECURITY_GROUPS}\" \
+            } \
+          } \
+          }\"' \
+          https://{{.ExternalDNSName}}:443/api/v1/nodes/$(hostname)"
 {{end}}
 
 {{if .SSHAuthorizedKeys}}

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -181,6 +181,8 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # experimental:
 #   nodeDrainer:
 #     enabled: true
+#   nodeLabel:
+#     enabled: true
 #   awsEnvironment:
 #     enabled: true
 #     environment:

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -239,6 +239,13 @@
                     ] }
                 },
                 {{end}}
+                {{if .Experimental.NodeLabel.Enabled}}
+                {
+                  "Action": "autoscaling:Describe*",
+                  "Effect": "Allow",
+                  "Resource": [ "*" ]
+                },
+                {{end}}
                 {
                   "Action" : "kms:Decrypt",
                   "Effect" : "Allow",
@@ -323,6 +330,13 @@
                       { "Ref": "AWS::StackName" },
                       "/*" ]
                     ] }
+                },
+                {{end}}
+                {{if .Experimental.NodeLabel.Enabled}}
+                {
+                  "Action": "autoscaling:Describe*",
+                  "Effect": "Allow",
+                  "Resource": [ "*" ]
                 },
                 {{end}}
                 {


### PR DESCRIPTION
Currently adds:

Labels:
- `kube-aws.coreos.com/autoscalinggroup` = autoscalinggroup the node belongs to
- `kube-aws.coreos.com/launchconfiguration` = launchconfiguration of the autoscalinggroup during node intialization

Annotations:
- `kube-aws.coreos.com/securitygroups` = comma separated list of security groups attached to node