### PR TITLE
Add cloudinit sshAuthorizedKeys option to cluster.yaml

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -187,6 +187,7 @@ type Cluster struct {
 	Subnets                  []*Subnet         `yaml:"subnets,omitempty"`
 	MapPublicIPs             bool              `yaml:"mapPublicIPs,omitempty"`
 	ElasticFileSystemID      string            `yaml:"elasticFileSystemId,omitempty"`
+	SSHAuthorizedKeys        []string          `yaml:"sshAuthorizedKeys,omitempty"`
 	Experimental             Experimental      `yaml:"experimental"`
 	providedEncryptService   encryptService
 	IsChinaRegion            bool

--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -2,7 +2,6 @@
 coreos:
   update:
     reboot-strategy: "off"
-
   flannel:
     interface: $private_ipv4
     etcd_endpoints: {{ .EtcdEndpoints }}
@@ -253,6 +252,13 @@ coreos:
               --region {{.Region}} \
               --resource AutoScaleController \
               --stack {{.ClusterName}}
+{{end}}
+
+{{if .SSHAuthorizedKeys}}
+ssh_authorized_keys:
+  {{range $sshkey := .SSHAuthorizedKeys}}
+  - {{$sshkey}}
+  {{end}}
 {{end}}
 
 write_files:

--- a/config/templates/cloud-config-etcd
+++ b/config/templates/cloud-config-etcd
@@ -85,6 +85,12 @@ coreos:
         [Install]
         RequiredBy=etcd2.service
 
+{{if .SSHAuthorizedKeys}}
+ssh_authorized_keys:
+  {{range $sshkey := .SSHAuthorizedKeys}}
+  - {{$sshkey}}
+  {{end}}
+{{end}}
 
 write_files:
 

--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -8,6 +8,7 @@ coreos:
     etcd_cafile: /etc/kubernetes/ssl/ca.pem
     etcd_certfile: /etc/kubernetes/ssl/etcd-client.pem
     etcd_keyfile: /etc/kubernetes/ssl/etcd-client-key.pem
+
   units:
     - name: docker.service
       drop-ins:
@@ -244,6 +245,13 @@ coreos:
               --region {{.Region}} \
               --resource AutoScaleWorker \
               --stack {{.ClusterName}}
+{{end}}
+
+{{if .SSHAuthorizedKeys}}
+ssh_authorized_keys:
+  {{range $sshkey := .SSHAuthorizedKeys}}
+  - {{$sshkey}}
+  {{end}}
 {{end}}
 
 write_files:

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -37,6 +37,10 @@ externalDNSName: {{.ExternalDNSName}}
 # account being used to deploy this cluster.
 keyName: {{.KeyName}}
 
+# Additional keys to preload on the coreos account (keep this to a minimum)
+# sshAuthorizedKeys:
+# - "ssh-rsa AAAAEXAMPLEKEYEXAMPLEKEYEXAMPLEKEYEXAMPLEKEYEXAMPLEKEYEXAMPLEKEYEXAMPLEKEYEXAMPLEKEYEXAMPLEKEYEXAMPLEKEY example@example.org"
+
 # Region to provision Kubernetes cluster
 region: {{.Region}}
 


### PR DESCRIPTION
So cluster operators don't have to share the same SSH public key.

Suggested workflow:
- Keep a main organization key (`keyPair`) in a keysafe. Don't use it for normal daily operations.
- Add a select number of cluster operators to the `sshAuthorizedKeys` list