### PR TITLE
Option to automatically assign externally managed ELBs to the worker autoscaling group

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,12 +31,6 @@ const (
 
 func newDefaultCluster() *Cluster {
 	experimental := Experimental{
-		NodeDrainer{
-			Enabled: false,
-		},
-		NodeLabel{
-			Enabled: false,
-		},
 		AwsEnvironment{
 			Enabled: false,
 		},
@@ -44,6 +38,15 @@ func newDefaultCluster() *Cluster {
 			Enabled:    false,
 			Disk:       "xvdb",
 			Filesystem: "xfs",
+		},
+		LoadBalancer{
+			Enabled: false,
+		},
+		NodeDrainer{
+			Enabled: false,
+		},
+		NodeLabel{
+			Enabled: false,
 		},
 		WaitSignal{
 			Enabled:      false,
@@ -208,11 +211,23 @@ type Subnet struct {
 }
 
 type Experimental struct {
-	NodeDrainer           NodeDrainer           `yaml:"nodeDrainer"`
-	NodeLabel             NodeLabel             `yaml:"nodeLabel"`
 	AwsEnvironment        AwsEnvironment        `yaml:"awsEnvironment"`
 	EphemeralImageStorage EphemeralImageStorage `yaml:"ephemeralImageStorage"`
+	LoadBalancer          LoadBalancer          `yaml:"loadBalancer"`
+	NodeDrainer           NodeDrainer           `yaml:"nodeDrainer"`
+	NodeLabel             NodeLabel             `yaml:"nodeLabel"`
 	WaitSignal            WaitSignal            `yaml:"waitSignal"`
+}
+
+type AwsEnvironment struct {
+	Enabled     bool              `yaml:"enabled"`
+	Environment map[string]string `yaml:"environment"`
+}
+
+type EphemeralImageStorage struct {
+	Enabled    bool   `yaml:"enabled"`
+	Disk       string `yaml:"disk"`
+	Filesystem string `yaml:"filesystem"`
 }
 
 type NodeDrainer struct {
@@ -223,20 +238,15 @@ type NodeLabel struct {
 	Enabled bool `yaml:"enabled"`
 }
 
-type AwsEnvironment struct {
-	Enabled     bool              `yaml:"enabled"`
-	Environment map[string]string `yaml:"environment"`
+type LoadBalancer struct {
+	Enabled          bool     `yaml:"enabled"`
+	Names            []string `yaml:"names"`
+	SecurityGroupIds []string `yaml:"securityGroupIds"`
 }
 
 type WaitSignal struct {
 	Enabled      bool `yaml:"enabled"`
 	MaxBatchSize int  `yaml:"maxBatchSize"`
-}
-
-type EphemeralImageStorage struct {
-	Enabled    bool   `yaml:"enabled"`
-	Disk       string `yaml:"disk"`
-	Filesystem string `yaml:"filesystem"`
 }
 
 const (

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -192,6 +192,10 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #   # This option has not yet been tested with rkt as container runtime
 #   ephemeralImageStorage:
 #     enabled: true
+#   loadBalancer:
+#     enabled: true
+#     names: [ "manuallymanagedelb" ]
+#     securityGroupIds: [ "sg-87654321" ]
 
 # AWS Tags for cloudformation stack resources
 #stackTags:

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -37,6 +37,14 @@
             "Value": "{{.ClusterName}}-kube-aws-worker"
           }
         ],
+        {{if .Experimental.LoadBalancer.Enabled}}
+        "LoadBalancerNames" : [
+        {{range $index, $elb := .Experimental.LoadBalancer.Names}}
+        {{if $index}},{{end}}
+          "{{$elb}}"
+        {{end}}
+        ],
+        {{end}}
         "VPCZoneIdentifier": [
           {{range $index, $subnet := .Subnets}}
           {{with $subnetLogicalName := printf "Subnet%d" $index}}
@@ -116,9 +124,9 @@
           {{end}}
           {{end}}
         ],
-	"LoadBalancerNames" : [
-	  { "Ref" : "ElbAPIServer" }
-	]
+        "LoadBalancerNames" : [
+          { "Ref" : "ElbAPIServer" }
+        ]
       },
       {{if .Experimental.WaitSignal.Enabled}}
       "CreationPolicy" : {
@@ -477,6 +485,11 @@
         "InstanceType": "{{.WorkerInstanceType}}",
         "KeyName": "{{.KeyName}}",
         "SecurityGroups": [
+          {{if .Experimental.LoadBalancer.Enabled}}
+          {{range $elbsg := .Experimental.LoadBalancer.SecurityGroupIds}}
+            "{{$elbsg}}",
+          {{end}}
+          {{end}}
           {
             "Ref": "SecurityGroupWorker"
           }


### PR DESCRIPTION
This is useful for operators that have special ELB requirements like the proxyprotocol or where loadbalancer/network asset management is delegated to a different team.