### PR TITLE
Enable Scheduled Jobs in k8s 1.4  aka Cron Jobs in 1.5

### DIFF
--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -344,7 +344,7 @@ write_files:
           - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
           - --client-ca-file=/etc/kubernetes/ssl/ca.pem
           - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-          - --runtime-config=extensions/v1beta1/networkpolicies=true
+          - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1
           - --cloud-provider=aws
           livenessProbe:
             httpGet:


### PR DESCRIPTION
`Scheduled Jobs` from 1.4 was renamed to  `Cron Jobs` in 1.5.
This PR works with both versions.

More info here:
http://kubernetes.io/docs/user-guide/cron-jobs/