### PR TITLE
Add option to mount ephemeral disks for image storage

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -40,6 +40,11 @@ func newDefaultCluster() *Cluster {
 		AwsEnvironment{
 			Enabled: false,
 		},
+		EphemeralImageStorage{
+			Enabled:    false,
+			Disk:       "xvdb",
+			Filesystem: "xfs",
+		},
 		WaitSignal{
 			Enabled:      false,
 			MaxBatchSize: 1,
@@ -203,10 +208,11 @@ type Subnet struct {
 }
 
 type Experimental struct {
-	NodeDrainer    NodeDrainer    `yaml:"nodeDrainer"`
-	NodeLabel      NodeLabel      `yaml:"nodeLabel"`
-	AwsEnvironment AwsEnvironment `yaml:"awsEnvironment"`
-	WaitSignal     WaitSignal     `yaml:"waitSignal"`
+	NodeDrainer           NodeDrainer           `yaml:"nodeDrainer"`
+	NodeLabel             NodeLabel             `yaml:"nodeLabel"`
+	AwsEnvironment        AwsEnvironment        `yaml:"awsEnvironment"`
+	EphemeralImageStorage EphemeralImageStorage `yaml:"ephemeralImageStorage"`
+	WaitSignal            WaitSignal            `yaml:"waitSignal"`
 }
 
 type NodeDrainer struct {
@@ -225,6 +231,12 @@ type AwsEnvironment struct {
 type WaitSignal struct {
 	Enabled      bool `yaml:"enabled"`
 	MaxBatchSize int  `yaml:"maxBatchSize"`
+}
+
+type EphemeralImageStorage struct {
+	Enabled    bool   `yaml:"enabled"`
+	Disk       string `yaml:"disk"`
+	Filesystem string `yaml:"filesystem"`
 }
 
 const (

--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -298,6 +298,36 @@ coreos:
           http://localhost:8080/api/v1/nodes/$(hostname)"
 {{end}}
 
+{{if .Experimental.EphemeralImageStorage.Enabled}}
+    - name: format-ephemeral.service
+      command: start
+      content: |
+        [Unit]
+        Description=Formats the ephemeral drive
+        After=dev-{{.Experimental.EphemeralImageStorage.Disk}}.device
+        Requires=dev-{{.Experimental.EphemeralImageStorage.Disk}}.device
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStart=/usr/sbin/wipefs -f /dev/{{.Experimental.EphemeralImageStorage.Disk}}
+        ExecStart=/usr/sbin/mkfs.{{.Experimental.EphemeralImageStorage.Filesystem}} -f /dev/{{.Experimental.EphemeralImageStorage.Disk}}
+    - name: var-lib-docker.mount
+      command: start
+      content: |
+        [Unit]
+        Description=Mount ephemeral to /var/lib/docker
+        Requires=format-ephemeral.service
+        After=format-ephemeral.service
+        [Mount]
+        What=/dev/{{.Experimental.EphemeralImageStorage.Disk}}
+{{if eq .ContainerRuntime "docker"}}
+        Where=/var/lib/docker
+{{else if eq .ContainerRuntime "rkt"}}
+        Where=/var/lib/rkt
+{{end}}
+        Type={{.Experimental.EphemeralImageStorage.Filesystem}}
+{{end}}
+
 {{if .SSHAuthorizedKeys}}
 ssh_authorized_keys:
   {{range $sshkey := .SSHAuthorizedKeys}}

--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -295,6 +295,36 @@ coreos:
           https://{{.ExternalDNSName}}:443/api/v1/nodes/$(hostname)"
 {{end}}
 
+{{if .Experimental.EphemeralImageStorage.Enabled}}
+    - name: format-ephemeral.service
+      command: start
+      content: |
+        [Unit]
+        Description=Formats the ephemeral drive
+        After=dev-{{.Experimental.EphemeralImageStorage.Disk}}.device
+        Requires=dev-{{.Experimental.EphemeralImageStorage.Disk}}.device
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStart=/usr/sbin/wipefs -f /dev/{{.Experimental.EphemeralImageStorage.Disk}}
+        ExecStart=/usr/sbin/mkfs.{{.Experimental.EphemeralImageStorage.Filesystem}} -f /dev/{{.Experimental.EphemeralImageStorage.Disk}}
+    - name: var-lib-docker.mount
+      command: start
+      content: |
+        [Unit]
+        Description=Mount ephemeral to /var/lib/docker
+        Requires=format-ephemeral.service
+        After=format-ephemeral.service
+        [Mount]
+        What=/dev/{{.Experimental.EphemeralImageStorage.Disk}}
+{{if eq .ContainerRuntime "docker"}}
+        Where=/var/lib/docker
+{{else if eq .ContainerRuntime "rkt"}}
+        Where=/var/lib/rkt
+{{end}}
+        Type={{.Experimental.EphemeralImageStorage.Filesystem}}
+{{end}}
+
 {{if .SSHAuthorizedKeys}}
 ssh_authorized_keys:
   {{range $sshkey := .SSHAuthorizedKeys}}

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -189,6 +189,9 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #       CFNSTACK: '{ "Ref" : "AWS::StackId" }'
 #   waitSignal:
 #     enabled: true
+#   # This option has not yet been tested with rkt as container runtime
+#   ephemeralImageStorage:
+#     enabled: true
 
 # AWS Tags for cloudformation stack resources
 #stackTags:


### PR DESCRIPTION
Intended to be used on instances that come with local storage (eg the `m3`, `c3`,`r3` and`g2` instance types).

When just setting the  `enabled` flag it formats (XFS) & mounts the local `xvdb` disk by default to the appropriate location (depending on container runtime). I chose XFS because of speed and the generous amounts of inodes by default.
Users can choose the filesystem and source disk by overriding the defaults:
```yaml
experimental:
  ephemeralImageStorage:
    enabled: true
    disk: xvdc
    filesystem: ext4
```

:warning: i haven't tested `rkt` as container runtime yet but i guess this will work? :crossed_swords: 

I would like to add the option to RAID together some local disks. The defaults should work all nodes with local storage, but doesn't use additional disks which is a waste if you move up to nodes of reasonable size (`xlarge`). Might add format/mount options later too.

Submitting incomplete work because @mumoshu seems to like rolling balls :laughing: :soccer: 