### PR TITLE
refactoring: Move the code generator

### DIFF
--- a/codegen/templates_gen.go
+++ b/codegen/templates_gen.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"text/template"
 	"time"
 )
@@ -29,16 +30,9 @@ var (
 )
 `))
 
-var files = []struct {
+type Entry struct {
 	Filename string
 	VarName  string
-}{
-	{"cloud-config-controller", "CloudConfigController"},
-	{"cloud-config-worker", "CloudConfigWorker"},
-	{"cloud-config-etcd", "CloudConfigEtcd"},
-	{"cluster.yaml", "DefaultClusterConfig"},
-	{"kubeconfig.tmpl", "KubeConfigTemplate"},
-	{"stack-template.json", "StackTemplateTemplate"},
 }
 
 type Data struct {
@@ -69,6 +63,18 @@ func toGoByteSlice(sli []byte) string {
 }
 
 func main() {
+	files := []Entry{}
+	args := os.Args[1:]
+	for _, arg := range args {
+		parts := strings.Split(arg, "=")
+		varname, filename := parts[0], parts[1]
+		entry := Entry{
+			Filename: filename,
+			VarName:  varname,
+		}
+		files = append(files, entry)
+	}
+
 	tmpls := make([]Var, len(files))
 	for i, file := range files {
 		path := filepath.Join("templates", file.Filename)

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,6 @@
 package config
 
-//go:generate go run templates_gen.go
+//go:generate go run ../codegen/templates_gen.go CloudConfigController=cloud-config-controller CloudConfigWorker=cloud-config-worker CloudConfigEtcd=cloud-config-etcd DefaultClusterConfig=cluster.yaml KubeConfigTemplate=kubeconfig.tmpl StackTemplateTemplate=stack-template.json
 //go:generate gofmt -w templates.go
 
 import (


### PR DESCRIPTION
which has been used for embedding config/templates/* files into go structs hence kube-aws binaries, from the config package to its own package, so that we can reuse it from the upcoming node pools feature.

I'm merging this without mentioning anyone because recalling recent pull requests turns out that no one seems to touch or use this code :)