### PR TITLE
fix: Remove problematic states from Config objects

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -310,6 +310,13 @@ func (c Cluster) Config() (*Config, error) {
 
 	config.EtcdInstances = make([]etcdInstance, config.EtcdCount)
 	var etcdEndpoints, etcdInitialCluster bytes.Buffer
+
+	// Reset lastAllocatedAddr or we'll end up returning different cluster config w/ inconsistent static private ips
+	// for each time we call this function `cluster.Config()`
+	for _, subnet := range config.Subnets {
+		subnet.lastAllocatedAddr = nil
+	}
+
 	for etcdIndex := 0; etcdIndex < config.EtcdCount; etcdIndex++ {
 
 		//Round-robbin etcd instances across all available subnets


### PR DESCRIPTION
Config() func had been returning inconsistent result for each call by incrementing private IPs statically assigned to etcd nodes in configuration time.

This has never affected clusters created via kube-aws but does break the upcoming node pools feature. So I'm fixing this now.