### PR TITLE
Extract templating and compressing

### DIFF
--- a/config/tls_config.go
+++ b/config/tls_config.go
@@ -1,21 +1,19 @@
 package config
 
 import (
-	"bytes"
-	"compress/gzip"
 	"crypto/rsa"
 	"crypto/x509"
-	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"net"
-	"path/filepath"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/coreos/kube-aws/gzipcompressor"
 	"github.com/coreos/kube-aws/netutil"
 	"github.com/coreos/kube-aws/tlsutil"
+	"io/ioutil"
+	"path/filepath"
 )
 
 // PEM encoded TLS assets.
@@ -239,18 +237,6 @@ func (r *RawTLSAssets) WriteToDir(dirname string, includeCAKey bool) error {
 	return nil
 }
 
-func compressData(d []byte) (string, error) {
-	var buff bytes.Buffer
-	gzw := gzip.NewWriter(&buff)
-	if _, err := gzw.Write(d); err != nil {
-		return "", err
-	}
-	if err := gzw.Close(); err != nil {
-		return "", err
-	}
-	return base64.StdEncoding.EncodeToString(buff.Bytes()), nil
-}
-
 type encryptService interface {
 	Encrypt(*kms.EncryptInput) (*kms.EncryptOutput, error)
 }
@@ -274,7 +260,7 @@ func (r *RawTLSAssets) compact(cfg *Config, kmsSvc encryptService) (*CompactTLSA
 		data = encryptOutput.CiphertextBlob
 
 		var out string
-		if out, err = compressData(data); err != nil {
+		if out, err = gzipcompressor.CompressData(data); err != nil {
 			return ""
 		}
 		return out

--- a/filereader/jsontemplate/jsontemplate.go
+++ b/filereader/jsontemplate/jsontemplate.go
@@ -1,0 +1,55 @@
+package jsontemplate
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/coreos/kube-aws/filereader/texttemplate"
+)
+
+func GetBytes(filename string, data interface{}) ([]byte, error) {
+	rendered, err := texttemplate.GetString(filename, data)
+	if err != nil {
+		return nil, err
+	}
+
+	//Use unmarshal function to do syntax validation
+	renderedBytes := []byte(rendered)
+	var jsonHolder map[string]interface{}
+	if err := json.Unmarshal(renderedBytes, &jsonHolder); err != nil {
+		syntaxError, ok := err.(*json.SyntaxError)
+		if ok {
+			contextString := getContextString(renderedBytes, int(syntaxError.Offset), 3)
+			return nil, fmt.Errorf("%v:\njson syntax error (offset=%d), in this region:\n-------\n%s\n-------\n", err, syntaxError.Offset, contextString)
+		}
+		return nil, err
+	}
+
+	// minify JSON
+	var buff bytes.Buffer
+	if err := json.Compact(&buff, renderedBytes); err != nil {
+		return nil, err
+	}
+	return buff.Bytes(), nil
+}
+
+func getContextString(buf []byte, offset, lineCount int) string {
+
+	linesSeen := 0
+	var leftLimit int
+	for leftLimit = offset; leftLimit > 0 && linesSeen <= lineCount; leftLimit-- {
+		if buf[leftLimit] == '\n' {
+			linesSeen++
+		}
+	}
+
+	linesSeen = 0
+	var rightLimit int
+	for rightLimit = offset + 1; rightLimit < len(buf) && linesSeen <= lineCount; rightLimit++ {
+		if buf[rightLimit] == '\n' {
+			linesSeen++
+		}
+	}
+
+	return string(buf[leftLimit:rightLimit])
+}

--- a/filereader/texttemplate/texttemplate.go
+++ b/filereader/texttemplate/texttemplate.go
@@ -1,0 +1,33 @@
+package texttemplate
+
+import (
+	"bytes"
+	"io/ioutil"
+	"text/template"
+)
+
+func GetBytesBuffer(filename string, data interface{}) (*bytes.Buffer, error) {
+	raw, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	tmpl, err := template.New(filename).Parse(string(raw))
+	if err != nil {
+		return nil, err
+	}
+	var buff bytes.Buffer
+	if err := tmpl.Execute(&buff, data); err != nil {
+		return nil, err
+	}
+	return &buff, nil
+}
+
+func GetString(filename string, data interface{}) (string, error) {
+	buf, err := GetBytesBuffer(filename, data)
+
+	if err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}

--- a/filereader/userdatatemplate/userdatatemplate.go
+++ b/filereader/userdatatemplate/userdatatemplate.go
@@ -1,0 +1,20 @@
+package userdatatemplate
+
+import (
+	"github.com/coreos/kube-aws/filereader/texttemplate"
+	"github.com/coreos/kube-aws/gzipcompressor"
+)
+
+func GetString(filename string, data interface{}, compress bool) (string, error) {
+	buf, err := texttemplate.GetBytesBuffer(filename, data)
+
+	if err != nil {
+		return "", err
+	}
+
+	if compress {
+		return gzipcompressor.CompressData(buf.Bytes())
+	}
+
+	return buf.String(), nil
+}

--- a/gzipcompressor/gzipcompressor.go
+++ b/gzipcompressor/gzipcompressor.go
@@ -1,0 +1,19 @@
+package gzipcompressor
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+)
+
+func CompressData(d []byte) (string, error) {
+	var buff bytes.Buffer
+	gzw := gzip.NewWriter(&buff)
+	if _, err := gzw.Write(d); err != nil {
+		return "", err
+	}
+	if err := gzw.Close(); err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(buff.Bytes()), nil
+}


### PR DESCRIPTION
We'd been doing text/json/userdata templating in a specific package(=`config`).
While doing the same templating in the implementation of the node pools feature, it turned out that it is time to reveal what is the common sense of "templating" in kube-aws and what can be reused.

I've made each of the text, json and userdata templating resides in their own packages, and placed them under the umbrella package renamed `filereader` because the templating happens while reading files e.g. `user-data/cloud-config-*` and `stack-template.json` templates initially generated via `kube-aws render` but can be modified by users, hence they're `reader`s rather than `templator`s.
