### PR TITLE
refactoring: Extract coreos-cloud-init userdata validation

### DIFF
--- a/coreos/amiregistry/amiregistry.go
+++ b/coreos/amiregistry/amiregistry.go
@@ -1,4 +1,4 @@
-package coreosutil
+package amiregistry
 
 import (
 	"encoding/json"

--- a/coreos/userdatavalidation/userdatavalidation.go
+++ b/coreos/userdatavalidation/userdatavalidation.go
@@ -1,0 +1,42 @@
+package userdatavalidation
+
+import (
+	"fmt"
+	"github.com/coreos/coreos-cloudinit/config/validate"
+	"strings"
+)
+
+type Entry struct {
+	Name    string
+	Content string
+}
+
+func Execute(entries []Entry) error {
+	errors := []string{}
+
+	for _, userData := range entries {
+		report, err := validate.Validate([]byte(userData.Content))
+
+		if err != nil {
+			errors = append(
+				errors,
+				fmt.Sprintf("cloud-config %s could not be parsed: %v",
+					userData.Name,
+					err,
+				),
+			)
+			continue
+		}
+
+		for _, entry := range report.Entries() {
+			errors = append(errors, fmt.Sprintf("%s: %+v", userData.Name, entry))
+		}
+	}
+
+	if len(errors) > 0 {
+		reportString := strings.Join(errors, "\n")
+		return fmt.Errorf("cloud-config validation errors:\n%s\n", reportString)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Extract it out of the config package into its own package "userdatavalidation" for future use in the upcoming node pools feature.
The former `coreosutil` package is now named `coreos/amiregistry` and the validation is in the `coreos/userdatavalidation` package to reflect the fact that both of them are coreos specific but they have different responsiblity compared to each other.