### PR TITLE
refactoring: Make the Compact func and the KMS ecryption interface

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -93,7 +93,7 @@ func newDefaultCluster() *Cluster {
 	}
 }
 
-func newDefaultClusterWithDeps(encSvc encryptService) *Cluster {
+func newDefaultClusterWithDeps(encSvc EncryptService) *Cluster {
 	cluster := newDefaultCluster()
 	cluster.providedEncryptService = encSvc
 	return cluster
@@ -200,7 +200,7 @@ type Cluster struct {
 	ElasticFileSystemID      string            `yaml:"elasticFileSystemId,omitempty"`
 	SSHAuthorizedKeys        []string          `yaml:"sshAuthorizedKeys,omitempty"`
 	Experimental             Experimental      `yaml:"experimental"`
-	providedEncryptService   encryptService
+	providedEncryptService   EncryptService
 	IsChinaRegion            bool
 }
 
@@ -449,14 +449,14 @@ func (c Cluster) stackConfig(opts StackTemplateOptions, compressUserData bool) (
 		WithCredentialsChainVerboseErrors(true)
 
 	// TODO Cleaner way to inject this dependency
-	var kmsSvc encryptService
+	var kmsSvc EncryptService
 	if c.providedEncryptService != nil {
 		kmsSvc = c.providedEncryptService
 	} else {
 		kmsSvc = kms.New(session.New(awsConfig))
 	}
 
-	compactAssets, err := assets.compact(stackConfig.Config, kmsSvc)
+	compactAssets, err := assets.Compact(stackConfig.Config.KMSKeyARN, kmsSvc)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compress TLS assets: %v", err)
 	}

--- a/config/tls_config.go
+++ b/config/tls_config.go
@@ -237,11 +237,11 @@ func (r *RawTLSAssets) WriteToDir(dirname string, includeCAKey bool) error {
 	return nil
 }
 
-type encryptService interface {
+type EncryptService interface {
 	Encrypt(*kms.EncryptInput) (*kms.EncryptOutput, error)
 }
 
-func (r *RawTLSAssets) compact(cfg *Config, kmsSvc encryptService) (*CompactTLSAssets, error) {
+func (r *RawTLSAssets) Compact(kMSKeyARN string, kmsSvc EncryptService) (*CompactTLSAssets, error) {
 	var err error
 	compact := func(data []byte) string {
 		if err != nil {
@@ -249,7 +249,7 @@ func (r *RawTLSAssets) compact(cfg *Config, kmsSvc encryptService) (*CompactTLSA
 		}
 
 		encryptInput := kms.EncryptInput{
-			KeyId:     aws.String(cfg.KMSKeyARN),
+			KeyId:     aws.String(kMSKeyARN),
 			Plaintext: data,
 		}
 

--- a/config/user_data_config_test.go
+++ b/config/user_data_config_test.go
@@ -37,7 +37,7 @@ func TestCloudConfigTemplating(t *testing.T) {
 		t.Fatalf("Failed to create config: %v", err)
 	}
 
-	compactAssets, err := assets.compact(cfg, &dummyEncryptService{})
+	compactAssets, err := assets.Compact(cfg.KMSKeyARN, &dummyEncryptService{})
 	if err != nil {
 		t.Fatalf("failed to compress TLS assets: %v", err)
 	}


### PR DESCRIPTION
which is used for compacting TLSassets more open to be reused from other packages

This makes implementing the upcoming node pools feature a bit easier.