### PR TITLE
refactoring: Rethink how we organize cluster configuration for better maintenability

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -728,7 +728,7 @@ nodeDrainer:
 }
 
 func newMinimalConfig() (*Config, error) {
-	cluster := newDefaultCluster()
+	cluster := NewDefaultCluster()
 	cluster.ExternalDNSName = "k8s.example.com"
 	cluster.Region = "us-west-1"
 	cluster.Subnets = []*Subnet{
@@ -871,7 +871,7 @@ func TestValidateExistingVPC(t *testing.T) {
 		{"10.1.0.0/16", []string{"1o.1.1.o/24", "10.1.2.0/24"}},
 	}
 
-	cluster := newDefaultCluster()
+	cluster := NewDefaultCluster()
 
 	cluster.VPCCIDR = "10.0.0.0/16"
 	cluster.Subnets = []*Subnet{


### PR DESCRIPTION
This is intended to make implementing and maintaining the upcoming node pools feature eaiser.

Reorganizing structs and funcs like this would result in:

* Less conflicts between commits from multiple branches
* Better reusability when we try to make kube-aws provision a separate cfn stack for each part of a cluster e.g. etcd, control plane, worker nodes(incoming as the node pools feature)
