### PR TITLE
Initial implementation of Node Pools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /e2e/assets
 *~
 /config/templates.go
+/nodepool/config/templates.go
 .idea/
 .envrc
 coverage.txt

--- a/build
+++ b/build
@@ -19,6 +19,7 @@ fi
 echo Building kube-aws ${VERSION}
 
 go generate ./config
+go generate ./nodepool/config
 
 if [[ ! "${BUILD_GOOS:-}" == "" ]];then
   export GOOS=$BUILD_GOOS

--- a/cmd/nodepool.go
+++ b/cmd/nodepool.go
@@ -1,0 +1,7 @@
+package cmd
+
+import "github.com/coreos/kube-aws/cmd/nodepool"
+
+func init() {
+	RootCmd.AddCommand(nodepool.NodePoolCmd)
+}

--- a/cmd/nodepool/init.go
+++ b/cmd/nodepool/init.go
@@ -1,0 +1,137 @@
+package nodepool
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	cfg "github.com/coreos/kube-aws/config"
+	"github.com/coreos/kube-aws/filegen"
+	"github.com/coreos/kube-aws/nodepool/config"
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdInit = &cobra.Command{
+		Use:          "init",
+		Short:        "Initialize default node pool configuration",
+		Long:         ``,
+		RunE:         runCmdInit,
+		SilenceUsage: true,
+	}
+
+	initOpts = config.ComputedConfig{}
+)
+
+func init() {
+	NodePoolCmd.AddCommand(cmdInit)
+	cmdInit.Flags().StringVar(&initOpts.AvailabilityZone, "availability-zone", "", "The AWS availability-zone to deploy to")
+	cmdInit.Flags().StringVar(&initOpts.KeyName, "key-name", "", "The AWS key-pair for ssh access to nodes")
+	cmdInit.Flags().StringVar(&initOpts.KMSKeyARN, "kms-key-arn", "", "The ARN of the AWS KMS key for encrypting TLS assets")
+	cmdInit.Flags().StringVar(&initOpts.AmiId, "ami-id", "", "The AMI ID of CoreOS")
+}
+
+func runCmdInit(cmd *cobra.Command, args []string) error {
+	initOpts.NodePoolName = nodePoolOpts.PoolName
+
+	// Validate flags.
+	required := []struct {
+		name, val string
+	}{
+		{"--node-pool-name", initOpts.NodePoolName},
+		{"--availability-zone", initOpts.AvailabilityZone},
+	}
+	var missing []string
+	for _, req := range required {
+		if req.val == "" {
+			missing = append(missing, strconv.Quote(req.name))
+		}
+	}
+	if len(missing) != 0 {
+		return fmt.Errorf("Missing required flag(s): %s", strings.Join(missing, ", "))
+	}
+
+	// Read the config from file.
+	mainConfig, err := cfg.ClusterFromFile(clusterConfigFilePath())
+	if err != nil {
+		return fmt.Errorf("Failed to read cluster config: %v", err)
+	}
+
+	main, err := mainConfig.Config()
+	if err != nil {
+		return fmt.Errorf("Failed to create config: %v", err)
+	}
+
+	// Required and inheritable settings for the node pool.
+	//
+	// These can be set via command-line options to kube-aws nodepool init.
+	// If omitted, these can be inherited from the main cluster's cluster.yaml.
+
+	if initOpts.Region == "" {
+		initOpts.Region = main.Region
+	}
+
+	if initOpts.KeyName == "" {
+		initOpts.KeyName = main.KeyName
+	}
+
+	if initOpts.KMSKeyARN == "" {
+		initOpts.KMSKeyARN = main.KMSKeyARN
+	}
+
+	if initOpts.AmiId == "" {
+		initOpts.AmiId = main.AmiId
+	}
+
+	if initOpts.ReleaseChannel == "" {
+		initOpts.ReleaseChannel = main.ReleaseChannel
+	}
+
+	if initOpts.VPCCIDR == "" {
+		initOpts.VPCCIDR = main.VPCCIDR
+	}
+
+	// Required, inheritable and importable settings for the node pool.
+	//
+	// These can be customized in the node pool's cluster.yaml
+	// If omitted from it, these can also can be exported from the main cluster
+	// and then imported to the node pool in the cloudformation layer.
+
+	if initOpts.VPCID == "" {
+		initOpts.VPCID = main.VPCID
+	}
+
+	if initOpts.RouteTableID == "" {
+		initOpts.RouteTableID = main.RouteTableID
+	}
+
+	if initOpts.EtcdEndpoints == "" {
+		initOpts.EtcdEndpoints = main.EtcdEndpoints
+	}
+
+	initOpts.ClusterName = main.ClusterName
+
+	// Required and shared settings for the node pool.
+	//
+	// These can not be customized in the node pool's cluster yaml.
+	// Customizing these values in each node pool doesn't make sense
+	// because inconsistency between the main cluster and node pools result in
+	// unusable worker nodes that can't communicate with k8s apiserver, kube-dns, calico, etc.
+
+	initOpts.KubeClusterSettings = main.KubeClusterSettings
+
+	if err := filegen.CreateFileFromTemplate(nodePoolClusterConfigFilePath(), initOpts, config.DefaultClusterConfig); err != nil {
+		return fmt.Errorf("Error exec-ing default config template: %v", err)
+	}
+
+	successMsg :=
+		`Success! Created %s
+
+Next steps:
+1. (Optional) Edit %s to parameterize the cluster.
+2. Use the "kube-aws nodepool render" command to render the stack template.
+`
+
+	fmt.Printf(successMsg, nodePoolClusterConfigFilePath, nodePoolClusterConfigFilePath)
+	return nil
+}

--- a/cmd/nodepool/render.go
+++ b/cmd/nodepool/render.go
@@ -1,0 +1,105 @@
+package nodepool
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"path"
+
+	cfg "github.com/coreos/kube-aws/config"
+	"github.com/coreos/kube-aws/nodepool/config"
+	"github.com/spf13/cobra"
+	"strconv"
+	"strings"
+)
+
+var (
+	cmdRender = &cobra.Command{
+		Use:          "render",
+		Short:        "Render deployment artifacts",
+		Long:         ``,
+		RunE:         runCmdRender,
+		SilenceUsage: true,
+	}
+
+	cmdRenderStack = &cobra.Command{
+		Use:          "stack",
+		Short:        "Render CloudFormation stack",
+		Long:         ``,
+		RunE:         runCmdRenderStack,
+		SilenceUsage: true,
+	}
+)
+
+func init() {
+	NodePoolCmd.AddCommand(cmdRender)
+
+	cmdRender.AddCommand(cmdRenderStack)
+}
+
+func runCmdRender(cmd *cobra.Command, args []string) error {
+	fmt.Printf("WARNING: 'kube-aws render' is deprecated. See 'kube-aws render --help' for usage\n")
+
+	if len(args) != 0 {
+		return fmt.Errorf("render takes no arguments\n")
+	}
+
+	if err := runCmdRenderStack(cmd, args); err != nil {
+		return err
+	}
+
+	return nil
+}
+func runCmdRenderStack(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		return fmt.Errorf("render stack takes no arguments\n")
+	}
+
+	// Validate flags.
+	required := []struct {
+		name, val string
+	}{
+		{"--node-pool-name", nodePoolOpts.PoolName},
+	}
+	var missing []string
+	for _, req := range required {
+		if req.val == "" {
+			missing = append(missing, strconv.Quote(req.name))
+		}
+	}
+	if len(missing) != 0 {
+		return fmt.Errorf("Missing required flag(s): %s", strings.Join(missing, ", "))
+	}
+
+	// Write all assets to disk.
+	files := []struct {
+		name string
+		data []byte
+		mode os.FileMode
+	}{
+		{stackTemplateOptions().WorkerTmplFile, cfg.CloudConfigWorker, 0644},
+		{stackTemplateOptions().StackTemplateTmplFile, config.StackTemplateTemplate, 0644},
+	}
+	for _, file := range files {
+		if err := os.MkdirAll(path.Dir(file.name), 0755); err != nil {
+			return err
+		}
+
+		if err := ioutil.WriteFile(file.name, file.data, file.mode); err != nil {
+			return err
+		}
+	}
+
+	successMsg :=
+		`Success! Stack rendered to nodepools/%s/stack-template.json.
+
+Next steps:
+1. (Optional) Validate your changes to %s with "kube-aws nodepool validate --pool-name %s"
+2. (Optional) Further customize the cluster by modifying stack-template.json or files in ./userdata.
+3. Start the cluster with "kube-aws up".
+`
+
+	fmt.Printf(successMsg, nodePoolOpts.PoolName, nodePoolClusterConfigFilePath(), nodePoolOpts.PoolName)
+	return nil
+}

--- a/cmd/nodepool/root.go
+++ b/cmd/nodepool/root.go
@@ -1,0 +1,45 @@
+package nodepool
+
+import (
+	"fmt"
+	"github.com/coreos/kube-aws/nodepool/config"
+	"github.com/spf13/cobra"
+)
+
+var (
+	NodePoolCmd = &cobra.Command{
+		Use:   "node-pools",
+		Short: "Manage node pools",
+		Long:  ``,
+	}
+
+	nodePoolOpts = config.Ref{}
+)
+
+func clusterConfigFilePath() string {
+	return "cluster.yaml"
+}
+
+func nodePoolConfigDirPath() string {
+	return fmt.Sprintf("node-pools/%s", nodePoolOpts.PoolName)
+}
+
+func nodePoolClusterConfigFilePath() string {
+	return fmt.Sprintf("%s/cluster.yaml", nodePoolConfigDirPath())
+}
+
+func nodePoolExportedStackTemplatePath() string {
+	return fmt.Sprintf("%s/%s.stack-template.json", nodePoolConfigDirPath(), nodePoolOpts.PoolName)
+}
+
+func stackTemplateOptions() config.StackTemplateOptions {
+	return config.StackTemplateOptions{
+		TLSAssetsDir:          "credentials",
+		WorkerTmplFile:        fmt.Sprintf("%s/userdata/cloud-config-worker", nodePoolConfigDirPath(), nodePoolOpts.PoolName),
+		StackTemplateTmplFile: fmt.Sprintf("%s/stack-template.json", nodePoolConfigDirPath()),
+	}
+}
+
+func init() {
+	NodePoolCmd.PersistentFlags().StringVar(&nodePoolOpts.PoolName, "node-pool-name", "", "The name of this node pool. This will be the name of the cloudformation stack")
+}

--- a/cmd/nodepool/up.go
+++ b/cmd/nodepool/up.go
@@ -1,0 +1,82 @@
+package nodepool
+
+import (
+	"fmt"
+
+	"github.com/coreos/kube-aws/nodepool/cluster"
+	"github.com/coreos/kube-aws/nodepool/config"
+	"github.com/spf13/cobra"
+	"io/ioutil"
+)
+
+var (
+	cmdUp = &cobra.Command{
+		Use:          "up",
+		Short:        "Create a new Kubernetes cluster",
+		Long:         ``,
+		RunE:         runCmdUp,
+		SilenceUsage: true,
+	}
+
+	upOpts = struct {
+		awsDebug, export bool
+		s3URI            string
+	}{}
+)
+
+func init() {
+	NodePoolCmd.AddCommand(cmdUp)
+	cmdUp.Flags().BoolVar(&upOpts.export, "export", false, "Don't create cluster, instead export cloudformation stack file")
+	cmdUp.Flags().BoolVar(&upOpts.awsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
+	cmdUp.Flags().StringVar(&upOpts.s3URI, "s3-uri", "", "When your template is bigger than the cloudformation limit of 51200 bytes, upload the template to the specified location in S3")
+}
+
+func runCmdUp(cmd *cobra.Command, args []string) error {
+	conf, err := config.ClusterFromFile(nodePoolClusterConfigFilePath())
+	if err != nil {
+		return fmt.Errorf("Failed to read cluster config: %v", err)
+	}
+
+	if err := conf.ValidateUserData(stackTemplateOptions()); err != nil {
+		return fmt.Errorf("Failed to validate user data: %v", err)
+	}
+
+	data, err := conf.RenderStackTemplate(stackTemplateOptions())
+	if err != nil {
+		return fmt.Errorf("Failed to render stack template: %v", err)
+	}
+
+	if upOpts.export {
+		templatePath := nodePoolExportedStackTemplatePath()
+		fmt.Printf("Exporting %s\n", templatePath)
+		if err := ioutil.WriteFile(templatePath, data, 0600); err != nil {
+			return fmt.Errorf("Error writing %s : %v", templatePath, err)
+		}
+		if conf.KMSKeyARN == "" {
+			fmt.Printf("BEWARE: %s contains your TLS secrets!\n", templatePath)
+		}
+		return nil
+	}
+
+	cluster := cluster.New(conf, upOpts.awsDebug)
+	fmt.Printf("Creating AWS resources. This should take around 5 minutes.\n")
+	if err := cluster.Create(string(data), upOpts.s3URI); err != nil {
+		return fmt.Errorf("Error creating cluster: %v", err)
+	}
+
+	info, err := cluster.Info()
+	if err != nil {
+		return fmt.Errorf("Failed fetching cluster info: %v", err)
+	}
+
+	successMsg :=
+		`Success! Your AWS resources have been created:
+%s
+The containers that power your cluster are now being downloaded.
+
+You should be able to access the Kubernetes API once the containers finish downloading.
+`
+	fmt.Printf(successMsg, info.String())
+
+	return nil
+}

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -1119,11 +1119,6 @@
   },
 
   "Outputs": {
-    "WorkerSecurityGroup" : {
-      "Description" : "The security group assigned to worker nodes",
-      "Value" :  { "Ref" : "SecurityGroupWorker" },
-      "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-WorkerSecurityGroup" }}
-    },
     {{if not .VPCID}}
     "RouteTable" : {
       "Description" : "The route table assigned managed by this stack",
@@ -1134,7 +1129,12 @@
       "Description" : "The VPC managed by this stack",
       "Value" :  { "Ref" : "{{.VPCLogicalName}}" },
       "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-VPC" }}
-    }
+    },
     {{end}}
+    "WorkerSecurityGroup" : {
+      "Description" : "The security group assigned to worker nodes",
+      "Value" :  { "Ref" : "SecurityGroupWorker" },
+      "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-WorkerSecurityGroup" }}
+    }
   }
 }

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -1116,5 +1116,25 @@
     {{end}}
     {{end}}
 
+  },
+
+  "Outputs": {
+    "WorkerSecurityGroup" : {
+      "Description" : "The security group assigned to worker nodes",
+      "Value" :  { "Ref" : "SecurityGroupWorker" },
+      "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-WorkerSecurityGroup" }}
+    },
+    {{if not .VPCID}}
+    "RouteTable" : {
+      "Description" : "The route table assigned managed by this stack",
+      "Value" :  { "Ref" : "RouteTable" },
+      "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-RouteTable" }}
+    },
+    "VPC" : {
+      "Description" : "The VPC managed by this stack",
+      "Value" :  { "Ref" : "{{.VPCLogicalName}}" },
+      "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-VPC" }}
+    }
+    {{end}}
   }
 }

--- a/e2e/run
+++ b/e2e/run
@@ -76,6 +76,12 @@ configure() {
   if [ "${KUBE_AWS_WAIT_SIGNAL_ENABLED}" != "" ]; then
     echo -e '  waitSignal:\n    enabled: true' >> cluster.yaml
   fi
+  if [ "${KUBE_AWS_NODE_LABEL_ENABLED}" != "" ]; then
+    echo -e '  nodeLabel:\n    enabled: true' >> cluster.yaml
+  fi
+  if [ "${KUBE_AWS_AWS_ENV_ENABLED}" != "" ]; then
+    echo -e "  awsEnvironment:\n    enabled: true\n    environment:\n      CFNSTACK: '{\"Ref\":\"AWS::StackId\"}'" >> cluster.yaml
+  fi
   if [ "${KUBE_AWS_USE_CALICO}" != "" ]; then
     echo 'useCalico: true' >> cluster.yaml
   fi

--- a/e2e/run
+++ b/e2e/run
@@ -204,11 +204,25 @@ ssh_worker() {
   ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${KUBE_AWS_SSH_KEY} core@$(worker_host) "$@"
 }
 
+nodepool() {
+  cd ${WORK_DIR}
+
+  ${KUBE_AWS_CMD} node-pools init --node-pool-name ${KUBE_AWS_POOL_NAME} \
+      --availability-zone ${KUBE_AWS_AVAILABILITY_ZONE} \
+      --key-name ${KUBE_AWS_KEY_NAME} \
+      --kms-key-arn ${KUBE_AWS_KMS_KEY_ARN}
+
+  ${KUBE_AWS_CMD} node-pools render stack --node-pool-name ${KUBE_AWS_POOL_NAME}
+  ${KUBE_AWS_CMD} node-pools up --node-pool-name ${KUBE_AWS_POOL_NAME} --export
+  ${KUBE_AWS_CMD} node-pools up --node-pool-name ${KUBE_AWS_POOL_NAME} --s3-uri ${KUBE_AWS_S3_URI}
+}
+
 all() {
   build
   prepare
   configure
   up
+  nodepool
   update
   conformance
 }

--- a/nodepool/cluster/cluster.go
+++ b/nodepool/cluster/cluster.go
@@ -1,0 +1,67 @@
+package cluster
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/coreos/kube-aws/cfnstack"
+	"github.com/coreos/kube-aws/nodepool/config"
+	"text/tabwriter"
+)
+
+type Cluster struct {
+	config.ProvidedConfig
+	session *session.Session
+}
+
+type Info struct {
+	Name string
+}
+
+func (c *Info) String() string {
+	buf := new(bytes.Buffer)
+	w := new(tabwriter.Writer)
+	w.Init(buf, 0, 8, 0, '\t', 0)
+
+	fmt.Fprintf(w, "Cluster Name:\t%s\n", c.Name)
+
+	w.Flush()
+	return buf.String()
+}
+
+func New(cfg *config.ProvidedConfig, awsDebug bool) *Cluster {
+	awsConfig := aws.NewConfig().
+		WithRegion(cfg.Region).
+		WithCredentialsChainVerboseErrors(true)
+
+	if awsDebug {
+		awsConfig = awsConfig.WithLogLevel(aws.LogDebug)
+	}
+
+	return &Cluster{
+		ProvidedConfig: *cfg,
+		session:        session.New(awsConfig),
+	}
+}
+
+func (c *Cluster) stackProvisioner() *cfnstack.Provisioner {
+	return cfnstack.NewProvisioner(c.NodePoolName, c.StackTags, "{}", c.session)
+}
+
+func (c *Cluster) Create(stackBody string, s3URI string) error {
+	cfSvc := cloudformation.New(c.session)
+	s3Svc := s3.New(c.session)
+
+	return c.stackProvisioner().CreateStackAndWait(cfSvc, s3Svc, stackBody, s3URI)
+}
+
+func (c *Cluster) Info() (*Info, error) {
+	var info Info
+	{
+		info.Name = c.NodePoolName
+	}
+	return &info, nil
+}

--- a/nodepool/config/config.go
+++ b/nodepool/config/config.go
@@ -29,13 +29,12 @@ type ComputedConfig struct {
 }
 
 type ProvidedConfig struct {
-	cfg.KubeClusterSettings       `yaml:",inline"`
-	cfg.WorkerSettings            `yaml:",inline"`
-	cfg.DeploymentSettings        `yaml:",inline"`
-	EtcdEndpoints                 string `yaml:"etcdEndpoints,omitempty"`
-	NodePoolName                  string `yaml:"nodePoolName,omitempty"`
-	WorkerInternalSecurityGroupID string `yaml:"workerInternalSecurityGroupId,omitempty"`
-	providedEncryptService        cfg.EncryptService
+	cfg.KubeClusterSettings `yaml:",inline"`
+	cfg.WorkerSettings      `yaml:",inline"`
+	cfg.DeploymentSettings  `yaml:",inline"`
+	EtcdEndpoints           string `yaml:"etcdEndpoints,omitempty"`
+	NodePoolName            string `yaml:"nodePoolName,omitempty"`
+	providedEncryptService  cfg.EncryptService
 }
 
 type StackTemplateOptions struct {
@@ -212,9 +211,10 @@ func (c ComputedConfig) RouteTableRef() string {
 	return fmt.Sprintf(`{"Fn::ImportValue" : {"Fn::Sub" : "%s-RouteTable"}}`, c.ClusterName)
 }
 
-func (c ComputedConfig) WorkerSecurityGroupRef() string {
-	if c.WorkerInternalSecurityGroupID != "" {
-		return fmt.Sprintf(`%q`, c.WorkerInternalSecurityGroupID)
+func (c ComputedConfig) WorkerSecurityGroupRefs() []string {
+	return []string{
+		// The security group assigned to worker nodes to allow communication to etcd nodes and controller nodes
+		// which is created and maintained in the main cluster and then imported to node pools.
+		fmt.Sprintf(`{"Fn::ImportValue" : {"Fn::Sub" : "%s-WorkerSecurityGroup"}}`, c.ClusterName),
 	}
-	return fmt.Sprintf(`{"Fn::ImportValue" : {"Fn::Sub" : "%s-WorkerSecurityGroup"}}`, c.ClusterName)
 }

--- a/nodepool/config/config.go
+++ b/nodepool/config/config.go
@@ -1,0 +1,220 @@
+package config
+
+//go:generate go run ../../codegen/templates_gen.go DefaultClusterConfig=cluster.yaml StackTemplateTemplate=stack-template.json
+//go:generate gofmt -w templates.go
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/kms"
+	cfg "github.com/coreos/kube-aws/config"
+	"github.com/coreos/kube-aws/coreos/amiregistry"
+	"github.com/coreos/kube-aws/coreos/userdatavalidation"
+	"github.com/coreos/kube-aws/filereader/jsontemplate"
+	"github.com/coreos/kube-aws/filereader/userdatatemplate"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+)
+
+type Ref struct {
+	PoolName string
+}
+
+type ComputedConfig struct {
+	ProvidedConfig
+	// Fields computed from Cluster
+	AMI       string
+	TLSConfig *cfg.CompactTLSAssets
+}
+
+type ProvidedConfig struct {
+	cfg.KubeClusterSettings       `yaml:",inline"`
+	cfg.WorkerSettings            `yaml:",inline"`
+	cfg.DeploymentSettings        `yaml:",inline"`
+	EtcdEndpoints                 string `yaml:"etcdEndpoints,omitempty"`
+	NodePoolName                  string `yaml:"nodePoolName,omitempty"`
+	WorkerInternalSecurityGroupID string `yaml:"workerInternalSecurityGroupId,omitempty"`
+	providedEncryptService        cfg.EncryptService
+}
+
+type StackTemplateOptions struct {
+	WorkerTmplFile        string
+	StackTemplateTmplFile string
+	TLSAssetsDir          string
+}
+
+type stackConfig struct {
+	*ComputedConfig
+	UserDataWorker string
+}
+
+func (c ProvidedConfig) stackConfig(opts StackTemplateOptions, compressUserData bool) (*stackConfig, error) {
+	assets, err := cfg.ReadTLSAssets(opts.TLSAssetsDir)
+	if err != nil {
+		return nil, err
+	}
+	stackConfig := stackConfig{}
+
+	if stackConfig.ComputedConfig, err = c.Config(); err != nil {
+		return nil, err
+	}
+
+	// TODO Cleaner way to inject this dependency
+	var kmsSvc cfg.EncryptService
+	if c.providedEncryptService != nil {
+		kmsSvc = c.providedEncryptService
+	} else {
+		awsConfig := aws.NewConfig().
+			WithRegion(stackConfig.ComputedConfig.Region).
+			WithCredentialsChainVerboseErrors(true)
+
+		kmsSvc = kms.New(session.New(awsConfig))
+	}
+
+	compactAssets, err := assets.Compact(stackConfig.ComputedConfig.KMSKeyARN, kmsSvc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compress TLS assets: %v", err)
+	}
+
+	stackConfig.ComputedConfig.TLSConfig = compactAssets
+
+	if stackConfig.UserDataWorker, err = userdatatemplate.GetString(opts.WorkerTmplFile, stackConfig.ComputedConfig, compressUserData); err != nil {
+		return nil, fmt.Errorf("failed to render worker cloud config: %v", err)
+	}
+
+	return &stackConfig, nil
+}
+
+func (c ProvidedConfig) ValidateUserData(opts StackTemplateOptions) error {
+	stackConfig, err := c.stackConfig(opts, false)
+	if err != nil {
+		return fmt.Errorf("failed to create stack config: %v", err)
+	}
+
+	err = userdatavalidation.Execute([]userdatavalidation.Entry{
+		{"UserDataWorker", stackConfig.UserDataWorker},
+	})
+
+	return err
+}
+
+func (c ProvidedConfig) RenderStackTemplate(opts StackTemplateOptions) ([]byte, error) {
+	stackConfig, err := c.stackConfig(opts, true)
+	if err != nil {
+		return nil, err
+	}
+
+	bytes, err := jsontemplate.GetBytes(opts.StackTemplateTmplFile, stackConfig)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return bytes, nil
+}
+
+func ClusterFromFile(filename string) (*ProvidedConfig, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := ClusterFromBytes(data)
+	if err != nil {
+		return nil, fmt.Errorf("file %s: %v", filename, err)
+	}
+
+	return c, nil
+}
+
+func NewDefaultCluster() *ProvidedConfig {
+	defaults := cfg.NewDefaultCluster()
+
+	return &ProvidedConfig{
+		DeploymentSettings: defaults.DeploymentSettings,
+		WorkerSettings:     defaults.WorkerSettings,
+	}
+}
+
+// ClusterFromBytes Necessary for unit tests, which store configs as hardcoded strings
+func ClusterFromBytes(data []byte) (*ProvidedConfig, error) {
+	c := NewDefaultCluster()
+	if err := yaml.Unmarshal(data, c); err != nil {
+		return nil, fmt.Errorf("failed to parse cluster: %v", err)
+	}
+
+	// If the user specified no subnets, we assume that a single AZ configuration with the default instanceCIDR is demanded
+	if len(c.Subnets) == 0 && c.InstanceCIDR == "" {
+		c.InstanceCIDR = "10.0.1.0/24"
+	}
+
+	if err := c.valid(); err != nil {
+		return nil, fmt.Errorf("invalid cluster: %v", err)
+	}
+
+	// For backward-compatibility
+	if len(c.Subnets) == 0 {
+		c.Subnets = []*cfg.Subnet{
+			{
+				AvailabilityZone: c.AvailabilityZone,
+				InstanceCIDR:     c.InstanceCIDR,
+			},
+		}
+	}
+
+	return c, nil
+}
+
+func (c ProvidedConfig) Config() (*ComputedConfig, error) {
+	config := ComputedConfig{ProvidedConfig: c}
+
+	if c.AmiId == "" {
+		var err error
+		if config.AMI, err = amiregistry.GetAMI(config.Region, config.ReleaseChannel); err != nil {
+			return nil, fmt.Errorf("failed getting AMI for config: %v", err)
+		}
+	} else {
+		config.AMI = c.AmiId
+	}
+
+	return &config, nil
+}
+
+func (c ProvidedConfig) valid() error {
+	if _, err := c.DeploymentSettings.Valid(); err != nil {
+		return err
+	}
+
+	if _, err := c.KubeClusterSettings.Valid(); err != nil {
+		return err
+	}
+
+	if err := c.WorkerSettings.Valid(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c ComputedConfig) VPCRef() string {
+	//This means this VPC already exists, and we can reference it directly by ID
+	if c.VPCID != "" {
+		return fmt.Sprintf("%q", c.VPCID)
+	}
+	return fmt.Sprintf(`{"Fn::ImportValue" : {"Fn::Sub" : "%s-VPC"}}`, c.ClusterName)
+}
+
+func (c ComputedConfig) RouteTableRef() string {
+	if c.RouteTableID != "" {
+		return fmt.Sprintf("%q", c.RouteTableID)
+	}
+	return fmt.Sprintf(`{"Fn::ImportValue" : {"Fn::Sub" : "%s-RouteTable"}}`, c.ClusterName)
+}
+
+func (c ComputedConfig) WorkerSecurityGroupRef() string {
+	if c.WorkerInternalSecurityGroupID != "" {
+		return fmt.Sprintf(`%q`, c.WorkerInternalSecurityGroupID)
+	}
+	return fmt.Sprintf(`{"Fn::ImportValue" : {"Fn::Sub" : "%s-WorkerSecurityGroup"}}`, c.ClusterName)
+}

--- a/nodepool/config/config_test.go
+++ b/nodepool/config/config_test.go
@@ -1,0 +1,155 @@
+package config
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+type dummyEncryptService struct{}
+
+func (d dummyEncryptService) Encrypt(input *kms.EncryptInput) (*kms.EncryptOutput, error) {
+	output := kms.EncryptOutput{
+		CiphertextBlob: input.Plaintext,
+	}
+	return &output, nil
+}
+
+const insufficientConfigYaml = `clusterName: mycluster
+nodePoolName: myculster-pool1
+externalDNSName: test.staging.core-os.net
+keyName: test-key-name
+kmsKeyArn: "arn:aws:kms:us-west-1:xxxxxxxxx:key/xxxxxxxxxxxxxxxxxxx"
+region: us-west-1
+`
+
+const availabilityZoneConfig = `
+availabilityZone: us-west-1c
+`
+
+const singleAzConfigYaml = insufficientConfigYaml + availabilityZoneConfig
+
+func withDummyCredentials(fn func(dir string)) {
+	if _, err := ioutil.ReadDir("temp"); err != nil {
+		if err := os.Mkdir("temp", 0755); err != nil {
+			panic(err)
+		}
+	}
+
+	dir, err := ioutil.TempDir("temp", "dummy-credentials")
+
+	if err != nil {
+		panic(err)
+	}
+
+	defer os.Remove(dir)
+
+	for _, pairName := range []string{"ca", "apiserver", "worker", "admin", "etcd", "etcd-client"} {
+		certFile := fmt.Sprintf("%s/%s.pem", dir, pairName)
+
+		if err := ioutil.WriteFile(certFile, []byte("dummycert"), 0644); err != nil {
+			panic(err)
+		}
+
+		defer os.Remove(certFile)
+
+		keyFile := fmt.Sprintf("%s/%s-key.pem", dir, pairName)
+
+		if err := ioutil.WriteFile(keyFile, []byte("dummykey"), 0644); err != nil {
+			panic(err)
+		}
+
+		defer os.Remove(keyFile)
+	}
+
+	fn(dir)
+}
+
+func TestConfig(t *testing.T) {
+	minimalValidConfigYaml := insufficientConfigYaml + `
+availabilityZone: us-west-1c
+dnsServiceIP: "10.3.0.10"
+etcdEndpoints: "10.0.0.1"
+`
+	validCases := []struct {
+		context    string
+		configYaml string
+	}{
+		{
+			context:    "WithMinimalValidConfig",
+			configYaml: minimalValidConfigYaml,
+		},
+		{
+			context: "WithVpcIdSpecified",
+			configYaml: minimalValidConfigYaml + `
+vpcId: vpc-1a2b3c4d
+`,
+		},
+		{
+			context: "WithVpcIdAndRouteTableIdSpecified",
+			configYaml: minimalValidConfigYaml + `
+vpcId: vpc-1a2b3c4d
+routeTableId: rtb-1a2b3c4d
+`,
+		},
+	}
+
+	for _, validCase := range validCases {
+		t.Run(validCase.context, func(t *testing.T) {
+			configBytes := validCase.configYaml
+			providedConfig, err := ClusterFromBytes([]byte(configBytes))
+			if err != nil {
+				t.Errorf("failed to parse config %s: %v", configBytes, err)
+				t.FailNow()
+			}
+			providedConfig.providedEncryptService = dummyEncryptService{}
+
+			withDummyCredentials(func(dummyTlsAssetsDir string) {
+				var stackTemplateOptions = StackTemplateOptions{
+					TLSAssetsDir:          dummyTlsAssetsDir,
+					WorkerTmplFile:        "../../config/templates/cloud-config-worker",
+					StackTemplateTmplFile: "templates/stack-template.json",
+				}
+
+				t.Run("ValidateUserData", func(t *testing.T) {
+					if err := providedConfig.ValidateUserData(stackTemplateOptions); err != nil {
+						t.Errorf("failed to validate user data: %v", err)
+					}
+				})
+
+				t.Run("RenderStackTemplate", func(t *testing.T) {
+					if _, err := providedConfig.RenderStackTemplate(stackTemplateOptions); err != nil {
+						t.Errorf("failed to render stack template: %v", err)
+					}
+				})
+			})
+		})
+	}
+
+	parseErrorCases := []struct {
+		context    string
+		configYaml string
+	}{
+		{
+			context: "WithVpcIdAndVPCCIDRSpecified",
+			configYaml: minimalValidConfigYaml + `
+vpcId: vpc-1a2b3c4d
+# vpcCIDR (10.1.0.0/16) does not contain instanceCIDR (10.0.1.0/24)
+vpcCIDR: "10.1.0.0/16"
+`,
+		},
+	}
+
+	for _, invalidCase := range parseErrorCases {
+		t.Run(invalidCase.context, func(t *testing.T) {
+			configBytes := invalidCase.configYaml
+			providedConfig, err := ClusterFromBytes([]byte(configBytes))
+			if err == nil {
+				t.Errorf("expected to fail parsing config %s: %v", configBytes, providedConfig)
+				t.FailNow()
+			}
+		})
+	}
+}

--- a/nodepool/config/templates/cluster.yaml
+++ b/nodepool/config/templates/cluster.yaml
@@ -64,9 +64,6 @@ routeTableId: "{{.RouteTableID}}"
 # CIDR for Kubernetes VPC. If vpcId is specified, must match the CIDR of existing vpc.
 vpcCIDR: "{{.VPCCIDR}}"
 
-# The security group assigned to worker nodes to allow communication to etcd nodes and controller nodes. Leave blank to import the value from the base cluster
-workerInternalSecurityGroupId: "{{.WorkerInternalSecurityGroupID}}"
-
 # CIDR for Kubernetes subnet when placing nodes in a single availability zone (not highly-available) Leave commented out for multi availability zone setting and use the below `subnets` section instead.
 # instanceCIDR: "10.0.0.0/24"
 

--- a/nodepool/config/templates/cluster.yaml
+++ b/nodepool/config/templates/cluster.yaml
@@ -1,0 +1,120 @@
+# Unique name of the node pool. In order to deploy
+# more than one node pool into the same AWS account, this
+# name must not conflict with an existing cluster.
+nodePoolName: {{.NodePoolName}}
+
+# The name of an existing Kubernetes cluster
+# Required in order to import reused resources' IDs and ARNs from the cluster
+# to this node pool in the CloudFormation layer using Cross Stack References.
+clusterName: {{.ClusterName}}
+
+# DNS name routable to the Kubernetes controller nodes
+# from worker nodes and external clients. Configure the options
+# below if you'd like kube-aws to create a Route53 record sets/hosted zones
+# for you.  Otherwise the deployer is responsible for making this name routable
+externalDNSName: {{.ExternalDNSName}}
+
+# CoreOS release channel to use. Currently supported options: alpha, beta, stable
+# See coreos.com/releases for more information
+releaseChannel: {{.ReleaseChannel}}
+
+# The AMI ID of CoreOS.
+# If omitted, the latest AMI for the releaseChannel is used.
+amiId: {{.AmiId}}
+
+# Name of the SSH keypair already loaded into the AWS
+# account being used to deploy this cluster.
+keyName: {{.KeyName}}
+
+# Region to provision Kubernetes cluster
+region: {{.Region}}
+
+# Availability Zone to provision Kubernetes cluster when placing nodes in a single availability zone (not highly-available) Comment out for multi availability zone setting and use the below `subnets` section instead.
+availabilityZone: {{.AvailabilityZone}}
+
+# ARN of the KMS key used to encrypt TLS assets.
+kmsKeyArn: "{{.KMSKeyARN}}"
+
+# Number of worker nodes to create
+#workerCount: 1
+
+# Instance type for worker nodes
+#workerInstanceType: m3.medium
+
+# Disk size (GiB) for worker nodes
+#workerRootVolumeSize: 30
+
+# Disk type for worker node (one of standard, io1, or gp2)
+#workerRootVolumeType: gp2
+
+# Number of I/O operations per second (IOPS) that the worker node disk supports. Leave blank if workerRootVolumeType is not io1
+#workerRootVolumeIOPS: 0
+
+# Price (Dollars) to bid for spot instances. Omit for on-demand instances.
+# workerSpotPrice: "0.05"
+
+## Networking config
+
+# ID of existing VPC to create subnet in. Leave blank to import the value from the base cluster
+vpcId: "{{.VPCID}}"
+
+# ID of existing route table in existing VPC to attach subnet to. Leave blank to import the value from the base cluster
+routeTableId: "{{.RouteTableID}}"
+
+# CIDR for Kubernetes VPC. If vpcId is specified, must match the CIDR of existing vpc.
+vpcCIDR: "{{.VPCCIDR}}"
+
+# The security group assigned to worker nodes to allow communication to etcd nodes and controller nodes. Leave blank to import the value from the base cluster
+workerInternalSecurityGroupId: "{{.WorkerInternalSecurityGroupID}}"
+
+# CIDR for Kubernetes subnet when placing nodes in a single availability zone (not highly-available) Leave commented out for multi availability zone setting and use the below `subnets` section instead.
+# instanceCIDR: "10.0.0.0/24"
+
+# Kubernetes subnets with their CIDRs and availability zones. Differentiating availability zone for 2 or more subnets result in high-availability (failures of a single availability zone won't result in immediate downtimes)
+# subnets:
+#   - availabilityZone: us-west-1a
+#     instanceCIDR: "10.0.0.0/24"
+#   - availabilityZone: us-west-1b
+#     instanceCIDR: "10.0.1.0/24"
+
+etcdEndpoints: "{{.EtcdEndpoints}}"
+
+# Required by kubelet to locate the cluster-internal dns hosted on controller nodes in the base cluster
+dnsServiceIP: "{{.DNSServiceIP}}"
+
+# Uncomment to provision nodes without a public IP. This assumes your VPC route table is setup to route to the internet via a NAT gateway.
+# If you did not set vpcId and routeTableId the cluster will not bootstrap.
+# mapPublicIPs: false
+
+# Version of hyperkube image to use. This is the tag for the hyperkube image repository.
+# kubernetesVersion: v1.4.5_coreos.0
+
+# Hyperkube image repository to use.
+# hyperkubeImageRepo: quay.io/coreos/hyperkube
+
+# Use Calico for network policy.
+useCalico: {{.UseCalico}}
+
+# Create MountTargets for a pre-existing Elastic File System (Amazon EFS). Enter the resource id, eg "fs-47a2c22e"
+# This is a NFS share that will be available across the entire cluster through a hostPath volume on the "/efs" mountpoint
+#
+# You can create a new EFS volume using the CLI:
+# $ aws efs create-file-system --creation-token $(uuidgen)
+#elasticFileSystemId: fs-47a2c22e
+
+# Determines the container runtime for kubernetes to use. Accepts 'docker' or 'rkt'.
+# containerRuntime: docker
+
+# Experimental features will change in backward-incompatible ways
+# experimental:
+#   nodeDrainer:
+#     enabled: true
+#   awsEnvironment:
+#     enabled: true
+#     environment:
+#       CFNSTACK: '{ "Ref" : "AWS::StackId" }'
+
+# AWS Tags for cloudformation stack resources 
+#stackTags:
+#  Name: "Kubernetes"
+#  Environment: "Production"

--- a/nodepool/config/templates/stack-template.json
+++ b/nodepool/config/templates/stack-template.json
@@ -30,9 +30,14 @@
             "Value": "{{.ClusterName}}"
           },
           {
+            "Key": "KubernetesNodePool",
+            "PropagateAtLaunch": "true",
+            "Value": "{{.NodePoolName}}"
+          },
+          {
             "Key": "Name",
             "PropagateAtLaunch": "true",
-            "Value": "{{.ClusterName}}-kube-aws-worker"
+            "Value": "{{.NodePoolName}}-kube-aws-worker"
           }
         ],
         "VPCZoneIdentifier": [

--- a/nodepool/config/templates/stack-template.json
+++ b/nodepool/config/templates/stack-template.json
@@ -1,0 +1,217 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "kube-aws Kubernetes node pool {{.ClusterName}}",
+  "Resources": {
+    "AutoScaleWorker": {
+      "Properties": {
+        "AvailabilityZones": [
+          {{range $index, $subnet := .Subnets}}
+          {{if gt $index 0}},{{end}}
+          "{{$subnet.AvailabilityZone}}"
+          {{end}}
+        ],
+        "DesiredCapacity": "{{.WorkerCount}}",
+        "HealthCheckGracePeriod": 600,
+        "HealthCheckType": "EC2",
+        "LaunchConfigurationName": {
+          "Ref": "LaunchConfigurationWorker"
+        },
+        "MaxSize": "{{.MaxWorkerCount}}",
+        "MinSize": "{{.MinWorkerCount}}",
+        "Tags": [
+          {
+            "Key": "KubernetesCluster",
+            "PropagateAtLaunch": "true",
+            "Value": "{{.ClusterName}}"
+          },
+          {
+            "Key": "Name",
+            "PropagateAtLaunch": "true",
+            "Value": "{{.ClusterName}}-kube-aws-worker"
+          }
+        ],
+        "VPCZoneIdentifier": [
+          {{range $index, $subnet := .Subnets}}
+          {{with $subnetLogicalName := printf "Subnet%d" $index}}
+          {{if gt $index 0}},{{end}}
+          {
+            "Ref": "{{$subnetLogicalName}}"
+          }
+          {{end}}
+          {{end}}
+        ]
+      },
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "UpdatePolicy" : {
+        "AutoScalingRollingUpdate" : {
+          "MinInstancesInService" :
+          {{if .WorkerSpotPrice}}
+          "0"
+          {{else}}
+          "{{.WorkerCount}}"
+          {{end}},
+          "MaxBatchSize" : "1",
+          "PauseTime" : "PT2M"
+        }
+      }
+    },
+    "IAMInstanceProfileWorker": {
+      "Properties": {
+        "Path": "/",
+        "Roles": [
+          {
+            "Ref": "IAMRoleWorker"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::InstanceProfile"
+    },
+    "IAMRoleWorker": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "ec2.amazonaws.com{{if .IsChinaRegion}}.cn{{end}}"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "ec2:Describe*",
+                  "Effect": "Allow",
+                  "Resource": "*"
+                },
+                {
+                  "Action": "ec2:AttachVolume",
+                  "Effect": "Allow",
+                  "Resource": "*"
+                },
+                {
+                  "Action": "ec2:DetachVolume",
+                  "Effect": "Allow",
+                  "Resource": "*"
+                },
+                {
+                  "Action" : "kms:Decrypt",
+                  "Effect" : "Allow",
+                  "Resource" : "{{.KMSKeyARN}}"
+                },
+                {
+                  "Action": [
+                    "ecr:GetAuthorizationToken",
+                    "ecr:BatchCheckLayerAvailability",
+                    "ecr:GetDownloadUrlForLayer",
+                    "ecr:GetRepositoryPolicy",
+                    "ecr:DescribeRepositories",
+                    "ecr:ListImages",
+                    "ecr:BatchGetImage"
+                  ],
+                  "Resource": "*",
+                  "Effect": "Allow"
+                }
+              ],
+              "Version": "2012-10-17"
+            },
+            "PolicyName": "root"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+
+    "LaunchConfigurationWorker": {
+      "Properties": {
+        "BlockDeviceMappings": [
+          {
+            "DeviceName": "/dev/xvda",
+            "Ebs": {
+              "VolumeSize": "{{.WorkerRootVolumeSize}}",
+              {{if gt .WorkerRootVolumeIOPS 0}}
+              "Iops": "{{.WorkerRootVolumeIOPS}}",
+              {{end}}
+              "VolumeType": "{{.WorkerRootVolumeType}}"
+            }
+          }
+        ],
+        "IamInstanceProfile": {
+          "Ref": "IAMInstanceProfileWorker"
+        },
+        "ImageId": "{{.AMI}}",
+        "InstanceType": "{{.WorkerInstanceType}}",
+        "KeyName": "{{.KeyName}}",
+        "SecurityGroups": [
+          {{.WorkerSecurityGroupRef}}
+        ],
+        {{if .WorkerSpotPrice}}
+        "SpotPrice": {{.WorkerSpotPrice}},
+        {{end}}
+        "UserData": "{{ .UserDataWorker }}"
+      },
+      "Type": "AWS::AutoScaling::LaunchConfiguration"
+    }
+    {{range $index, $subnet := .Subnets}}
+    {{with $subnetLogicalName := printf "Subnet%d" $index}}
+    ,
+    "{{$subnetLogicalName}}": {
+      "Properties": {
+        "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
+        "CidrBlock": "{{$subnet.InstanceCIDR}}",
+        "MapPublicIpOnLaunch": {{$.MapPublicIPs}},
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "{{$.ClusterName}}-{{$subnetLogicalName}}"
+          },
+          {
+            "Key": "KubernetesCluster",
+            "Value": "{{$.ClusterName}}"
+          }
+        ],
+        "VpcId": {{$.VPCRef}}
+      },
+      "Type": "AWS::EC2::Subnet"
+    }
+    {{if $.ElasticFileSystemID}}
+    ,
+    "{{$subnetLogicalName}}MountTarget": {
+      "Properties" : {
+        "FileSystemId": "{{$.ElasticFileSystemID}}",
+        "SubnetId": { "Ref": "{{$subnetLogicalName}}" },
+        "SecurityGroups": [ { "Ref": "SecurityGroupMountTarget" } ]
+      },
+      "Type" : "AWS::EFS::MountTarget"
+    }
+    {{end}}
+    {{end}}
+    {{end}}
+
+    {{range $index, $subnet := .Subnets}}
+    {{with $subnetLogicalName := printf "Subnet%d" $index}}
+    ,
+    "{{$subnetLogicalName}}RouteTableAssociation": {
+      "Properties": {
+        "RouteTableId": {{$.RouteTableRef}},
+        "SubnetId": {
+          "Ref": "{{$subnetLogicalName}}"
+        }
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation"
+    }
+    {{end}}
+    {{end}}
+
+  }
+}

--- a/nodepool/config/templates/stack-template.json
+++ b/nodepool/config/templates/stack-template.json
@@ -1,7 +1,12 @@
-{
-  "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "kube-aws Kubernetes node pool {{.ClusterName}}",
-  "Resources": {
+{{define "WorkerSecurityGroups"}}
+[
+  {{range $sgIndex, $sgRef := $.WorkerSecurityGroupRefs}}
+  {{if gt $sgIndex 0}},{{end}}
+  {{$sgRef}}
+  {{end}}
+]
+{{end}}
+{{define "AutoScaling"}}
     "AutoScaleWorker": {
       "Properties": {
         "AvailabilityZones": [
@@ -55,6 +60,41 @@
         }
       }
     },
+
+    "LaunchConfigurationWorker": {
+      "Properties": {
+        "BlockDeviceMappings": [
+          {
+            "DeviceName": "/dev/xvda",
+            "Ebs": {
+              "VolumeSize": "{{.WorkerRootVolumeSize}}",
+              {{if gt .WorkerRootVolumeIOPS 0}}
+              "Iops": "{{.WorkerRootVolumeIOPS}}",
+              {{end}}
+              "VolumeType": "{{.WorkerRootVolumeType}}"
+            }
+          }
+        ],
+        "IamInstanceProfile": {
+          "Ref": "IAMInstanceProfileWorker"
+        },
+        "ImageId": "{{.AMI}}",
+        "InstanceType": "{{.WorkerInstanceType}}",
+        "KeyName": "{{.KeyName}}",
+        "SecurityGroups": {{template "WorkerSecurityGroups" $}},
+        {{if .WorkerSpotPrice}}
+        "SpotPrice": {{.WorkerSpotPrice}},
+        {{end}}
+        "UserData": "{{ .UserDataWorker }}"
+      },
+      "Type": "AWS::AutoScaling::LaunchConfiguration"
+    },
+{{end}}
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "kube-aws Kubernetes node pool {{.NodePoolName}}",
+  "Resources": {
+    {{template "AutoScaling" .}}
     "IAMInstanceProfileWorker": {
       "Properties": {
         "Path": "/",
@@ -130,37 +170,6 @@
         ]
       },
       "Type": "AWS::IAM::Role"
-    },
-
-    "LaunchConfigurationWorker": {
-      "Properties": {
-        "BlockDeviceMappings": [
-          {
-            "DeviceName": "/dev/xvda",
-            "Ebs": {
-              "VolumeSize": "{{.WorkerRootVolumeSize}}",
-              {{if gt .WorkerRootVolumeIOPS 0}}
-              "Iops": "{{.WorkerRootVolumeIOPS}}",
-              {{end}}
-              "VolumeType": "{{.WorkerRootVolumeType}}"
-            }
-          }
-        ],
-        "IamInstanceProfile": {
-          "Ref": "IAMInstanceProfileWorker"
-        },
-        "ImageId": "{{.AMI}}",
-        "InstanceType": "{{.WorkerInstanceType}}",
-        "KeyName": "{{.KeyName}}",
-        "SecurityGroups": [
-          {{.WorkerSecurityGroupRef}}
-        ],
-        {{if .WorkerSpotPrice}}
-        "SpotPrice": {{.WorkerSpotPrice}},
-        {{end}}
-        "UserData": "{{ .UserDataWorker }}"
-      },
-      "Type": "AWS::AutoScaling::LaunchConfiguration"
     }
     {{range $index, $subnet := .Subnets}}
     {{with $subnetLogicalName := printf "Subnet%d" $index}}


### PR DESCRIPTION
The initial implementation for #46.

Several pull requests were already merged to make this easier, smaller:

#97, #98, #99, #100, #101, #102, #103, #104, #105

Our E2E test suite now include `kube-aws node-pools` and Kubernetes conformance tests are passing.

---

Notes on the initial implementation of Node Pools.

## Usage

`kube-aws node-pools (init|render|up) --node-pool-name mypool` commands assume you run `kube-aws` from the same working directory where you've run `kube-aws (init|render|up)` hence the `cluster.yaml` and other assets exist.

```
$ mkdir mycluster
$ cd mycluster
$ kube-aws init --cluster-name mycluster ...
$ kube-aws render credentials
$ kube-aws render stack
$ kube-aws up ...
$ kube-aws node-pools init --node-pool-name mypool ...
$ kube-aws node-pools render stack --node-pool-name mypool ...
$ kube-aws node-pools up --node-pool-name mypool ...
```

## Design

* A node pool is a group of worker nodes.
* Worker nodes in the same node pool have the same instance type, volume type, volume size.
* A cluster is not a node pool.
* A cluster may be called a "main" cluster if needed to be very explicit.
* A cluster has been able to contain 1 or more etcd nodes, 1 or more controller nodes, 1 or more worker nodes.
* A cluster can contain zero or more node pools from now on.
* Vanilla `kube-aws` sub-commands work for a cluster, while `kube-aws node-pools` sub-commands work for a node pool.

## Sources of inspiration

* GKE/the `gcloud` command
  * Both `kube-aws` and `gcloud` uses notion of `<root cmd> node-pools` for subcommands, instead of `nodepool`, `nodepools`, `node-pool`.

## Specifications
- 1 cloudformation stack for each main cluster, 1 stack for each node pool.
- We now have separate `cluster.yaml`, `stack-template.json`, `user-data/cloud-init-worker` for each node pool.
- I tried to make `cluster.yaml` for node pools look familiar to us. You'll see the `worker*` config keys e.g. `workerInstanceType`, `workerRootVolumeSize`, `workerRootVolumeType`, etc. in both main cluster's and node pools' `cluster.yaml`, instead of seeing `instanceType`, `rootVolumeSize`, `rootVolumeType`, etc. without `worker` prefix only in node pools' `cluster.yaml`.
  -  The end result is a bit verbose but consistent, familiar looking `cluster.yaml`s for clusters themselves and their addition - node pools.
- Worker nodes in a main cluster and node pools are assigned to the same security group(the one with the logical name `SecurityGroupWorker` in cloudformation stacks) so that we can allow etcd nodes in the main cluster can communicate with newly added worker nodes from node pools, controller nodes in the main cluster can communicate with the worker nodes.
- A cloudformation stack for a node pool works in two ways
  - If you've omitted `vpcId` and/or `routeTableId` in a node pool's `cluster.yaml`, `kube-aws node-pools up` will generate a cfn stack template containing [`Fn::ImportValue`s](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-importvalue.html) to import required values from the main cluster's cfn stack.
  - If you've specified `vpcId` and/or `routeTableId` in it, `kube-aws nodepool up` doesn't import values from the main stack. It just embed values as is, instead of embedding `Fn::ImportValue`s. This is achieved via computing `RouteTableRef` and `VPCRef` in go code and referencing it from `stack-template.json` for node pools. (refs to [go code](https://github.com/mumoshu/kube-aws/blob/node-pools/nodepool/config/config.go#L150-L160) and [stack-template.json](https://github.com/mumoshu/kube-aws/blob/node-pools/nodepool/config/templates/stack-template.json#L204-L212))

## Implications
- It won't allow us to create kube-aws node pools connected to non-kube-aws main clusters in a clean way. Though allowing it would be out of scope for this issue, I just wanted to note.

## File tree

The whole file tree for a main cluster named `mycluster` with a node pool named `mypool` would look like:

```
$ tree mycluster/
mycluster/
├── cluster.yaml
├── credentials
│   ├── admin-key.pem
│   ├── admin.pem
│   ├── apiserver-key.pem
│   ├── apiserver.pem
│   ├── ca-key.pem
│   ├── ca.pem
│   ├── etcd-client-key.pem
│   ├── etcd-client.pem
│   ├── etcd-key.pem
│   ├── etcd.pem
│   ├── worker-key.pem
│   └── worker.pem
├── kubeconfig
├── node-pools (NEW!)
│   └── mypool
│       ├── cluster.yaml
│       ├── stack-template.json
│       └── userdata
│           └── cloud-config-worker
├── stack-template.json
└── userdata
    ├── cloud-config-controller
    ├── cloud-config-etcd
    └── cloud-config-worker

5 directories, 21 files
```

# Notes for POC users/testers

While in the POC building phase, `nodePoolName` in a node pool's `cluster.yaml` had been `clusterName`, `clusterName` had been `baseClusterName` respectively.

See notes on the POC: https://github.com/coreos/kube-aws/issues/46#issuecomment-261115517

They're now named `nodePoolName` and `clusterName` respectively to be more explicit about the clusterName is clusterName - the same variable in the main cluster's `cluster.yaml`, and the design which differentiates a cluster and a node pool. A cluster is not a node pool, and vice versa.
