### PR TITLE
Ensure ephemeral storage is prepared before docker starts

### DIFF
--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -37,6 +37,13 @@ coreos:
 {{end}}
     - name: docker.service
       drop-ins:
+{{if .Experimental.EphemeralImageStorage.Enabled}}
+        - name: 10-docker-mount.conf
+          content: |
+            [Unit]
+            After=var-lib-docker.mount
+            Wants=var-lib-docker.mount
+{{end}}
         - name: 40-flannel.conf
           content: |
             [Unit]

--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -12,6 +12,13 @@ coreos:
   units:
     - name: docker.service
       drop-ins:
+{{if .Experimental.EphemeralImageStorage.Enabled}}
+        - name: 10-docker-mount.conf
+          content: |
+            [Unit]
+            After=var-lib-docker.mount
+            Wants=var-lib-docker.mount
+{{end}}
         - name: 40-flannel.conf
           content: |
             [Unit]


### PR DESCRIPTION
This was left out in PR https://github.com/coreos/kube-aws/pull/95
I am using `Wants=` instead of `Requires=` so that it works even for instance types that do not have ephemeral storage.