### PR TITLE
fix: `kube-aws update` success message formatting issue

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -61,6 +61,7 @@ func runCmdUpdate(cmd *cobra.Command, args []string) error {
 
 	successMsg :=
 		`Success! Your AWS resources are being updated:
+%s
 `
 	fmt.Printf(successMsg, info.String())
 


### PR DESCRIPTION
Output from `kube-aws update` contained an errant `%!(EXTRA`
due to a missing formatting placeholder.

Fixes #116