### PR TITLE
Fix console msg when initializing node pools

### DIFF
--- a/cmd/nodepool/init.go
+++ b/cmd/nodepool/init.go
@@ -132,6 +132,6 @@ Next steps:
 2. Use the "kube-aws nodepool render" command to render the stack template.
 `
 
-	fmt.Printf(successMsg, nodePoolClusterConfigFilePath, nodePoolClusterConfigFilePath)
+	fmt.Printf(successMsg, nodePoolClusterConfigFilePath(), nodePoolClusterConfigFilePath())
 	return nil
 }

--- a/cmd/nodepool/root.go
+++ b/cmd/nodepool/root.go
@@ -35,7 +35,7 @@ func nodePoolExportedStackTemplatePath() string {
 func stackTemplateOptions() config.StackTemplateOptions {
 	return config.StackTemplateOptions{
 		TLSAssetsDir:          "credentials",
-		WorkerTmplFile:        fmt.Sprintf("%s/userdata/cloud-config-worker", nodePoolConfigDirPath(), nodePoolOpts.PoolName),
+		WorkerTmplFile:        fmt.Sprintf("%s/userdata/cloud-config-worker", nodePoolConfigDirPath()),
 		StackTemplateTmplFile: fmt.Sprintf("%s/stack-template.json", nodePoolConfigDirPath()),
 	}
 }


### PR DESCRIPTION
When initializing a node pools I got a "wrong" message, fixed calling the function.

```
$ bin/kube-aws node-pools init --node-pool-name mypool --availability-zone=eu-west-1b
Success! Created %!s(func() string=0xacd50)

Next steps:
1. (Optional) Edit %!s(func() string=0xacd50) to parameterize the cluster.
2. Use the "kube-aws nodepool render" command to render the stack template.
```

After the fix
```
$ bin/kube-aws node-pools init --node-pool-name mypool --availability-zone=eu-west-1b
Success! Created node-pools/mypool/cluster.yaml

Next steps:
1. (Optional) Edit node-pools/mypool/cluster.yaml to parameterize the cluster.
2. Use the "kube-aws nodepool render" command to render the stack template.

```