### PR TITLE
Persist encrypted credentials under the `credentials/` directory

### DIFF
--- a/e2e/run
+++ b/e2e/run
@@ -133,9 +133,12 @@ destroy() {
 
 update() {
   cd ${WORK_DIR}
+
+  ${KUBE_AWS_CMD} update --s3-uri ${KUBE_AWS_S3_URI} || true
+
   SED_CMD="sed -e 's/workerCount: 2/workerCount: 3/' -e 's/controllerCount: 2/controllerCount: 3/'"
   diff --unified cluster.yaml <(cat cluster.yaml | sh -c "${SED_CMD}") || true
-  sh -c '${SED_CMD} -i bak cluster.yaml' || true
+  sh -c "${SED_CMD} -i bak cluster.yaml"
   ${KUBE_AWS_CMD} update --s3-uri ${KUBE_AWS_S3_URI}
   aws cloudformation wait stack-update-complete --stack-name ${KUBE_AWS_CLUSTER_NAME}
 

--- a/test/helper/helper.go
+++ b/test/helper/helper.go
@@ -19,7 +19,10 @@ func WithDummyCredentials(fn func(dir string)) {
 		panic(err)
 	}
 
-	defer os.Remove(dir)
+	// Remove all the contents in the dir including *.pem.enc created by ReadOrUpdateCompactTLSAssets()
+	// Otherwise we end up with a lot of garbage directories we failed to remove as they aren't empty in
+	// config/temp, nodepool/config/temp, test/integration/temp
+	defer os.RemoveAll(dir)
 
 	for _, pairName := range []string{"ca", "apiserver", "worker", "admin", "etcd", "etcd-client"} {
 		certFile := fmt.Sprintf("%s/%s.pem", dir, pairName)


### PR DESCRIPTION
so that we can prevent unnecessary node replacement when `kube-aws update` run.

Encrypted credentials are named with the suffix `.enc` hence `*-key.pem.enc` for keys, `*.pem.env` for certs, and `ca.pem.enc` for ca cert.

If you've removed one of more `*.enc` files, `kube-aws (validate|up)` automatically re-generate not only removed ones but "all" the `*.enc` files by encrypting pem files.

The whole file tree representing kube-aws' state after `kube-aws init` now look like:

```
$ tree e2e/assets/
e2e/assets/
└── kubeawstest2
    ├── cluster.yaml
    ├── credentials
    │   ├── admin-key.pem
    │   ├── admin-key.pem.enc
    │   ├── admin.pem
    │   ├── admin.pem.enc
    │   ├── apiserver-key.pem
    │   ├── apiserver-key.pem.enc
    │   ├── apiserver.pem
    │   ├── apiserver.pem.enc
    │   ├── ca-key.pem
    │   ├── ca-key.pem.enc
    │   ├── ca.pem
    │   ├── ca.pem.enc
    │   ├── etcd-client-key.pem
    │   ├── etcd-client-key.pem.enc
    │   ├── etcd-client.pem
    │   ├── etcd-client.pem.enc
    │   ├── etcd-key.pem
    │   ├── etcd-key.pem.enc
    │   ├── etcd.pem
    │   ├── etcd.pem.enc
    │   ├── worker-key.pem
    │   ├── worker-key.pem.enc
    │   ├── worker.pem
    │   └── worker.pem.enc
    ├── kubeconfig
    ├── stack-template.json
    └── userdata
        ├── cloud-config-controller
        ├── cloud-config-etcd
        └── cloud-config-worker

3 directories, 30 files
```

fixes #107

cc @pieterlange 