### PR TITLE
Allow to attach user defined security groups to worker nodes

### DIFF
--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -89,6 +89,11 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # Price (Dollars) to bid for spot instances. Omit for on-demand instances.
 # workerSpotPrice: "0.05"
 
+# Existing "glue" security groups attached to worker nodes which are typically used to allow access from worker nodes to services running on an existing infrastructure
+# workerSecurityGroupIds:
+#   - sg-1234abcd
+#   - sg-5678efab
+
 ## Etcd Cluster config
 ## WARNING: Any changes to etcd parameters after the cluster is first created will not be applied
 ## during a cluster upgrade, due to concerns over data loss.

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -493,10 +493,8 @@
         "InstanceType": "{{.WorkerInstanceType}}",
         "KeyName": "{{.KeyName}}",
         "SecurityGroups": [
-          {{if .Experimental.LoadBalancer.Enabled}}
-          {{range $elbsg := .Experimental.LoadBalancer.SecurityGroupIds}}
-            "{{$elbsg}}",
-          {{end}}
+          {{range $sgRef := .WorkerSecurityGroupRefs}}
+            {{$sgRef}},
           {{end}}
           {
             "Ref": "SecurityGroupWorker"

--- a/nodepool/config/config.go
+++ b/nodepool/config/config.go
@@ -181,6 +181,13 @@ func (c ProvidedConfig) Config() (*ComputedConfig, error) {
 	return &config, nil
 }
 
+func (c ProvidedConfig) WorkerDeploymentSettings() cfg.WorkerDeploymentSettings {
+	return cfg.WorkerDeploymentSettings{
+		WorkerSettings:     c.WorkerSettings,
+		DeploymentSettings: c.DeploymentSettings,
+	}
+}
+
 func (c ProvidedConfig) valid() error {
 	if _, err := c.DeploymentSettings.Valid(); err != nil {
 		return err
@@ -195,6 +202,10 @@ func (c ProvidedConfig) valid() error {
 	}
 
 	if err := c.Worker.Valid(); err != nil {
+		return err
+	}
+
+	if err := c.WorkerDeploymentSettings().Valid(); err != nil {
 		return err
 	}
 
@@ -217,10 +228,7 @@ func (c ComputedConfig) RouteTableRef() string {
 }
 
 func (c ComputedConfig) WorkerSecurityGroupRefs() []string {
-	refs := cfg.WorkerDeploymentSettings{
-		WorkerSettings:     c.WorkerSettings,
-		DeploymentSettings: c.DeploymentSettings,
-	}.WorkerSecurityGroupRefs()
+	refs := c.WorkerDeploymentSettings().WorkerSecurityGroupRefs()
 
 	refs = append(
 		refs,

--- a/nodepool/config/config.go
+++ b/nodepool/config/config.go
@@ -217,9 +217,17 @@ func (c ComputedConfig) RouteTableRef() string {
 }
 
 func (c ComputedConfig) WorkerSecurityGroupRefs() []string {
-	return []string{
+	refs := cfg.WorkerDeploymentSettings{
+		WorkerSettings:     c.WorkerSettings,
+		DeploymentSettings: c.DeploymentSettings,
+	}.WorkerSecurityGroupRefs()
+
+	refs = append(
+		refs,
 		// The security group assigned to worker nodes to allow communication to etcd nodes and controller nodes
 		// which is created and maintained in the main cluster and then imported to node pools.
 		fmt.Sprintf(`{"Fn::ImportValue" : {"Fn::Sub" : "%s-WorkerSecurityGroup"}}`, c.ClusterName),
-	}
+	)
+
+	return refs
 }

--- a/nodepool/config/templates/cluster.yaml
+++ b/nodepool/config/templates/cluster.yaml
@@ -64,6 +64,11 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # Price (Dollars) to bid for spot instances. Omit for on-demand instances.
 # workerSpotPrice: "0.05"
 
+# Existing "glue" security groups attached to worker nodes which are typically used to allow access from worker nodes to services running on an existing infrastructure
+# workerSecurityGroupIds:
+#   - sg-1234abcd
+#   - sg-5678efab
+
 # Experimental worker config which can be changed in backward-incompatible ways
 #worker:
 #  # Spot fleet config for worker nodes

--- a/test/integration/aws_test.go
+++ b/test/integration/aws_test.go
@@ -156,6 +156,20 @@ worker:
       rootVolumeIOPS: 500
 `,
 		},
+		{
+			context: "WithWorkerAndLBSecurityGroupIds",
+			configYaml: minimalValidConfigYaml + `
+workerSecurityGroupIds:
+  - sg-12345678
+  - sg-abcdefab
+experimental:
+  loadBalancer:
+    enabled: true
+    securityGroupIds:
+      - sg-23456789
+      - sg-bcdefabc
+`,
+		},
 	}
 
 	for _, validCase := range validCases {


### PR DESCRIPTION
We can now specify which existing security groups to be attached to worker nodes created by kube-aws.

`workerSecurityGroupIds` configuration key was added to allow that.

In cluster.yaml, it would look like:

```
workerSecurityGroupIds:
  - sg-87654321
  - sg-98765432
```

Worker nodes in either main clusters and node pools are supported.

fix #43 

TODOs:

- [x] Add unit test cases
- [x] Add integration test cases
