### PR TITLE
Add several experimental features already introduced to main clusters to node pools

### DIFF
--- a/nodepool/config/templates/cluster.yaml
+++ b/nodepool/config/templates/cluster.yaml
@@ -177,10 +177,18 @@ useCalico: {{.UseCalico}}
 # experimental:
 #   nodeDrainer:
 #     enabled: true
+#   nodeLabel:
+#     enabled: true
 #   awsEnvironment:
 #     enabled: true
 #     environment:
 #       CFNSTACK: '{ "Ref" : "AWS::StackId" }'
+#   waitSignal:
+#     enabled: true
+#   loadBalancer:
+#     enabled: true
+#     names: [ "manuallymanagedelb" ]
+#     securityGroupIds: [ "sg-87654321" ]
 
 # AWS Tags for cloudformation stack resources 
 #stackTags:

--- a/nodepool/config/templates/stack-template.json
+++ b/nodepool/config/templates/stack-template.json
@@ -90,6 +90,14 @@
             "Value": "{{.NodePoolName}}-kube-aws-worker"
           }
         ],
+        {{if .Experimental.LoadBalancer.Enabled}}
+        "LoadBalancerNames" : [
+        {{range $index, $elb := .Experimental.LoadBalancer.Names}}
+        {{if $index}},{{end}}
+          "{{$elb}}"
+        {{end}}
+        ],
+        {{end}}
         "VPCZoneIdentifier": [
           {{range $index, $subnet := .Subnets}}
           {{with $subnetLogicalName := printf "Subnet%d" $index}}
@@ -102,6 +110,14 @@
         ]
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
+      {{if .Experimental.WaitSignal.Enabled}}
+      "CreationPolicy" : {
+        "ResourceSignal" : {
+          "Count" : "{{.WorkerCount}}",
+          "Timeout" : "{{.WorkerCreateTimeout}}"
+        }
+      },
+      {{end}}
       "UpdatePolicy" : {
         "AutoScalingRollingUpdate" : {
           "MinInstancesInService" :
@@ -110,8 +126,14 @@
           {{else}}
           "{{.WorkerCount}}"
           {{end}},
+          {{if .Experimental.WaitSignal.Enabled}}
+          "WaitOnResourceSignals" : "true",
+          "MaxBatchSize" : "{{.Experimental.WaitSignal.MaxBatchSize}}",
+          "PauseTime": "{{.WorkerCreateTimeout}}"
+          {{else}}
           "MaxBatchSize" : "1",
-          "PauseTime" : "PT2M"
+          "PauseTime": "PT2M"
+          {{end}}
         }
       }
     },
@@ -147,6 +169,23 @@
         {{end}}
         "UserData": "{{ .UserDataWorker }}"
       },
+  {{ if .Experimental.AwsEnvironment.Enabled }}
+        "Metadata" : {
+          "AWS::CloudFormation::Init" : {
+            "config" : {
+              "commands": {
+                "write-environment": {
+                  "command": { "Fn::Join" : ["", [ "echo '",
+  {{range $variable, $function := .Experimental.AwsEnvironment.Environment}}
+  "{{$variable}}=", {{$function}} , "\n",
+  {{end}}
+  "' > /etc/aws-environment" ] ] }
+                }
+              }
+            }
+          }
+        },
+  {{end}}
       "Type": "AWS::AutoScaling::LaunchConfiguration"
     },
 {{end}}
@@ -213,6 +252,29 @@
                   "Effect" : "Allow",
                   "Resource" : "{{.KMSKeyARN}}"
                 },
+                {{if .Experimental.WaitSignal.Enabled}}
+                {
+                  "Action": "cloudformation:SignalResource",
+                  "Effect": "Allow",
+                  "Resource":
+                    { "Fn::Join": [ "", [
+                      "arn:aws:cloudformation:",
+                      { "Ref": "AWS::Region" },
+                      ":",
+                      { "Ref": "AWS::AccountId" },
+                      ":stack/",
+                      { "Ref": "AWS::StackName" },
+                      "/*" ]
+                    ] }
+                },
+                {{end}}
+                {{if .Experimental.NodeLabel.Enabled}}
+                {
+                  "Action": "autoscaling:Describe*",
+                  "Effect": "Allow",
+                  "Resource": [ "*" ]
+                },
+                {{end}}
                 {
                   "Action": [
                     "ecr:GetAuthorizationToken",

--- a/test/integration/aws_test.go
+++ b/test/integration/aws_test.go
@@ -86,6 +86,30 @@ etcdEndpoints: "10.0.0.1"
 		configYaml string
 	}{
 		{
+			context: "WithExperimentalFeatures",
+			configYaml: minimalValidConfigYaml + `
+experimental:
+  awsEnvironment:
+    enabled: true
+    environment:
+      CFNSTACK: '{ "Ref" : "AWS::StackId" }'
+  ephemeralImageStorage:
+    enabled: true
+  loadBalancer:
+    enabled: true
+    names:
+      - manuallymanagedlb
+    securityGroupIds:
+      - sg-12345678
+  nodeDrainer:
+    enabled: true
+  nodeLabel:
+    enabled: true
+  waitSignal:
+    enabled: true
+`,
+		},
+		{
 			context:    "WithMinimalValidConfig",
 			configYaml: minimalValidConfigYaml,
 		},


### PR DESCRIPTION
The following experimental features are added to node pools via this change:

* awsEnvironment
* waitSignal
* nodeLabel
* loadBalancer

ref #46 

TODOs:

- [x] Add unit test cases
- [x] Add integration test cases
