### PR TITLE
Experimental feature to taint worker nodes with user-provided `key=value:effect`

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1024,6 +1024,7 @@ func TestConfig(t *testing.T) {
 			NodeLabel: NodeLabel{
 				Enabled: false,
 			},
+			Taints: []Taint{},
 			WaitSignal: WaitSignal{
 				Enabled:      false,
 				MaxBatchSize: 1,
@@ -1072,6 +1073,10 @@ experimental:
   plugins:
     rbac:
       enabled: true
+  taints:
+    - key: reservation
+      value: spot
+      effect: NoSchedule
   waitSignal:
     enabled: true
 `,
@@ -1110,6 +1115,9 @@ experimental:
 							Rbac: Rbac{
 								Enabled: true,
 							},
+						},
+						Taints: []Taint{
+							{Key: "reservation", Value: "spot", Effect: "NoSchedule"},
 						},
 						WaitSignal: WaitSignal{
 							Enabled:      true,
@@ -1307,6 +1315,17 @@ etcdDataVolumeIOPS: 104
 		configYaml           string
 		expectedErrorMessage string
 	}{
+		{
+			context: "WithInvalidTaint",
+			configYaml: minimalValidConfigYaml + `
+experimental:
+  taints:
+    - key: foo
+      value: bar
+      effect: UnknownEffect
+`,
+			expectedErrorMessage: "Effect must be NoSchdule or PreferNoSchedule, but was UnknownEffect",
+		},
 		{
 			context: "WithVpcIdAndVPCCIDRSpecified",
 			configYaml: minimalValidConfigYaml + `

--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -71,7 +71,8 @@ coreos:
         --rkt-path=/usr/bin/rkt \
         --rkt-stage1-image=coreos.com/rkt/stage1-coreos \
         --register-node=true \
-        --allow-privileged=true \
+        {{if .Experimental.Taints}}--register-schedulable=false \
+        {{end}}--allow-privileged=true \
         --pod-manifest-path=/etc/kubernetes/manifests \
         --cluster_dns={{.DNSServiceIP}} \
         --cluster_domain=cluster.local \
@@ -228,6 +229,27 @@ coreos:
         [Install]
         WantedBy=kubelet.service
 {{ end }}
+
+{{if .Experimental.Taints }}
+    - name: kube-node-taint-and-uncordon.service
+      command: start
+      runtime: true
+      content: |
+        [Unit]
+        Description=Taint this kubernetes node with user-provided taints and then uncordon it
+        Wants=kubelet.service
+        After=kubelet.service
+        Before=cfn-signal.service
+
+        [Service]
+        Type=simple
+        StartLimitInterval=0
+        RestartSec=10
+        Restart=on-failure
+        ExecStartPre=/usr/bin/systemctl is-active kubelet.service
+        ExecStartPre=/usr/bin/bash -c "while sleep 1; do if /usr/bin/curl  --insecure -s -m 20 -f  https://127.0.0.1:10250/healthz > /dev/null ; then break ; fi;  done"
+        ExecStart=/opt/bin/taint-and-uncordon
+{{end}}
 
 {{ if .Experimental.WaitSignal.Enabled }}
     - name: cfn-signal.service
@@ -413,6 +435,42 @@ write_files:
       for encKey in $(find /etc/kubernetes/ssl/*.pem.enc);do
         base64 --decode < $encKey.b64 > ${encKey%.enc}
       done
+      echo done.
+
+  - path: /opt/bin/taint-and-uncordon
+    owner: root:root
+    permissions: 0700
+    content: |
+      #!/bin/bash -e
+
+      hostname=$(hostname)
+
+      sudo rkt run \
+        --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
+        --mount=volume=kube,target=/etc/kubernetes \
+        --uuid-file-save=/var/run/coreos/taint-and-uncordon.uuid \
+        --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
+        --net=host \
+        --trust-keys-from-https \
+        {{.HyperkubeImageRepo}}:{{.K8sVer}} --exec=/bin/bash -- \
+          -vxc \
+          'echo tainting this node; \
+           hostname="'${hostname}'"; \
+           taints=({{range $i, $taint := .Experimental.Taints}}"{{$taint.String}}" {{end}}); \
+           kubectl="/kubectl --server=https://{{.ExternalDNSName}}:443 --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml"; \
+           taint="$kubectl taint node $hostname"; \
+           for t in ${taints[@]}; do \
+             $taint "$t"; \
+           done; \
+           echo done. ;\
+           echo uncordoning this node; \
+           $kubectl uncordon $hostname;\
+           echo done.'
+
+      echo cleaning pod resources.
+
+      sudo rkt rm --uuid-file=/var/run/coreos/taint-and-uncordon.uuid
+
       echo done.
 
   - path: /etc/kubernetes/manifests/kube-proxy.yaml

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -211,6 +211,10 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #     enabled: true
 #     maxage: 30
 #     logpath: /dev/stdout
+#   taints:
+#     - key: dedicated
+#       value: search
+#       effect: NoSchedule
 #   waitSignal:
 #     enabled: true
 #   # This option has not yet been tested with rkt as container runtime

--- a/nodepool/config/config_test.go
+++ b/nodepool/config/config_test.go
@@ -97,6 +97,7 @@ etcdEndpoints: "10.0.0.1"
 			NodeLabel: cfg.NodeLabel{
 				Enabled: false,
 			},
+			Taints: []cfg.Taint{},
 			WaitSignal: cfg.WaitSignal{
 				Enabled:      false,
 				MaxBatchSize: 1,
@@ -135,6 +136,10 @@ experimental:
     enabled: true
   nodeLabel:
     enabled: true
+  taints:
+    - key: reservation
+      value: spot
+      effect: NoSchedule
   waitSignal:
     enabled: true
 `,
@@ -168,6 +173,9 @@ experimental:
 						},
 						NodeLabel: cfg.NodeLabel{
 							Enabled: true,
+						},
+						Taints: []cfg.Taint{
+							{Key: "reservation", Value: "spot", Effect: "NoSchedule"},
 						},
 						WaitSignal: cfg.WaitSignal{
 							Enabled:      true,
@@ -432,6 +440,17 @@ experimental:
 		configYaml           string
 		expectedErrorMessage string
 	}{
+		{
+			context: "WithInvalidTaint",
+			configYaml: minimalValidConfigYaml + `
+experimental:
+  taints:
+    - key: foo
+      value: bar
+      effect: UnknownEffect
+`,
+			expectedErrorMessage: "Effect must be NoSchdule or PreferNoSchedule, but was UnknownEffect",
+		},
 		{
 			context: "WithVpcIdAndVPCCIDRSpecified",
 			configYaml: minimalValidConfigYaml + `

--- a/test/integration/aws_test.go
+++ b/test/integration/aws_test.go
@@ -105,6 +105,10 @@ experimental:
     enabled: true
   nodeLabel:
     enabled: true
+  taints:
+    - key: reservation
+      value: spot
+      effect: NoSchedule
   waitSignal:
     enabled: true
 `,


### PR DESCRIPTION
ref #112

TODOs

- [x] Validate `Effect`s ([Only `NoSchedule` and `PreferNoSchedule` are currently supported in Kubernetes](https://github.com/kubernetes/kubernetes/blob/a0d4878ea99cd188c8da92b79c001125c62119f2/pkg/api/v1/types.go#L1693-L1713))
- [x] Add integration tests to `test/integration/aws_test.go`
- [x] Add unit tests to `config/config_test.go`
- [x] Add unit tests to `nodepool/config/config_test.go`
