### PR TITLE
Add `kube-aws node-pools destroy` command

### DIFF
--- a/cfnstack/provisioner.go
+++ b/cfnstack/provisioner.go
@@ -281,3 +281,12 @@ func (c *Provisioner) Validate(stackBody string, s3URI string) (string, error) {
 
 	return validationReport.String(), nil
 }
+
+func (c *Provisioner) Destroy() error {
+	cfSvc := cloudformation.New(c.session)
+	dreq := &cloudformation.DeleteStackInput{
+		StackName: aws.String(c.stackName),
+	}
+	_, err := cfSvc.DeleteStack(dreq)
+	return err
+}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -306,12 +306,7 @@ func (c *Cluster) Info() (*Info, error) {
 }
 
 func (c *Cluster) Destroy() error {
-	cfSvc := cloudformation.New(c.session)
-	dreq := &cloudformation.DeleteStackInput{
-		StackName: aws.String(c.ClusterName),
-	}
-	_, err := cfSvc.DeleteStack(dreq)
-	return err
+	return c.stackProvisioner().Destroy()
 }
 
 func (c *Cluster) validateKeyPair(ec2Svc ec2Service) error {

--- a/cmd/nodepool/destroy.go
+++ b/cmd/nodepool/destroy.go
@@ -1,0 +1,43 @@
+package nodepool
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/coreos/kube-aws/nodepool/cluster"
+	"github.com/coreos/kube-aws/nodepool/config"
+)
+
+var (
+	cmdDestroy = &cobra.Command{
+		Use:          "destroy",
+		Short:        "Destroy an existing node pool",
+		Long:         ``,
+		RunE:         runCmdDestroy,
+		SilenceUsage: true,
+	}
+	destroyOpts = struct {
+		awsDebug bool
+	}{}
+)
+
+func init() {
+	NodePoolCmd.AddCommand(cmdDestroy)
+	cmdDestroy.Flags().BoolVar(&destroyOpts.awsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
+}
+
+func runCmdDestroy(cmd *cobra.Command, args []string) error {
+	cfg, err := config.ClusterFromFile(nodePoolClusterConfigFilePath())
+	if err != nil {
+		return fmt.Errorf("Error parsing node pool config: %v", err)
+	}
+
+	c := cluster.New(cfg, destroyOpts.awsDebug)
+	if err := c.Destroy(); err != nil {
+		return fmt.Errorf("Failed destroying node pool: %v", err)
+	}
+
+	fmt.Println("CloudFormation stack is being destroyed. This will take several minutes")
+	return nil
+}

--- a/e2e/run
+++ b/e2e/run
@@ -238,6 +238,12 @@ nodepool() {
   ${KUBE_AWS_CMD} node-pools up --node-pool-name ${KUBE_AWS_POOL_NAME} --s3-uri ${KUBE_AWS_S3_URI}
 }
 
+nodepool_destroy() {
+  cd ${WORK_DIR}
+
+  ${KUBE_AWS_CMD} node-pools destroy --node-pool-name ${KUBE_AWS_POOL_NAME}
+}
+
 all() {
   build
   prepare

--- a/nodepool/cluster/cluster.go
+++ b/nodepool/cluster/cluster.go
@@ -78,3 +78,7 @@ func (c *Cluster) Info() (*Info, error) {
 	}
 	return &info, nil
 }
+
+func (c *Cluster) Destroy() error {
+	return c.stackProvisioner().Destroy()
+}


### PR DESCRIPTION
which had been missing since the first implementation of Node Pools