### PR TITLE
Fix node registration issue for spot-fleet-powered worker nodes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -281,6 +281,7 @@ type Cluster struct {
 	TLSCertDurationDays    int    `yaml:"tlsCertDurationDays,omitempty"`
 	HostedZone             string `yaml:"hostedZone,omitempty"`
 	HostedZoneID           string `yaml:"hostedZoneId,omitempty"`
+	Worker                 Worker
 	providedEncryptService EncryptService
 }
 
@@ -288,6 +289,17 @@ type Subnet struct {
 	AvailabilityZone  string `yaml:"availabilityZone,omitempty"`
 	InstanceCIDR      string `yaml:"instanceCIDR,omitempty"`
 	lastAllocatedAddr *net.IP
+}
+
+// Just a place-holder to keep compatibility of cloud-config-worker between main cluster and node pool
+// Without this, {{if .Worker.SpotFleet.Enabled}} in the cloud-config-worker template fails with an obvious error like
+// "executing "CloudConfigWorker" at <.Worker>: can't evaluate field Worker in type *config.Config"
+type Worker struct {
+	SpotFleet SpotFleet
+}
+
+type SpotFleet struct {
+	Enabled bool
 }
 
 type Experimental struct {

--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -211,6 +211,22 @@ coreos:
               --stack {{.ClusterName}}
 {{end}}
 
+{{if .Worker.SpotFleet.Enabled}}
+    - name: tag-spot-instance.service
+      enable: true
+      command: start
+      runtime: true
+      content: |
+        [Unit]
+        Description=Tag this spot instance with cluster name
+        After=network-online.target
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        ExecStart=/opt/bin/tag-spot-instance
+{{end}}
+
 {{ if $.ElasticFileSystemID }}
     - name: rpc-statd.service
       command: start
@@ -436,6 +452,36 @@ write_files:
         base64 --decode < $encKey.b64 > ${encKey%.enc}
       done
       echo done.
+
+{{if .Worker.SpotFleet.Enabled}}
+  - path: /opt/bin/tag-spot-instance
+    owner: root:root
+    permissions: 0700
+    content: |
+      #!/bin/bash -e
+
+      instance_id=$(curl http://169.254.169.254/latest/meta-data/instance-id)
+
+      sudo rkt run \
+        --volume=ssl,kind=host,source=/etc/kubernetes/ssl,readOnly=false \
+        --mount=volume=ssl,target=/etc/kubernetes/ssl \
+        --uuid-file-save=/var/run/coreos/tag-spot-instance.uuid \
+        --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
+        --net=host \
+        --trust-keys-from-https \
+        --insecure-options=ondisk \
+        {{.AWSCliImageRepo}}:{{.AWSCliTag}} --exec=/bin/bash -- \
+          -vxc \
+          'echo tagging this spot instance; \
+           instance_id="'$instance_id'"; \
+           /usr/bin/aws \
+             --region {{.Region}} ec2 create-tags \
+             --resource $instance_id \
+             --tags "Key=KubernetesCluster,Value={{.ClusterName}}"; \
+           echo done.'
+
+      sudo rkt rm --uuid-file=/var/run/coreos/tag-spot-instance.uuid
+{{end}}
 
   - path: /opt/bin/taint-and-uncordon
     owner: root:root

--- a/nodepool/config/templates/stack-template.json
+++ b/nodepool/config/templates/stack-template.json
@@ -280,6 +280,13 @@
                   "Resource": [ "*" ]
                 },
                 {{end}}
+                {{if .Worker.SpotFleet.Enabled}}
+                {
+                  "Action": "ec2:CreateTags",
+                  "Effect": "Allow",
+                  "Resource": "*"
+                },
+                {{end}}
                 {
                   "Action": [
                     "ecr:GetAuthorizationToken",


### PR DESCRIPTION
This change fixes the issue that the second and the subsequent nodes in each spot fleet couldn't be registered thus unable to run any pods.

ref https://github.com/coreos/kube-aws/issues/112#issuecomment-265643237