### PR TITLE
Add configurable instance tenancy

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -89,6 +89,7 @@ func NewDefaultCluster() *Cluster {
 			WorkerRootVolumeIOPS:   0,
 			WorkerRootVolumeSize:   30,
 			WorkerSecurityGroupIds: []string{},
+			WorkerTenancy:          "default",
 		},
 		ControllerSettings: ControllerSettings{
 			ControllerCount:          1,
@@ -97,6 +98,7 @@ func NewDefaultCluster() *Cluster {
 			ControllerRootVolumeType: "gp2",
 			ControllerRootVolumeIOPS: 0,
 			ControllerRootVolumeSize: 30,
+			ControllerTenancy:        "default",
 		},
 		EtcdSettings: EtcdSettings{
 			EtcdCount:          1,
@@ -107,6 +109,7 @@ func NewDefaultCluster() *Cluster {
 			EtcdDataVolumeSize: 30,
 			EtcdDataVolumeType: "gp2",
 			EtcdDataVolumeIOPS: 0,
+			EtcdTenancy:        "default",
 		},
 		FlannelSettings: FlannelSettings{
 			PodCIDR: "10.2.0.0/16",
@@ -240,6 +243,7 @@ type WorkerSettings struct {
 	WorkerRootVolumeSize   int      `yaml:"workerRootVolumeSize,omitempty"`
 	WorkerSpotPrice        string   `yaml:"workerSpotPrice,omitempty"`
 	WorkerSecurityGroupIds []string `yaml:"workerSecurityGroupIds,omitempty"`
+	WorkerTenancy          string   `yaml:"workerTenancy,omitempty"`
 }
 
 // Part of configuration which is specific to controller nodes
@@ -251,6 +255,7 @@ type ControllerSettings struct {
 	ControllerRootVolumeType string `yaml:"controllerRootVolumeType,omitempty"`
 	ControllerRootVolumeIOPS int    `yaml:"controllerRootVolumeIOPS,omitempty"`
 	ControllerRootVolumeSize int    `yaml:"controllerRootVolumeSize,omitempty"`
+	ControllerTenancy        string `yaml:"controllerTenancy,omitempty"`
 }
 
 // Part of configuration which is specific to etcd nodes
@@ -264,6 +269,7 @@ type EtcdSettings struct {
 	EtcdDataVolumeType      string `yaml:"etcdDataVolumeType,omitempty"`
 	EtcdDataVolumeIOPS      int    `yaml:"etcdDataVolumeIOPS,omitempty"`
 	EtcdDataVolumeEphemeral bool   `yaml:"etcdDataVolumEphemeral,omitempty"`
+	EtcdTenancy             string `yaml:"etcdTenancy,omitempty"`
 }
 
 // Part of configuration which is specific to flanneld
@@ -765,6 +771,14 @@ func (c Cluster) valid() error {
 
 	if err := c.WorkerDeploymentSettings().Valid(); err != nil {
 		return err
+	}
+
+	if c.WorkerTenancy != "default" && c.Worker.SpotFleet.Enabled() {
+		return fmt.Errorf("selected worker tenancy (%s) is incompatible with spot fleet", c.WorkerTenancy)
+	}
+
+	if c.WorkerTenancy != "default" && c.WorkerSpotPrice != "" {
+		return fmt.Errorf("selected worker tenancy (%s) is incompatible with spot instances", c.WorkerTenancy)
 	}
 
 	return nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -989,6 +989,7 @@ func TestConfig(t *testing.T) {
 			EtcdDataVolumeType:      "gp2",
 			EtcdDataVolumeIOPS:      0,
 			EtcdDataVolumeEphemeral: false,
+			EtcdTenancy:             "default",
 		}
 		actual := c.EtcdSettings
 		if !reflect.DeepEqual(expected, actual) {
@@ -1237,6 +1238,27 @@ experimental:
 			},
 		},
 		{
+			context: "WithDedicatedInstanceTenancy",
+			configYaml: minimalValidConfigYaml + `
+workerTenancy: dedicated
+controllerTenancy: dedicated
+etcdTenancy: dedicated
+`,
+			assertConfig: []ConfigTester{
+				func(c *Cluster, t *testing.T) {
+					if c.EtcdSettings.EtcdTenancy != "dedicated" {
+						t.Errorf("EtcdSettings.EtcdTenancy didn't match: expected=dedicated actual=%s", c.EtcdSettings.EtcdTenancy)
+					}
+					if c.WorkerTenancy != "dedicated" {
+						t.Errorf("WorkerTenancy didn't match: expected=dedicated actual=%s", c.WorkerTenancy)
+					}
+					if c.ControllerTenancy != "dedicated" {
+						t.Errorf("ControllerTenancy didn't match: expected=dedicated actual=%s", c.ControllerTenancy)
+					}
+				},
+			},
+		},
+		{
 			context: "WithEtcdNodesWithCustomEBSVolumes",
 			configYaml: minimalValidConfigYaml + `
 vpcId: vpc-1a2b3c4d
@@ -1262,6 +1284,7 @@ etcdDataVolumeIOPS: 104
 						EtcdDataVolumeType:      "io1",
 						EtcdDataVolumeIOPS:      104,
 						EtcdDataVolumeEphemeral: false,
+						EtcdTenancy:             "default",
 					}
 					actual := c.EtcdSettings
 					if !reflect.DeepEqual(expected, actual) {

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -100,6 +100,10 @@ worker:
 # Number of I/O operations per second (IOPS) that the worker node disk supports. Leave blank if workerRootVolumeType is not io1
 #workerRootVolumeIOPS: 0
 
+# Tenancy of the worker nodes. Options are "default" and "dedicated"
+# Documentation: http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/dedicated-instance.html
+# workerTenancy: default
+
 # Price (Dollars) to bid for spot instances. Omit for on-demand instances.
 # workerSpotPrice: "0.05"
 
@@ -142,6 +146,10 @@ worker:
 
 # Number of I/O operations per second (IOPS) that the etcd node's data volume supports. Leave blank if etcdDataVolumeType is not io1
 # etcdDataVolumeIOPS: 0
+
+# Tenancy of the etcd instances. Options are "default" and "dedicated"
+# Documentation: http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/dedicated-instance.html
+# etcdTenancy: default
 
 ## Networking config
 

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -475,6 +475,7 @@
             "Value": "{{$.ClusterName}}-kube-aws-etcd-{{$etcdIndex}}"
           }
         ],
+        "Tenancy": "{{$.EtcdTenancy}}",
         "UserData": { "Fn::FindInMap" : [ "EtcdInstanceParams", "UserData", "cloudconfig"] }
       },
       "Type": "AWS::EC2::Instance"
@@ -510,6 +511,8 @@
         ],
         {{if .WorkerSpotPrice}}
         "SpotPrice": {{.WorkerSpotPrice}},
+        {{else}}
+        "PlacementTenancy": "{{.WorkerTenancy}}",
         {{end}}
         "UserData": "{{ .UserDataWorker }}"
       },
@@ -557,6 +560,7 @@
             "Ref": "SecurityGroupController"
           }
         ],
+        "PlacementTenancy": "{{ .ControllerTenancy }}",
         "UserData": "{{ .UserDataController }}"
       },
   {{ if .Experimental.AwsEnvironment.Enabled }}

--- a/nodepool/config/templates/cluster.yaml
+++ b/nodepool/config/templates/cluster.yaml
@@ -69,6 +69,10 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #   - sg-1234abcd
 #   - sg-5678efab
 
+# Tenancy of the worker nodes. Options are "default" and "dedicated"
+# Documentation: http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/dedicated-instance.html
+# workerTenancy: default
+
 # Experimental worker config which can be changed in backward-incompatible ways
 # worker:
 #   # Auto Scaling Group definition for workers. If only `workerCount` is specified, min and max will be the set to that value and `rollingUpdateMinInstancesInService` will be one less.
@@ -197,7 +201,7 @@ useCalico: {{.UseCalico}}
 #   waitSignal:
 #     enabled: true
 
-# AWS Tags for cloudformation stack resources 
+# AWS Tags for cloudformation stack resources
 #stackTags:
 #  Name: "Kubernetes"
 #  Environment: "Production"

--- a/nodepool/config/templates/stack-template.json
+++ b/nodepool/config/templates/stack-template.json
@@ -170,6 +170,8 @@
         ],
         {{if .WorkerSpotPrice}}
         "SpotPrice": {{.WorkerSpotPrice}},
+        {{else}}
+        "PlacementTenancy": "{{.WorkerTenancy}}",
         {{end}}
         "UserData": "{{ .UserDataWorker }}"
       },


### PR DESCRIPTION
Return of [my PR on the coreos-kubernetes repo](https://github.com/coreos/coreos-kubernetes/pull/252), this time with node-pool support added.

Let me know if you'd like tests or anything. The only thing slightly tricky about dedicated tenancy is that it's mutually exclusive with spot instances, I could potentially add a check for that.