### PR TITLE
cluster-autoscaler support

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -148,7 +148,7 @@ func (c *Cluster) stackProvisioner() *cfnstack.Provisioner {
   ]
 }
 `
-	return cfnstack.NewProvisioner(c.ClusterName, c.StackTags, stackPolicyBody, c.session)
+	return cfnstack.NewProvisioner(c.ClusterName, c.WorkerDeploymentSettings().StackTags(), stackPolicyBody, c.session)
 }
 
 func (c *Cluster) Create(stackBody string, s3URI string) error {

--- a/config/config.go
+++ b/config/config.go
@@ -789,6 +789,12 @@ func (c Cluster) valid() error {
 		return fmt.Errorf("selected worker tenancy (%s) is incompatible with spot instances", c.WorkerTenancy)
 	}
 
+	if c.Worker.ClusterAutoscaler.Enabled() {
+		return fmt.Errorf("cluster-autoscaler support can't be enabled for a main cluster because allowing so" +
+			"results in unreliability while scaling nodes out. " +
+			"Use experimental node pools instead to deploy worker nodes with cluster-autoscaler support.")
+	}
+
 	return nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1345,6 +1345,16 @@ etcdDataVolumeIOPS: 104
 		expectedErrorMessage string
 	}{
 		{
+			context: "WithClusterAutoscalerEnabledForWorkers",
+			configYaml: minimalValidConfigYaml + `
+worker:
+  clusterAutoscaler:
+    minSize: 1
+    maxSize: 2
+`,
+			expectedErrorMessage: "cluster-autoscaler support can't be enabled for a main cluster",
+		},
+		{
 			context: "WithInvalidTaint",
 			configYaml: minimalValidConfigYaml + `
 experimental:

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -84,13 +84,6 @@ controller:
 #     minSize: 1
 #     maxSize: 3
 #     rollingUpdateMinInstancesInService: 2
-#   # Tag the cloudformation stack with the key `kube-aws:cluster-autoscaler:scale-specs` with the value containing
-#   # source of truth for cluster-autoscaler to update their autoscaling target and its min/max size.
-#   # Currently, enabling this configuration doesn't automatically deploy cluster-autoscaler itself.
-#   # Please read [the original issue](https://github.com/coreos/kube-aws/issues/148) carefully for more information.
-#   clusterAutoscaler:
-#     minSize: 1
-#     maxSize: 3
 
 # Maximum time to wait for worker creation
 #workerCreateTimeout: PT15M

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -78,12 +78,19 @@ controller:
 # Number of worker nodes to create, for more control use `worker.autoScalingGroup` and do not use this setting
 #workerCount: 1
 
-worker:
-  # Auto Scaling Group definition for workers. If only `workerCount` is specified, min and max will be the set to that value and `rollingUpdateMinInstancesInService` will be one less.
-  # autoScalingGroup:
-  #   minSize: 1
-  #   maxSize: 3
-  #   rollingUpdateMinInstancesInService: 2
+# worker:
+#   # Auto Scaling Group definition for workers. If only `workerCount` is specified, min and max will be the set to that value and `rollingUpdateMinInstancesInService` will be one less.
+#   autoScalingGroup:
+#     minSize: 1
+#     maxSize: 3
+#     rollingUpdateMinInstancesInService: 2
+#   # Tag the cloudformation stack with the key `kube-aws:cluster-autoscaler:scale-specs` with the value containing
+#   # source of truth for cluster-autoscaler to update their autoscaling target and its min/max size.
+#   # Currently, enabling this configuration doesn't automatically deploy cluster-autoscaler itself.
+#   # Please read [the original issue](https://github.com/coreos/kube-aws/issues/148) carefully for more information.
+#   clusterAutoscaler:
+#     minSize: 1
+#     maxSize: 3
 
 # Maximum time to wait for worker creation
 #workerCreateTimeout: PT15M

--- a/e2e/run
+++ b/e2e/run
@@ -91,6 +91,24 @@ configure() {
 }
 
 customize_worker() {
+  echo Writing to $(pwd)/cluster.yaml
+
+  #
+  # Optionally enable experimental worker features
+  #
+
+  echo -e "worker:" >> cluster.yaml
+  if [ "${KUBE_AWS_SPOT_FLEET_ENABLED}" != "" ]; then
+    echo -e "  spotFleet:\n    targetCapacity: 3\n" >> cluster.yaml
+  fi
+  if [ "${KUBE_AWS_CLUSTER_AUTOSCALER_ENABLED}" != "" ]; then
+    echo -e "  clusterAutoscaler:\n    minSize: 1\n    maxSize: 2" >> cluster.yaml
+  fi
+
+  #
+  # Optionally enable experimental other features
+  #
+
   echo -e 'experimental:\n  nodeDrainer:\n    enabled: true' >> cluster.yaml
   if [ "${KUBE_AWS_WAIT_SIGNAL_ENABLED}" != "" ]; then
     echo -e '  waitSignal:\n    enabled: true' >> cluster.yaml
@@ -234,11 +252,6 @@ nodepool_init() {
       --kms-key-arn ${KUBE_AWS_KMS_KEY_ARN}
 
   cd ${NODE_POOL_ASSETS_DIR}
-
-  if [ "${KUBE_AWS_SPOT_FLEET_ENABLED}" != "" ]; then
-    echo Writing ${NODE_POOL_ASSETS_DIR}/cluster.yaml
-    echo -e "worker:\n  spotFleet:\n    targetCapacity: 3\n" >> ${NODE_POOL_ASSETS_DIR}/cluster.yaml
-  fi
 
   echo -e "instanceCIDR: 10.0.${KUBE_AWS_NODE_POOL_INDEX}.0/24" >> ${NODE_POOL_ASSETS_DIR}/cluster.yaml
 

--- a/model/worker.go
+++ b/model/worker.go
@@ -3,8 +3,18 @@ package model
 import "fmt"
 
 type Worker struct {
-	AutoScalingGroup `yaml:"autoScalingGroup,omitempty"`
-	SpotFleet        `yaml:"spotFleet,omitempty"`
+	AutoScalingGroup  `yaml:"autoScalingGroup,omitempty"`
+	ClusterAutoscaler ClusterAutoscaler `yaml:"clusterAutoscaler"`
+	SpotFleet         `yaml:"spotFleet,omitempty"`
+}
+
+type ClusterAutoscaler struct {
+	MinSize int `yaml:"minSize"`
+	MaxSize int `yaml:"maxSize"`
+}
+
+func (a ClusterAutoscaler) Enabled() bool {
+	return a.MinSize > 0
 }
 
 // UnitRootVolumeSize/IOPS are used for spot fleets instead of WorkerRootVolumeSize/IOPS,

--- a/nodepool/cluster/cluster.go
+++ b/nodepool/cluster/cluster.go
@@ -59,7 +59,7 @@ func (c *Cluster) stackProvisioner() *cfnstack.Provisioner {
   ]
 }`
 
-	return cfnstack.NewProvisioner(c.NodePoolName, c.StackTags, stackPolicyBody, c.session)
+	return cfnstack.NewProvisioner(c.NodePoolName, c.WorkerDeploymentSettings().StackTags(), stackPolicyBody, c.session)
 }
 
 func (c *Cluster) Create(stackBody string, s3URI string) error {

--- a/nodepool/config/config.go
+++ b/nodepool/config/config.go
@@ -114,12 +114,9 @@ func ClusterFromFile(filename string) (*ProvidedConfig, error) {
 func NewDefaultCluster() *ProvidedConfig {
 	defaults := cfg.NewDefaultCluster()
 
-	workerSettings := defaults.WorkerSettings
-	workerSettings.Worker = model.NewDefaultWorker()
-
 	return &ProvidedConfig{
 		DeploymentSettings: defaults.DeploymentSettings,
-		WorkerSettings:     workerSettings,
+		WorkerSettings:     defaults.WorkerSettings,
 	}
 }
 

--- a/nodepool/config/templates/cluster.yaml
+++ b/nodepool/config/templates/cluster.yaml
@@ -80,6 +80,13 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #     minSize: 1
 #     maxSize: 3
 #     rollingUpdateMinInstancesInService: 2
+#   # Tag the cloudformation stack with the key `kube-aws:cluster-autoscaler:scale-specs` with the value containing
+#   # source of truth for cluster-autoscaler to update their autoscaling target and its min/max size.
+#   # Currently, enabling this configuration doesn't automatically deploy cluster-autoscaler itself.
+#   # Please read [the original issue](https://github.com/coreos/kube-aws/issues/148) carefully for more information.
+#   clusterAutoscaler:
+#     minSize: 1
+#     maxSize: 3
 #  # Spot fleet config for worker nodes
 #  spotFleet:
 #    # Total desired number of units to maintain


### PR DESCRIPTION
CloudFormation stacks created via kube-aws can now be tagged with the following keys with the values containing source of truth for cluster-autoscaler to update their autoscaling target and its min/max size.

* `kube-aws:cluster-autoscaler:logical-name` (Currently fixed to `AutoScaleWorker` which corresponds to the logical name of the autoscaling group for worker nodes defined in `stack-template.json`)
* `kube-aws:cluster-autoscaler:max-size`
* `kube-aws:cluster-autoscaler:min-size`

Adding tags to stacks instead of to autoscaling groups allows us to support autoscaling of spot fleet via cluster-autoscaler, in the future.

Currently, enabling this configuration doesn't automatically deploy cluster-autoscaler itself.
Please read [the original issue](coreos#148) carefully for more information.

ref #148 
depends #150 

This will be rebased once #150 is merged.
