### PR TITLE
format ephemeral storage only on first boot

### DIFF
--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -311,6 +311,7 @@ coreos:
       content: |
         [Unit]
         Description=Formats the ephemeral drive
+        ConditionFirstBoot=yes
         After=dev-{{.Experimental.EphemeralImageStorage.Disk}}.device
         Requires=dev-{{.Experimental.EphemeralImageStorage.Disk}}.device
         [Service]

--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -346,6 +346,7 @@ coreos:
       content: |
         [Unit]
         Description=Formats the ephemeral drive
+        ConditionFirstBoot=yes
         After=dev-{{.Experimental.EphemeralImageStorage.Disk}}.device
         Requires=dev-{{.Experimental.EphemeralImageStorage.Disk}}.device
         [Service]


### PR DESCRIPTION
That way rebooting the agents does not cause a re-download of images
it's likely to have had and now need again nor losing any Pod logs