### PR TITLE
config: make sure minimum servers is always >= 0

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -379,6 +379,9 @@ var supportedReleaseChannels = map[string]bool{
 }
 
 func (c WorkerSettings) MinWorkerCount() int {
+	if c.WorkerCount == 0 {
+		return 0
+	}
 	return c.WorkerCount - 1
 }
 


### PR DESCRIPTION
I was setting up a new cluster and intended to create all of my worker nodes using node pools, so I  had a `workerCount: 0` line in there. This all works, except it tries to set the ASG's minSize to -1, and CloudFormation complains. This fixes that.