### PR TITLE
Fix kube-node-label failure when there is a whitespace in sg name

### DIFF
--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -276,18 +276,18 @@ coreos:
         ExecStop=/bin/true
         RemainAfterExit=true
         ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment INSTANCE_ID=$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/instance-id)"
-        ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment SECURITY_GROUPS=$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/security-groups | tr '\n' ',')"
-        ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment AUTOSCALINGGROUP=$(/usr/bin/docker run --rm --net=host \
+        ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment SECURITY_GROUPS=\"$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/security-groups | tr '\n' ',')\""
+        ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment AUTOSCALINGGROUP=\"$(/usr/bin/docker run --rm --net=host \
           {{.AWSCliImageRepo}}:{{.AWSCliTag}} aws \
           autoscaling describe-auto-scaling-instances \
           --instance-ids ${INSTANCE_ID} --region {{.Region}} \
-          --query 'AutoScalingInstances[].AutoScalingGroupName' --output text)"
+          --query 'AutoScalingInstances[].AutoScalingGroupName' --output text)\""
         ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment \
-          LAUNCHCONFIGURATION=$(/usr/bin/docker run --rm --net=host \
+          LAUNCHCONFIGURATION=\"$(/usr/bin/docker run --rm --net=host \
           {{.AWSCliImageRepo}}:{{.AWSCliTag}} \
           aws autoscaling describe-auto-scaling-groups \
           --auto-scaling-group-name $AUTOSCALINGGROUP --region {{.Region}} \
-          --query 'AutoScalingGroups[].LaunchConfigurationName' --output text)"
+          --query 'AutoScalingGroups[].LaunchConfigurationName' --output text)\""
         ExecStart=/bin/sh -c "/usr/bin/curl \
           --request PATCH \
           -H 'Content-Type: application/strategic-merge-patch+json' \

--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -309,18 +309,18 @@ coreos:
         RemainAfterExit=true
         ExecStop=/bin/true
         ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment INSTANCE_ID=$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/instance-id)"
-        ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment SECURITY_GROUPS=$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/security-groups | tr '\n' ',')"
-        ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment AUTOSCALINGGROUP=$(/usr/bin/docker run --rm --net=host \
+        ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment SECURITY_GROUPS=\"$(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/security-groups | tr '\n' ',')\""
+        ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment AUTOSCALINGGROUP=\"$(/usr/bin/docker run --rm --net=host \
           {{.AWSCliImageRepo}}:{{.AWSCliTag}} aws \
           autoscaling describe-auto-scaling-instances \
           --instance-ids ${INSTANCE_ID} --region {{.Region}} \
-          --query 'AutoScalingInstances[].AutoScalingGroupName' --output text)"
+          --query 'AutoScalingInstances[].AutoScalingGroupName' --output text)\""
         ExecStartPre=/bin/sh -c "/usr/bin/systemctl set-environment \
-          LAUNCHCONFIGURATION=$(/usr/bin/docker run --rm --net=host \
+          LAUNCHCONFIGURATION=\"$(/usr/bin/docker run --rm --net=host \
           {{.AWSCliImageRepo}}:{{.AWSCliTag}} \
           aws autoscaling describe-auto-scaling-groups \
           --auto-scaling-group-name $AUTOSCALINGGROUP --region {{.Region}} \
-          --query 'AutoScalingGroups[].LaunchConfigurationName' --output text)"
+          --query 'AutoScalingGroups[].LaunchConfigurationName' --output text)\""
         ExecStart=/bin/sh -c "/usr/bin/curl \
           --cert   /etc/kubernetes/ssl/worker.pem \
           --key    /etc/kubernetes/ssl/worker-key.pem \


### PR DESCRIPTION
e.g if you attach external security group to worker nodes and this group name contains whitespace then `systemctl set-environment` fails with `Failed to set environment: Invalid environment assignments`
Also applied same fix for launchconfiguration and autoscaling group labels, though these names are generated, but it is possible to create manually autoscaling group or launchconfiguration that has whitespace in its name