### PR TITLE
Create etcd and workers in private subnets, controllers in public subnet

### DIFF
--- a/Documentation/kubernetes-on-aws-limitations.md
+++ b/Documentation/kubernetes-on-aws-limitations.md
@@ -17,4 +17,6 @@ If you want to deploy `nginx-ingress-controller` which requires `hostPort`, just
 
 Relevant kube-aws issue: [does hostPort not work on kube-aws/CoreOS?](https://github.com/coreos/kube-aws/issues/91)
 
-See [the upstream issue](https://github.com/kubernetes/kubernetes/issues/23920#issuecomment-254918942) for more information.
+See [the related upstream issue](https://github.com/kubernetes/kubernetes/issues/23920#issuecomment-254918942) for more information.
+
+This limitation is also documented in [the official Kubernetes doc](http://kubernetes.io/docs/admin/network-plugins/#cni).

--- a/cmd/nodepool/up.go
+++ b/cmd/nodepool/up.go
@@ -42,7 +42,7 @@ func runCmdUp(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Failed to validate user data: %v", err)
 	}
 
-	data, err := conf.RenderStackTemplate(stackTemplateOptions(), upOpts.export)
+	data, err := conf.RenderStackTemplate(stackTemplateOptions(), upOpts.prettyPrint)
 	if err != nil {
 		return fmt.Errorf("Failed to render stack template: %v", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -179,6 +179,11 @@ func ClusterFromBytes(data []byte) (*Cluster, error) {
 		}
 	}
 
+	// Populate subnets
+	if len(c.Subnets) > 0 && c.WorkerSettings.MinWorkerCount() > 0 && c.WorkerSettings.TopologyPrivate() == false {
+		c.WorkerSettings.PublicSubnets = c.Subnets
+	}
+
 	return c, nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -254,14 +254,15 @@ type WorkerSettings struct {
 
 // Part of configuration which is specific to controller nodes
 type ControllerSettings struct {
-	model.Controller         `yaml:"controller,omitempty"`
-	ControllerCount          int    `yaml:"controllerCount,omitempty"`
-	ControllerCreateTimeout  string `yaml:"controllerCreateTimeout,omitempty"`
-	ControllerInstanceType   string `yaml:"controllerInstanceType,omitempty"`
-	ControllerRootVolumeType string `yaml:"controllerRootVolumeType,omitempty"`
-	ControllerRootVolumeIOPS int    `yaml:"controllerRootVolumeIOPS,omitempty"`
-	ControllerRootVolumeSize int    `yaml:"controllerRootVolumeSize,omitempty"`
-	ControllerTenancy        string `yaml:"controllerTenancy,omitempty"`
+	model.Controller               `yaml:"controller,omitempty"`
+	ControllerCount                int    `yaml:"controllerCount,omitempty"`
+	ControllerCreateTimeout        string `yaml:"controllerCreateTimeout,omitempty"`
+	ControllerInstanceType         string `yaml:"controllerInstanceType,omitempty"`
+	ControllerLoadBalancerPrivate  string `yaml:"controllerLoadBalancerPrivate,omitempty"`
+	ControllerRootVolumeType       string `yaml:"controllerRootVolumeType,omitempty"`
+	ControllerRootVolumeIOPS       int    `yaml:"controllerRootVolumeIOPS,omitempty"`
+	ControllerRootVolumeSize       int    `yaml:"controllerRootVolumeSize,omitempty"`
+	ControllerTenancy              string `yaml:"controllerTenancy,omitempty"`
 }
 
 // Part of configuration which is specific to etcd nodes

--- a/config/config.go
+++ b/config/config.go
@@ -249,6 +249,7 @@ type WorkerSettings struct {
 	WorkerSpotPrice        string   `yaml:"workerSpotPrice,omitempty"`
 	WorkerSecurityGroupIds []string `yaml:"workerSecurityGroupIds,omitempty"`
 	WorkerTenancy          string   `yaml:"workerTenancy,omitempty"`
+	WorkerTopologyPrivate  bool     `yaml:"workerTopologyPrivate,omitempty"`
 }
 
 // Part of configuration which is specific to controller nodes
@@ -986,12 +987,16 @@ func (c *Cluster) AvailabilityZones() []string {
 		return []string{c.AvailabilityZone}
 	}
 
-	azs := make([]string, len(c.Subnets))
-	for i := range azs {
-		azs[i] = c.Subnets[i].AvailabilityZone
+	result := []string{}
+	seen := map[string]bool{}
+	for _, s := range c.Subnets{
+		val := s.AvailabilityZone
+		if _, ok := seen[val]; !ok {
+			result = append(result, val)
+			seen[val] = true
+		}
 	}
-
-	return azs
+	return result
 }
 
 /*

--- a/config/config.go
+++ b/config/config.go
@@ -254,15 +254,15 @@ type WorkerSettings struct {
 
 // Part of configuration which is specific to controller nodes
 type ControllerSettings struct {
-	model.Controller               `yaml:"controller,omitempty"`
-	ControllerCount                int    `yaml:"controllerCount,omitempty"`
-	ControllerCreateTimeout        string `yaml:"controllerCreateTimeout,omitempty"`
-	ControllerInstanceType         string `yaml:"controllerInstanceType,omitempty"`
-	ControllerLoadBalancerPrivate  string `yaml:"controllerLoadBalancerPrivate,omitempty"`
-	ControllerRootVolumeType       string `yaml:"controllerRootVolumeType,omitempty"`
-	ControllerRootVolumeIOPS       int    `yaml:"controllerRootVolumeIOPS,omitempty"`
-	ControllerRootVolumeSize       int    `yaml:"controllerRootVolumeSize,omitempty"`
-	ControllerTenancy              string `yaml:"controllerTenancy,omitempty"`
+	model.Controller              `yaml:"controller,omitempty"`
+	ControllerCount               int    `yaml:"controllerCount,omitempty"`
+	ControllerCreateTimeout       string `yaml:"controllerCreateTimeout,omitempty"`
+	ControllerInstanceType        string `yaml:"controllerInstanceType,omitempty"`
+	ControllerLoadBalancerPrivate string `yaml:"controllerLoadBalancerPrivate,omitempty"`
+	ControllerRootVolumeType      string `yaml:"controllerRootVolumeType,omitempty"`
+	ControllerRootVolumeIOPS      int    `yaml:"controllerRootVolumeIOPS,omitempty"`
+	ControllerRootVolumeSize      int    `yaml:"controllerRootVolumeSize,omitempty"`
+	ControllerTenancy             string `yaml:"controllerTenancy,omitempty"`
 }
 
 // Part of configuration which is specific to etcd nodes
@@ -385,7 +385,7 @@ type WaitSignal struct {
 }
 
 const (
-	vpcLogicalName = "VPC"
+	vpcLogicalName             = "VPC"
 	internetGatewayLogicalName = "InternetGateway"
 )
 
@@ -507,8 +507,8 @@ func (c Cluster) Config() (*Config, error) {
 		nextAddr := netutil.IncrementIP(*lastAllocatedAddr[subnet])
 		lastAllocatedAddr[subnet] = &nextAddr
 		instance := etcdInstance{
-			IPAddress:   *lastAllocatedAddr[subnet],
-			Subnet: subnet,
+			IPAddress: *lastAllocatedAddr[subnet],
+			Subnet:    subnet,
 		}
 
 		//TODO(chom): validate we're not overflowing the address space
@@ -659,8 +659,8 @@ func (c Cluster) RenderStackTemplate(opts StackTemplateOptions, prettyPrint bool
 }
 
 type etcdInstance struct {
-	IPAddress   net.IP
-	Subnet      model.Subneter
+	IPAddress net.IP
+	Subnet    model.Subneter
 }
 
 type Config struct {
@@ -698,7 +698,7 @@ func (c Config) InternetGatewayLogicalName() string {
 
 func (c Config) InternetGatewayRef() string {
 	if c.InternetGatewayID != "" {
-		return fmt.Sprintf("%q", c.InternetGatewayID);
+		return fmt.Sprintf("%q", c.InternetGatewayID)
 	} else {
 		return fmt.Sprintf(`{ "Ref" : %q }`, c.InternetGatewayLogicalName())
 	}
@@ -990,7 +990,7 @@ func (c *Cluster) AvailabilityZones() []string {
 
 	result := []string{}
 	seen := map[string]bool{}
-	for _, s := range c.Subnets{
+	for _, s := range c.Subnets {
 		val := s.AvailabilityZone
 		if _, ok := seen[val]; !ok {
 			result = append(result, val)

--- a/config/config.go
+++ b/config/config.go
@@ -264,7 +264,7 @@ type ControllerSettings struct {
 	ControllerCount               int    `yaml:"controllerCount,omitempty"`
 	ControllerCreateTimeout       string `yaml:"controllerCreateTimeout,omitempty"`
 	ControllerInstanceType        string `yaml:"controllerInstanceType,omitempty"`
-	ControllerLoadBalancerPrivate string `yaml:"controllerLoadBalancerPrivate,omitempty"`
+	ControllerLoadBalancerPrivate bool   `yaml:"controllerLoadBalancerPrivate,omitempty"`
 	ControllerRootVolumeType      string `yaml:"controllerRootVolumeType,omitempty"`
 	ControllerRootVolumeIOPS      int    `yaml:"controllerRootVolumeIOPS,omitempty"`
 	ControllerRootVolumeSize      int    `yaml:"controllerRootVolumeSize,omitempty"`

--- a/config/config.go
+++ b/config/config.go
@@ -495,7 +495,7 @@ func (c Cluster) Config() (*Config, error) {
 		}
 
 		instance := model.EtcdInstance{
-			Subnet:    subnet,
+			Subnet: subnet,
 		}
 
 		config.EtcdInstances[etcdIndex] = instance

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"text/template"
+
+	model "github.com/coreos/kube-aws/model"
 )
 
 const minimalConfigYaml = `externalDNSName: test.staging.core-os.net
@@ -314,7 +316,7 @@ func TestMultipleSubnets(t *testing.T) {
 
 	validConfigs := []struct {
 		conf    string
-		subnets []*Subnet
+		subnets []*model.Subnet
 	}{
 		{
 			conf: `
@@ -327,7 +329,7 @@ subnets:
   - availabilityZone: ap-northeast-1c
     instanceCIDR: 10.4.4.0/24
 `,
-			subnets: []*Subnet{
+			subnets: []*model.Subnet{
 				{
 					InstanceCIDR:     "10.4.3.0/24",
 					AvailabilityZone: "ap-northeast-1a",
@@ -346,7 +348,7 @@ controllerIP: 10.4.3.50
 availabilityZone: ap-northeast-1a
 instanceCIDR: 10.4.3.0/24
 `,
-			subnets: []*Subnet{
+			subnets: []*model.Subnet{
 				{
 					AvailabilityZone: "ap-northeast-1a",
 					InstanceCIDR:     "10.4.3.0/24",
@@ -362,7 +364,7 @@ availabilityZone: ap-northeast-1a
 instanceCIDR: 10.4.3.0/24
 subnets: []
 `,
-			subnets: []*Subnet{
+			subnets: []*model.Subnet{
 				{
 					AvailabilityZone: "ap-northeast-1a",
 					InstanceCIDR:     "10.4.3.0/24",
@@ -375,7 +377,7 @@ subnets: []
 availabilityZone: "ap-northeast-1a"
 subnets: []
 `,
-			subnets: []*Subnet{
+			subnets: []*model.Subnet{
 				{
 					AvailabilityZone: "ap-northeast-1a",
 					InstanceCIDR:     "10.0.0.0/24",
@@ -387,7 +389,7 @@ subnets: []
 # Missing subnets field fall-backs to the single subnet with the default az/cidr.
 availabilityZone: "ap-northeast-1a"
 `,
-			subnets: []*Subnet{
+			subnets: []*model.Subnet{
 				{
 					AvailabilityZone: "ap-northeast-1a",
 					InstanceCIDR:     "10.0.0.0/24",
@@ -730,12 +732,12 @@ func newMinimalConfig() (*Config, error) {
 	cluster := NewDefaultCluster()
 	cluster.ExternalDNSName = "k8s.example.com"
 	cluster.Region = "us-west-1"
-	cluster.Subnets = []*Subnet{
-		&Subnet{
+	cluster.Subnets = []*model.Subnet{
+		&model.Subnet{
 			AvailabilityZone: "us-west-1a",
 			InstanceCIDR:     "10.0.0.0/24",
 		},
-		&Subnet{
+		&model.Subnet{
 			AvailabilityZone: "us-west-1b",
 			InstanceCIDR:     "10.0.1.0/24",
 		},
@@ -873,9 +875,9 @@ func TestValidateExistingVPC(t *testing.T) {
 	cluster := NewDefaultCluster()
 
 	cluster.VPCCIDR = "10.0.0.0/16"
-	cluster.Subnets = []*Subnet{
-		{"ap-northeast-1a", "10.0.1.0/24", nil},
-		{"ap-northeast-1a", "10.0.2.0/24", nil},
+	cluster.Subnets = []*model.Subnet{
+		{"ap-northeast-1a", "10.0.1.0/24", "", model.NatGateway{}},
+		{"ap-northeast-1a", "10.0.2.0/24", "", model.NatGateway{}},
 	}
 
 	for _, testCase := range validCases {
@@ -899,9 +901,9 @@ func TestValidateUserData(t *testing.T) {
 	cluster := newDefaultClusterWithDeps(&dummyEncryptService{})
 
 	cluster.Region = "us-west-1"
-	cluster.Subnets = []*Subnet{
-		{"us-west-1a", "10.0.1.0/16", nil},
-		{"us-west-1b", "10.0.2.0/16", nil},
+	cluster.Subnets = []*model.Subnet{
+		{"us-west-1a", "10.0.1.0/16", "", model.NatGateway{}},
+		{"us-west-1b", "10.0.2.0/16", "", model.NatGateway{}},
 	}
 
 	helper.WithDummyCredentials(func(dir string) {
@@ -923,9 +925,9 @@ func TestRenderStackTemplate(t *testing.T) {
 	cluster := newDefaultClusterWithDeps(&dummyEncryptService{})
 
 	cluster.Region = "us-west-1"
-	cluster.Subnets = []*Subnet{
-		{"us-west-1a", "10.0.1.0/16", nil},
-		{"us-west-1b", "10.0.2.0/16", nil},
+	cluster.Subnets = []*model.Subnet{
+		{"us-west-1a", "10.0.1.0/16", "", model.NatGateway{}},
+		{"us-west-1b", "10.0.2.0/16", "", model.NatGateway{}},
 	}
 
 	helper.WithDummyCredentials(func(dir string) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -333,10 +333,12 @@ subnets:
 				{
 					InstanceCIDR:     "10.4.3.0/24",
 					AvailabilityZone: "ap-northeast-1a",
+					TopLevel:         true,
 				},
 				{
 					InstanceCIDR:     "10.4.4.0/24",
 					AvailabilityZone: "ap-northeast-1c",
+					TopLevel:         true,
 				},
 			},
 		},
@@ -352,6 +354,7 @@ instanceCIDR: 10.4.3.0/24
 				{
 					AvailabilityZone: "ap-northeast-1a",
 					InstanceCIDR:     "10.4.3.0/24",
+					TopLevel:         true,
 				},
 			},
 		},
@@ -368,6 +371,7 @@ subnets: []
 				{
 					AvailabilityZone: "ap-northeast-1a",
 					InstanceCIDR:     "10.4.3.0/24",
+					TopLevel:         true,
 				},
 			},
 		},
@@ -381,6 +385,7 @@ subnets: []
 				{
 					AvailabilityZone: "ap-northeast-1a",
 					InstanceCIDR:     "10.0.0.0/24",
+					TopLevel:         true,
 				},
 			},
 		},
@@ -393,6 +398,7 @@ availabilityZone: "ap-northeast-1a"
 				{
 					AvailabilityZone: "ap-northeast-1a",
 					InstanceCIDR:     "10.0.0.0/24",
+					TopLevel:         true,
 				},
 			},
 		},
@@ -876,8 +882,8 @@ func TestValidateExistingVPC(t *testing.T) {
 
 	cluster.VPCCIDR = "10.0.0.0/16"
 	cluster.Subnets = []*model.Subnet{
-		{"ap-northeast-1a", "10.0.1.0/24", "", model.NatGateway{}},
-		{"ap-northeast-1a", "10.0.2.0/24", "", model.NatGateway{}},
+		{"ap-northeast-1a", "10.0.1.0/24", "", model.NatGateway{}, true},
+		{"ap-northeast-1a", "10.0.2.0/24", "", model.NatGateway{}, true},
 	}
 
 	for _, testCase := range validCases {
@@ -902,8 +908,8 @@ func TestValidateUserData(t *testing.T) {
 
 	cluster.Region = "us-west-1"
 	cluster.Subnets = []*model.Subnet{
-		{"us-west-1a", "10.0.1.0/16", "", model.NatGateway{}},
-		{"us-west-1b", "10.0.2.0/16", "", model.NatGateway{}},
+		{"us-west-1a", "10.0.1.0/16", "", model.NatGateway{}, true},
+		{"us-west-1b", "10.0.2.0/16", "", model.NatGateway{}, true},
 	}
 
 	helper.WithDummyCredentials(func(dir string) {
@@ -926,8 +932,8 @@ func TestRenderStackTemplate(t *testing.T) {
 
 	cluster.Region = "us-west-1"
 	cluster.Subnets = []*model.Subnet{
-		{"us-west-1a", "10.0.1.0/16", "", model.NatGateway{}},
-		{"us-west-1b", "10.0.2.0/16", "", model.NatGateway{}},
+		{"us-west-1a", "10.0.1.0/16", "", model.NatGateway{}, true},
+		{"us-west-1b", "10.0.2.0/16", "", model.NatGateway{}, true},
 	}
 
 	helper.WithDummyCredentials(func(dir string) {

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -53,18 +53,17 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # Number of controller nodes to create, for more control use `controller.autoScalingGroup` and do not use this setting
 #controllerCount: 1
 
-controller:
-  # Auto Scaling Group definition for controllers. If only `controllerCount` is specified, min and max will be the set to that value and `rollingUpdateMinInstancesInService` will be one less.
-  # autoScalingGroup:
-  #   minSize: 1
-  #   maxSize: 3
-  #   rollingUpdateMinInstancesInService: 2
-  # privateSubnets:
-  #   - availabilityZone: us-west-1a
-  #     instanceCIDR: "10.0.4.0/24"
-  #   - availabilityZone: us-west-1b
-  #     instanceCIDR: "10.0.5.0/24"
-
+#controller:
+#  # Auto Scaling Group definition for controllers. If only `controllerCount` is specified, min and max will be the set to that value and `rollingUpdateMinInstancesInService` will be one less.
+#  autoScalingGroup:
+#    minSize: 1
+#    maxSize: 3
+#    rollingUpdateMinInstancesInService: 2
+#  privateSubnets:
+#    - availabilityZone: us-west-1a
+#      instanceCIDR: "10.0.4.0/24"
+#    - availabilityZone: us-west-1b
+#      instanceCIDR: "10.0.5.0/24"
 
 # Maximum time to wait for controller creation
 #controlerCreateTimeout: PT15M
@@ -84,15 +83,17 @@ controller:
 # Number of worker nodes to create, for more control use `worker.autoScalingGroup` and do not use this setting
 #workerCount: 1
 
-# worker:
-#   # Auto Scaling Group definition for workers. If only `workerCount` is specified, min and max will be the set to that value and `rollingUpdateMinInstancesInService` will be one less.
-#   autoScalingGroup:
-#     minSize: 1
-#     maxSize: 3
-#     rollingUpdateMinInstancesInService: 2
-#   # Network topology Public or Private with NAT Gateway
-#   # A private subnet can be defined in the node pool.
-#   topologyPrivate: true
+#worker:
+#  # Auto Scaling Group definition for workers. If only `workerCount` is specified, min and max will be the set to that value and `rollingUpdateMinInstancesInService` will be one less.
+#  autoScalingGroup:
+#    minSize: 1
+#    maxSize: 3
+#    rollingUpdateMinInstancesInService: 2
+#  privateSubnets:
+#    - availabilityZone: us-west-1a
+#      instanceCIDR: "10.0.6.0/24"
+#    - availabilityZone: us-west-1b
+#      instanceCIDR: "10.0.7.0/24"
 
 # Maximum time to wait for worker creation
 #workerCreateTimeout: PT15M
@@ -130,17 +131,12 @@ controller:
 # (Set to an odd number >= 3 for HA control plane)
 # etcdCount: 1
 
-# etcd:
-#   privateSubnets:
-#     - availabilityZone: us-west-1a
-#       instanceCIDR: "10.0.2.0/24"
-#     - availabilityZone: us-west-1b
-#       instanceCIDR: "10.0.3.0/24"
-#       # natGateway:
-#       #   # Pre-allocated NAT Gateway. Used with private subnets.
-#       #   id: "ngw-abcdef12"
-#       #   # Pre-allocated EIP for NAT Gateways. Used with private subnets.
-#       #   eipAllocationIDs: "eipalloc-abcdef12"
+#etcd:
+#  privateSubnets:
+#    - availabilityZone: us-west-1a
+#      instanceCIDR: "10.0.2.0/24"
+#    - availabilityZone: us-west-1b
+#      instanceCIDR: "10.0.3.0/24"
 
 # Instance type for etcd node
 # etcdInstanceType: m3.medium
@@ -199,7 +195,7 @@ controller:
 #     #   # Pre-allocated NAT Gateway. Used with private subnets.
 #     #   id: "ngw-abcdef12"
 #     #   # Pre-allocated EIP for NAT Gateways. Used with private subnets.
-#     #   eipAllocationIDs: "eipalloc-abcdef12"
+#     #   eipAllocationId: "eipalloc-abcdef12"
 
 # CIDR for all service IP addresses
 # serviceCIDR: "10.3.0.0/24"

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -92,6 +92,11 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #    minSize: 1
 #    maxSize: 3
 #    rollingUpdateMinInstancesInService: 2
+#  privateSubnets:
+#    - availabilityZone: us-west-1a
+#      instanceCIDR: "10.0.6.0/24"
+#    - availabilityZone: us-west-1b
+#      instanceCIDR: "10.0.7.0/24"
 
 # Setting worker topology private ensures NAT Gateways are created for use in node pools.
 #workerTopologyPrivate: true

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -59,7 +59,7 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #    minSize: 1
 #    maxSize: 3
 #    rollingUpdateMinInstancesInService: 2
-#  privateSubnets:
+#  subnets:
 #    - availabilityZone: us-west-1a
 #      instanceCIDR: "10.0.4.0/24"
 #    - availabilityZone: us-west-1b
@@ -93,7 +93,7 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #    minSize: 1
 #    maxSize: 3
 #    rollingUpdateMinInstancesInService: 2
-#  privateSubnets:
+#  subnets:
 #    - availabilityZone: us-west-1a
 #      instanceCIDR: "10.0.6.0/24"
 #    - availabilityZone: us-west-1b
@@ -140,7 +140,7 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # etcdCount: 1
 
 #etcd:
-#  privateSubnets:
+#  subnets:
 #    - availabilityZone: us-west-1a
 #      instanceCIDR: "10.0.2.0/24"
 #    - availabilityZone: us-west-1b

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -59,6 +59,12 @@ controller:
   #   minSize: 1
   #   maxSize: 3
   #   rollingUpdateMinInstancesInService: 2
+  # privateSubnets:
+  #   - availabilityZone: us-west-1a
+  #     instanceCIDR: "10.0.4.0/24"
+  #   - availabilityZone: us-west-1b
+  #     instanceCIDR: "10.0.5.0/24"
+
 
 # Maximum time to wait for controller creation
 #controlerCreateTimeout: PT15M
@@ -84,6 +90,9 @@ controller:
 #     minSize: 1
 #     maxSize: 3
 #     rollingUpdateMinInstancesInService: 2
+#   # Network topology Public or Private with NAT Gateway
+#   # A private subnet can be defined in the node pool.
+#   topologyPrivate: true
 
 # Maximum time to wait for worker creation
 #workerCreateTimeout: PT15M
@@ -121,6 +130,18 @@ controller:
 # (Set to an odd number >= 3 for HA control plane)
 # etcdCount: 1
 
+# etcd:
+#   privateSubnets:
+#     - availabilityZone: us-west-1a
+#       instanceCIDR: "10.0.2.0/24"
+#     - availabilityZone: us-west-1b
+#       instanceCIDR: "10.0.3.0/24"
+#       # natGateway:
+#       #   # Pre-allocated NAT Gateway. Used with private subnets.
+#       #   id: "ngw-abcdef12"
+#       #   # Pre-allocated EIP for NAT Gateways. Used with private subnets.
+#       #   eipAllocationIDs: "eipalloc-abcdef12"
+
 # Instance type for etcd node
 # etcdInstanceType: m3.medium
 
@@ -156,6 +177,9 @@ controller:
 # ID of existing VPC to create subnet in. Leave blank to create a new VPC
 # vpcId:
 
+# ID of existing Internet Gateway to associate subnet with. Leave blank to create a new Internet Gateway
+# internetGatewayId:
+
 # ID of existing route table in existing VPC to attach subnet to. Leave blank to use the VPC's main route table.
 # routeTableId:
 
@@ -171,6 +195,11 @@ controller:
 #     instanceCIDR: "10.0.0.0/24"
 #   - availabilityZone: us-west-1b
 #     instanceCIDR: "10.0.1.0/24"
+#     # natGateway:
+#     #   # Pre-allocated NAT Gateway. Used with private subnets.
+#     #   id: "ngw-abcdef12"
+#     #   # Pre-allocated EIP for NAT Gateways. Used with private subnets.
+#     #   eipAllocationIDs: "eipalloc-abcdef12"
 
 # CIDR for all service IP addresses
 # serviceCIDR: "10.3.0.0/24"

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -89,11 +89,9 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #    minSize: 1
 #    maxSize: 3
 #    rollingUpdateMinInstancesInService: 2
-#  privateSubnets:
-#    - availabilityZone: us-west-1a
-#      instanceCIDR: "10.0.6.0/24"
-#    - availabilityZone: us-west-1b
-#      instanceCIDR: "10.0.7.0/24"
+
+# Setting worker topology private ensures NAT Gateways are created for use in node pools.
+#workerTopologyPrivate: true
 
 # Maximum time to wait for worker creation
 #workerCreateTimeout: PT15M

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -65,7 +65,7 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #    - availabilityZone: us-west-1b
 #      instanceCIDR: "10.0.5.0/24"
 
-# Maximum time to wait for controller creation
+# Set to true to put the ELB on the public subnet although having controller nodes on private subnets
 #controllerLoadBalancerPrivate: false
 
 # Maximum time to wait for controller creation

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -99,7 +99,7 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #      instanceCIDR: "10.0.7.0/24"
 
 # Setting worker topology private ensures NAT Gateways are created for use in node pools.
-#workerTopologyPrivate: true
+#workerTopologyPrivate: false
 
 # Maximum time to wait for worker creation
 #workerCreateTimeout: PT15M

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -66,7 +66,10 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #      instanceCIDR: "10.0.5.0/24"
 
 # Maximum time to wait for controller creation
-#controlerCreateTimeout: PT15M
+#controllerLoadBalancerPrivate: false
+
+# Maximum time to wait for controller creation
+#controllerCreateTimeout: PT15M
 
 # Instance type for controller node
 #controllerInstanceType: m3.medium

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -13,9 +13,16 @@
     "AutoScaleWorker": {
       "Properties": {
         "AvailabilityZones": [
+          {{if $.Worker.TopologyPrivate}}
+          {{range $index, $workerSubnet := .Worker.PrivateSubnets}}
+          {{if gt $index 0}},{{end}}
+          "{{$workerSubnet.AvailabilityZone}}"
+          {{end}}
+          {{else}}
           {{range $index, $subnet := .Subnets}}
           {{if gt $index 0}},{{end}}
           "{{$subnet.AvailabilityZone}}"
+          {{end}}
           {{end}}
         ],
         "HealthCheckGracePeriod": 600,
@@ -51,11 +58,22 @@
         ],
         {{end}}
         "VPCZoneIdentifier": [
+          {{if $.Worker.TopologyPrivate}}
+          {{range $index, $workerSubnet := .Worker.PrivateSubnets}}
+          {{with $workerSubnetLogicalName := printf "Worker%s" $workerSubnet.LogicalName}}
+          {{if gt $index 0}},{{end}}
+          {
+            "Ref": "{{$workerSubnetLogicalName}}"
+          }
+          {{end}}
+          {{end}}
+          {{else}}
           {{range $index, $subnet := .Subnets}}
           {{if gt $index 0}},{{end}}
           {
             "Ref": "{{$subnet.LogicalName}}"
           }
+          {{end}}
           {{end}}
         ]
       },
@@ -613,7 +631,7 @@
           "UnhealthyThreshold" : "3"
         },
         "Subnets" : [
-          {{if .Controller.TopologyPrivate}}
+          {{if .ControllerLoadBalancerPrivate}}
           {{range $index, $controllerSubnet := .Controller.PrivateSubnets}}
           {{with $controllerSubnetLogicalName := printf "Controller%s" $controllerSubnet.LogicalName}}
           {{if gt $index 0}},{{end}}
@@ -635,12 +653,10 @@
             "Protocol" : "TCP"
           }
         ],
-        {{if .Controller.TopologyPrivate}}
+        {{if .ControllerLoadBalancerPrivate}}
         "Scheme": "internal",
-        {{else if .MapPublicIPs}}
-        "Scheme": "internet-facing",
         {{else}}
-        "Scheme": "internal",
+        "Scheme": "internet-facing",
         {{end}}
         "SecurityGroups" : [
           { "Ref" : "SecurityGroupElbAPIServer" }
@@ -1163,6 +1179,47 @@
     {{end}}
     {{end}}
 
+    {{if $.Worker.TopologyPrivate}}
+    {{range $index, $subnet := .Worker.PrivateSubnets}}
+    {{with $workerSubnetLogicalName := printf "Worker%s" $subnet.LogicalName}}
+    ,
+    "{{$workerSubnetLogicalName}}": {
+      "Properties": {
+        "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
+        "CidrBlock": "{{$subnet.InstanceCIDR}}",
+        "MapPublicIpOnLaunch": {{not $.Worker.TopologyPrivate}},
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "{{$.ClusterName}}-{{$workerSubnetLogicalName}}"
+          },
+          {
+            "Key": "KubernetesCluster",
+            "Value": "{{$.ClusterName}}"
+          }
+        ],
+        "VpcId": {{$.VPCRef}}
+      },
+      "Type": "AWS::EC2::Subnet"
+    }
+    ,
+    "{{$workerSubnetLogicalName}}RouteTableAssociation": {
+      "Properties": {
+        "RouteTableId":
+          {{if not $subnet.RouteTableID}}
+          {"Ref" : "PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}"},
+          {{else}}
+          "{{$subnet.RouteTableID}}",
+          {{end}}
+        "SubnetId": {
+          "Ref": "{{$workerSubnetLogicalName}}"
+        }
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation"
+    }
+    {{end}}
+    {{end}}
+    {{end}}
     ,
     "PublicRouteTable": {
       "Properties": {
@@ -1290,9 +1347,7 @@
     },
     "VPCGatewayAttachment": {
       "Properties": {
-        "InternetGatewayId": {
-          "Ref": {{.InternetGatewayRef}}
-        },
+        "InternetGatewayId": {{.InternetGatewayRef}},
         "VpcId": {{.VPCRef}}
       },
       "Type": "AWS::EC2::VPCGatewayAttachment"

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -443,11 +443,11 @@
               "VolumeType": "{{$.EtcdRootVolumeType}}"
             }
           },
-	  {
+	      {
             "DeviceName": "/dev/xvdf",
-	    {{if $.EtcdDataVolumeEphemeral}}
-	    "VirtualName" : "ephemeral0"
-	    {{else}}
+	        {{if $.EtcdDataVolumeEphemeral}}
+	        "VirtualName" : "ephemeral0"
+	        {{else}}
             "Ebs": {
               "VolumeSize": "{{$.EtcdDataVolumeSize}}",
               {{if gt $.EtcdDataVolumeIOPS 0}}
@@ -455,7 +455,7 @@
               {{end}}
               "VolumeType": "{{$.EtcdDataVolumeType}}"
             }
-	    {{end}}
+	        {{end}}
           }
         ],
         "IamInstanceProfile": {
@@ -1097,7 +1097,7 @@
 
     {{if $.Etcd.TopologyPrivate}}
     {{range $index, $subnet := .Etcd.PrivateSubnets}}
-    {{with $etcdSubnetLogicalName := printf "Etcd%d" $subnet.LogicalName}}
+    {{with $etcdSubnetLogicalName := printf "Etcd%s" $subnet.LogicalName}}
     ,
     "{{$etcdSubnetLogicalName}}": {
       "Properties": {
@@ -1242,6 +1242,80 @@
     {{end}}
     {{end}}
 
+    {{if $.Worker.TopologyPrivate}}
+    {{range $index, $subnet := .Worker.PrivateSubnets}}
+    {{with $workerSubnetLogicalName := printf "Worker%s" $subnet.LogicalName}}
+    ,
+    "{{$workerSubnetLogicalName}}": {
+      "Properties": {
+        "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
+        "CidrBlock": "{{$subnet.InstanceCIDR}}",
+        "MapPublicIpOnLaunch": {{not $.Worker.TopologyPrivate}},
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "{{$.ClusterName}}-{{$workerSubnetLogicalName}}"
+          },
+          {
+            "Key": "KubernetesCluster",
+            "Value": "{{$.ClusterName}}"
+          }
+        ],
+        "VpcId": {{$.VPCRef}}
+      },
+      "Type": "AWS::EC2::Subnet"
+    }
+    {{if not $subnet.RouteTableID}}
+    ,
+    "{{$workerSubnetLogicalName}}RouteTable": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "{{$.ClusterName}}-{{$workerSubnetLogicalName}}-route-table"
+          },
+          {
+            "Key": "KubernetesCluster",
+            "Value": "{{$.ClusterName}}"
+          }
+        ],
+        "VpcId": {{$.VPCRef}}
+      },
+      "Type": "AWS::EC2::RouteTable"
+    },
+    "{{$workerSubnetLogicalName}}RouteToNatGateway": {
+      "Properties": {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "NatGatewayId":
+          {{if not $subnet.NatGateway.ID}}
+          {"Ref": "{{$subnet.LogicalName}}NatGateway"},
+          {{else}}
+          "{{$subnet.NatGateway.ID}}",
+          {{end}}
+        "RouteTableId": {"Ref" : "{{$workerSubnetLogicalName}}RouteTable"}
+      },
+      "Type": "AWS::EC2::Route"
+    }
+    {{end}}
+    ,
+    "{{$workerSubnetLogicalName}}RouteTableAssociation": {
+      "Properties": {
+        "RouteTableId":
+          {{if not $subnet.RouteTableID}}
+          {"Ref" : "{{$workerSubnetLogicalName}}RouteTable"},
+          {{else}}
+          "{{$subnet.RouteTableID}}",
+          {{end}}
+        "SubnetId": {
+          "Ref": "{{$workerSubnetLogicalName}}"
+        }
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation"
+    }
+    {{end}}
+    {{end}}
+    {{end}}
+
     {{if (or .Worker.TopologyPrivate .Etcd.TopologyPrivate .Controller.TopologyPrivate)}}
     {{range $index, $subnet := .Subnets}}
     {{if not $subnet.NatGateway.EIPAllocationID}}
@@ -1331,12 +1405,19 @@
       "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-VPC" }}
     },
     {{end}}
-    {{if (or .Worker.TopologyPrivate .Etcd.TopologyPrivate .Controller.TopologyPrivate)}}
     {{range $index, $subnet := .Subnets}}
-    "{{$subnet.LogicalName}}NatGateway" : {
-      "Description" : "The nat gateway assignedd managed by this stack subnet",
-      "Value" :  { "Ref" : "{{$subnet.LogicalName}}NatGateway" },
-      "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-{{$subnet.LogicalName}}NatGateway" }}
+    "{{$subnet.LogicalName}}" : {
+      "Description" : "The public subnets assigned to worker nodes",
+      "Value" :  { "Ref" : "{{$subnet.LogicalName}}" },
+      "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-{{$subnet.LogicalName}}" }}
+    },
+    {{end}}
+    {{if (or .Worker.TopologyPrivate)}}
+    {{range $index, $subnet := .Worker.PrivateSubnets}}
+    "{{$subnet.LogicalName}}" : {
+      "Description" : "The private subnets assigned to worker nodes",
+      "Value" :  { "Ref" : "{{$subnet.LogicalName}}" },
+      "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-{{$subnet.LogicalName}}" }}
     },
     {{end}}
     {{end}}

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -44,10 +44,10 @@
         ],
         {{if .Experimental.LoadBalancer.Enabled}}
         "LoadBalancerNames" : [
-        {{range $index, $elb := .Experimental.LoadBalancer.Names}}
-        {{if $index}},{{end}}
+          {{range $index, $elb := .Experimental.LoadBalancer.Names}}
+          {{if $index}},{{end}}
           "{{$elb}}"
-        {{end}}
+          {{end}}
         ],
         {{end}}
         "VPCZoneIdentifier": [
@@ -176,11 +176,11 @@
     "ExternalDNS": {
       "Type": "AWS::Route53::RecordSet",
       "Properties": {
-	{{ if .HostedZoneID }}
+        {{if .HostedZoneID}}
         "HostedZoneId": "{{.HostedZoneID}}",
-	{{else}}
+	    {{else}}
         "HostedZoneName": "{{.HostedZone}}",
-	{{ end }}
+	    {{end}}
         "Name": "{{.ExternalDNSName}}",
         "TTL": {{.RecordSetTTL}},
         "ResourceRecords": [{ "Fn::GetAtt": ["ElbAPIServer", "DNSName"]}],
@@ -613,9 +613,18 @@
           "UnhealthyThreshold" : "3"
         },
         "Subnets" : [
+          {{if .Controller.TopologyPrivate}}
+          {{range $index, $controllerSubnet := .Controller.PrivateSubnets}}
+          {{with $controllerSubnetLogicalName := printf "Controller%s" $controllerSubnet.LogicalName}}
+          {{if gt $index 0}},{{end}}
+          {"Ref": "{{$controllerSubnetLogicalName}}"}
+          {{end}}
+          {{end}}
+          {{else}}
           {{range $index, $subnet := .Subnets}}
           {{if gt $index 0}},{{end}}
           { "Ref" : "{{$subnet.LogicalName}}" }
+          {{end}}
           {{end}}
         ],
         "Listeners" : [
@@ -626,7 +635,9 @@
             "Protocol" : "TCP"
           }
         ],
-        {{if .MapPublicIPs}}
+        {{if .Controller.TopologyPrivate}}
+        "Scheme": "internal",
+        {{else if .MapPublicIPs}}
         "Scheme": "internet-facing",
         {{else}}
         "Scheme": "internal",
@@ -1017,6 +1028,7 @@
       },
       "Type": "AWS::EC2::SecurityGroup"
     }
+    {{/* TODO: Add Worker Mount Target */}}
     {{range $index, $subnet := .Subnets}}
     ,
     "{{$subnet.LogicalName}}MountTarget": {
@@ -1050,40 +1062,12 @@
         "VpcId": {{$.VPCRef}}
       },
       "Type": "AWS::EC2::Subnet"
-    }
-    {{if not $subnet.RouteTableID}}
-    ,
-    "{{$subnet.LogicalName}}RouteTable": {
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$subnet.LogicalName}}-route-table"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{$.ClusterName}}"
-          }
-        ],
-        "VpcId": {{$.VPCRef}}
-      },
-      "Type": "AWS::EC2::RouteTable"
     },
-    "{{$subnet.LogicalName}}RouteToInternet": {
-      "Properties": {
-        "DestinationCidrBlock": "0.0.0.0/0",
-        "GatewayId": {{$.InternetGatewayRef}},
-        "RouteTableId": {"Ref" : "{{$subnet.LogicalName}}RouteTable"}
-      },
-      "Type": "AWS::EC2::Route"
-    }
-    {{end}}
-    ,
     "{{$subnet.LogicalName}}RouteTableAssociation": {
       "Properties": {
         "RouteTableId":
           {{if not $subnet.RouteTableID}}
-          {"Ref" : "{{$subnet.LogicalName}}RouteTable"},
+          {"Ref" : "PublicRouteTable"},
           {{else}}
           "{{$subnet.RouteTableID}}",
           {{end}}
@@ -1118,44 +1102,12 @@
       },
       "Type": "AWS::EC2::Subnet"
     }
-    {{if not $subnet.RouteTableID}}
-    ,
-    "{{$etcdSubnetLogicalName}}RouteTable": {
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$etcdSubnetLogicalName}}-route-table"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{$.ClusterName}}"
-          }
-        ],
-        "VpcId": {{$.VPCRef}}
-      },
-      "Type": "AWS::EC2::RouteTable"
-    },
-    "{{$etcdSubnetLogicalName}}RouteToNatGateway": {
-      "Properties": {
-        "DestinationCidrBlock": "0.0.0.0/0",
-        "NatGatewayId":
-          {{if not $subnet.NatGateway.ID}}
-          {"Ref": "{{$subnet.LogicalName}}NatGateway"},
-          {{else}}
-          "{{$subnet.NatGateway.ID}}",
-          {{end}}
-        "RouteTableId": {"Ref" : "{{$etcdSubnetLogicalName}}RouteTable"}
-      },
-      "Type": "AWS::EC2::Route"
-    }
-    {{end}}
     ,
     "{{$etcdSubnetLogicalName}}RouteTableAssociation": {
       "Properties": {
         "RouteTableId":
           {{if not $subnet.RouteTableID}}
-          {"Ref" : "{{$etcdSubnetLogicalName}}RouteTable"},
+          {"Ref" : "PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}"},
           {{else}}
           "{{$subnet.RouteTableID}}",
           {{end}}
@@ -1192,43 +1144,12 @@
       },
       "Type": "AWS::EC2::Subnet"
     }
-    {{if not $subnet.RouteTableID}}
-    "{{$controllerSubnetLogicalName}}RouteTable": {
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$controllerSubnetLogicalName}}-route-table"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{$.ClusterName}}"
-          }
-        ],
-        "VpcId": {{$.VPCRef}}
-      },
-      "Type": "AWS::EC2::RouteTable"
-    },
-    "{{$controllerSubnetLogicalName}}RouteToNatGateway": {
-      "Properties": {
-        "DestinationCidrBlock": "0.0.0.0/0",
-        "NatGatewayId":
-          {{if not $subnet.NatGateway.ID}}
-          {"Ref": "{{$subnet.LogicalName}}NatGateway"},
-          {{else}}
-          "{{$subnet.NatGateway.ID}}",
-          {{end}}
-        "RouteTableId": {"Ref" : "{{$controllerSubnetLogicalName}}RouteTable"}
-      },
-      "Type": "AWS::EC2::Route"
-    }
-    {{end}}
     ,
     "{{$controllerSubnetLogicalName}}RouteTableAssociation": {
       "Properties": {
         "RouteTableId":
           {{if not $subnet.RouteTableID}}
-          {"Ref" : "{{$controllerSubnetLogicalName}}RouteTable"},
+          {"Ref" : "PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}"},
           {{else}}
           "{{$subnet.RouteTableID}}",
           {{end}}
@@ -1242,37 +1163,13 @@
     {{end}}
     {{end}}
 
-    {{if $.Worker.TopologyPrivate}}
-    {{range $index, $subnet := .Worker.PrivateSubnets}}
-    {{with $workerSubnetLogicalName := printf "Worker%s" $subnet.LogicalName}}
     ,
-    "{{$workerSubnetLogicalName}}": {
-      "Properties": {
-        "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
-        "CidrBlock": "{{$subnet.InstanceCIDR}}",
-        "MapPublicIpOnLaunch": {{not $.Worker.TopologyPrivate}},
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$workerSubnetLogicalName}}"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{$.ClusterName}}"
-          }
-        ],
-        "VpcId": {{$.VPCRef}}
-      },
-      "Type": "AWS::EC2::Subnet"
-    }
-    {{if not $subnet.RouteTableID}}
-    ,
-    "{{$workerSubnetLogicalName}}RouteTable": {
+    "PublicRouteTable": {
       "Properties": {
         "Tags": [
           {
             "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$workerSubnetLogicalName}}-route-table"
+            "Value": "{{$.ClusterName}}-PublicRouteTable"
           },
           {
             "Key": "KubernetesCluster",
@@ -1283,44 +1180,20 @@
       },
       "Type": "AWS::EC2::RouteTable"
     },
-    "{{$workerSubnetLogicalName}}RouteToNatGateway": {
+    "PublicRouteToInternet": {
       "Properties": {
         "DestinationCidrBlock": "0.0.0.0/0",
-        "NatGatewayId":
-          {{if not $subnet.NatGateway.ID}}
-          {"Ref": "{{$subnet.LogicalName}}NatGateway"},
-          {{else}}
-          "{{$subnet.NatGateway.ID}}",
-          {{end}}
-        "RouteTableId": {"Ref" : "{{$workerSubnetLogicalName}}RouteTable"}
+        "GatewayId": {{$.InternetGatewayRef}},
+        "RouteTableId": {"Ref" : "PublicRouteTable"}
       },
       "Type": "AWS::EC2::Route"
     }
-    {{end}}
-    ,
-    "{{$workerSubnetLogicalName}}RouteTableAssociation": {
-      "Properties": {
-        "RouteTableId":
-          {{if not $subnet.RouteTableID}}
-          {"Ref" : "{{$workerSubnetLogicalName}}RouteTable"},
-          {{else}}
-          "{{$subnet.RouteTableID}}",
-          {{end}}
-        "SubnetId": {
-          "Ref": "{{$workerSubnetLogicalName}}"
-        }
-      },
-      "Type": "AWS::EC2::SubnetRouteTableAssociation"
-    }
-    {{end}}
-    {{end}}
-    {{end}}
 
-    {{if (or .Worker.TopologyPrivate .Etcd.TopologyPrivate .Controller.TopologyPrivate)}}
+    {{if (or .WorkerTopologyPrivate .Etcd.TopologyPrivate .Controller.TopologyPrivate)}}
     {{range $index, $subnet := .Subnets}}
     {{if not $subnet.NatGateway.EIPAllocationID}}
     ,
-    "{{$subnet.LogicalName}}EIPNatGateway": {
+    "NatGateway{{$subnet.AvailabilityZoneLogicalName}}EIP": {
       "Properties": {
         "Domain": "vpc"
       },
@@ -1329,11 +1202,11 @@
     {{end}}
     {{if not $subnet.NatGateway.ID}}
     ,
-    "{{$subnet.LogicalName}}NatGateway": {
+    "NatGateway{{$subnet.AvailabilityZoneLogicalName}}": {
       "Properties": {
         "AllocationId":
           {{if not $subnet.NatGateway.EIPAllocationID}}
-          {"Fn::GetAtt": ["{{$subnet.LogicalName}}EIPNatGateway", "AllocationId"]},
+          {"Fn::GetAtt": ["NatGateway{{$subnet.AvailabilityZoneLogicalName}}EIP", "AllocationId"]},
           {{else}}
           "{{$subnet.NatGateway.EIPAllocationID}}",
           {{end}}
@@ -1342,6 +1215,36 @@
       "Type": "AWS::EC2::NatGateway"
     }
     {{end}}
+    ,
+    "PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "{{$.ClusterName}}-PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}"
+          },
+          {
+            "Key": "KubernetesCluster",
+            "Value": "{{$.ClusterName}}"
+          }
+        ],
+        "VpcId": {{$.VPCRef}}
+      },
+      "Type": "AWS::EC2::RouteTable"
+    },
+    "PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}RouteToNatGateway": {
+      "Properties": {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "NatGatewayId":
+          {{if not $subnet.NatGateway.ID}}
+          {"Ref": "NatGateway{{$subnet.AvailabilityZoneLogicalName}}"},
+          {{else}}
+          "{{$subnet.NatGateway.ID}}",
+          {{end}}
+        "RouteTableId": {"Ref" : "PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}"}
+      },
+      "Type": "AWS::EC2::Route"
+    }
     {{end}}
     {{end}}
 
@@ -1352,7 +1255,7 @@
         "Tags": [
           {
             "Key": "Name",
-            "Value": "{{$.ClusterName}}-igw"
+            "Value": "{{$.ClusterName}}-{{.InternetGatewayLogicalName}}"
           },
           {
             "Key": "KubernetesCluster",
@@ -1405,19 +1308,17 @@
       "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-VPC" }}
     },
     {{end}}
-    {{range $index, $subnet := .Subnets}}
-    "{{$subnet.LogicalName}}" : {
-      "Description" : "The public subnets assigned to worker nodes",
-      "Value" :  { "Ref" : "{{$subnet.LogicalName}}" },
-      "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-{{$subnet.LogicalName}}" }}
+    "PublicRouteTable" : {
+      "Description" : "The public route table assigned to the internet gateway for worker nodes",
+      "Value" :  { "Ref" : "PublicRouteTable" },
+      "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-PublicRouteTable" }}
     },
-    {{end}}
-    {{if (or .Worker.TopologyPrivate)}}
-    {{range $index, $subnet := .Worker.PrivateSubnets}}
-    "{{$subnet.LogicalName}}" : {
-      "Description" : "The private subnets assigned to worker nodes",
-      "Value" :  { "Ref" : "{{$subnet.LogicalName}}" },
-      "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-{{$subnet.LogicalName}}" }}
+    {{if .WorkerTopologyPrivate}}
+    {{range $index, $subnet := .Subnets}}
+    "PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}" : {
+      "Description" : "The private route table assigned to the nat gateway for worker nodes",
+      "Value" :  { "Ref" : "PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}" },
+      "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}" }}
     },
     {{end}}
     {{end}}

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -4,7 +4,7 @@
   "Mappings" : {
     "EtcdInstanceParams" : {
       "UserData" : {
-	"cloudconfig" : "{{.UserDataEtcd}}"
+        "cloudconfig" : "{{.UserDataEtcd}}"
       }
     }
   },
@@ -45,10 +45,10 @@
         ],
         {{end}}
         "VPCZoneIdentifier": [
-          {{range $index, $workerSubnet := .Worker.Subnets}}
+          {{range $index, $subnet := .Worker.Subnets}}
           {{if gt $index 0}},{{end}}
           {
-            "Ref": "{{$.Worker.SubnetLogicalNamePrefix}}{{$workerSubnet.LogicalName}}"
+            "Ref": "{{$.Worker.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}"
           }
           {{end}}
         ]
@@ -146,22 +146,11 @@
           }
         ],
         "VPCZoneIdentifier": [
-          {{if $.Controller.TopologyPrivate}}
-          {{range $index, $controllerSubnet := .Controller.PrivateSubnets}}
-          {{with $controllerSubnetLogicalName := printf "Controller%s" $controllerSubnet.LogicalName}}
+          {{range $index, $subnet := .Controller.Subnets}}
           {{if gt $index 0}},{{end}}
           {
-            "Ref": "{{$controllerSubnetLogicalName}}"
+            "Ref": "{{$.Controller.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}"
           }
-          {{end}}
-          {{end}}
-          {{else}}
-          {{range $index, $subnet := .Subnets}}
-          {{if gt $index 0}},{{end}}
-          {
-            "Ref": "{{$subnet.LogicalName}}"
-          }
-          {{end}}
           {{end}}
         ],
         "LoadBalancerNames" : [
@@ -248,9 +237,9 @@
       "Properties": {
         {{if .HostedZoneID}}
         "HostedZoneId": "{{.HostedZoneID}}",
-	    {{else}}
+        {{else}}
         "HostedZoneName": "{{.HostedZone}}",
-	    {{end}}
+        {{end}}
         "Name": "{{.ExternalDNSName}}",
         "TTL": {{.RecordSetTTL}},
         "ResourceRecords": [{ "Fn::GetAtt": ["ElbAPIServer", "DNSName"]}],
@@ -510,11 +499,7 @@
     "InstanceEtcd{{$etcdIndex}}eni": {
       "Properties": {
           "SubnetId": {
-            {{if $.Etcd.TopologyPrivate}}
-              "Ref": "Etcd{{$etcdInstance.Subnet.LogicalName}}"
-            {{else}}
-              "Ref": "{{$etcdInstance.Subnet.LogicalName}}"
-            {{end}}
+              "Ref": "{{$etcdInstance.SubnetLogicalNamePrefix}}{{$etcdInstance.Subnet.LogicalName}}"
           },
           "GroupSet": [
             {
@@ -537,11 +522,11 @@
               "VolumeType": "{{$.EtcdRootVolumeType}}"
             }
           },
-	      {
+          {
             "DeviceName": "/dev/xvdf",
-	        {{if $.EtcdDataVolumeEphemeral}}
-	        "VirtualName" : "ephemeral0"
-	        {{else}}
+            {{if $.EtcdDataVolumeEphemeral}}
+            "VirtualName" : "ephemeral0"
+            {{else}}
             "Ebs": {
               "VolumeSize": "{{$.EtcdDataVolumeSize}}",
               {{if gt $.EtcdDataVolumeIOPS 0}}
@@ -549,7 +534,7 @@
               {{end}}
               "VolumeType": "{{$.EtcdDataVolumeType}}"
             }
-	        {{end}}
+            {{end}}
           }
         ],
         "IamInstanceProfile": {
@@ -650,7 +635,7 @@
     "ElbAPIServer" : {
       "Type" : "AWS::ElasticLoadBalancing::LoadBalancer",
       "Properties" : {
-	    "CrossZone" : true,
+        "CrossZone" : true,
         "HealthCheck" : {
           "HealthyThreshold" : "3",
           "Interval" : "10",
@@ -659,18 +644,9 @@
           "UnhealthyThreshold" : "3"
         },
         "Subnets" : [
-          {{if .ControllerLoadBalancerPrivate}}
-          {{range $index, $controllerSubnet := .Controller.PrivateSubnets}}
-          {{with $controllerSubnetLogicalName := printf "Controller%s" $controllerSubnet.LogicalName}}
+          {{range $index, $subnet := .ControllerElb.Subnets}}
           {{if gt $index 0}},{{end}}
-          {"Ref": "{{$controllerSubnetLogicalName}}"}
-          {{end}}
-          {{end}}
-          {{else}}
-          {{range $index, $subnet := .Subnets}}
-          {{if gt $index 0}},{{end}}
-          { "Ref" : "{{$subnet.LogicalName}}" }
-          {{end}}
+          {"Ref": "{{$.ControllerElb.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}"}
           {{end}}
         ],
         "Listeners" : [
@@ -1092,12 +1068,12 @@
       },
       "Type": "AWS::EC2::SecurityGroup"
     }
-    {{range $index, $workerSubnet := .Worker.Subnets}}
+    {{range $index, $subnet := .Worker.Subnets}}
     ,
-    "{{$workerSubnet.LogicalName}}MountTarget": {
+    "{{$subnet.LogicalName}}MountTarget": {
       "Properties" : {
         "FileSystemId": "{{$.ElasticFileSystemID}}",
-        "SubnetId": { "Ref": "{{$workerSubnet.LogicalName}}" },
+        "SubnetId": { "Ref": "{{$subnet.LogicalName}}" },
         "SecurityGroups": [ { "Ref": "SecurityGroupMountTarget" } ]
       },
       "Type" : "AWS::EFS::MountTarget"
@@ -1143,18 +1119,17 @@
     {{end}}
 
     {{if $.Etcd.TopologyPrivate}}
-    {{range $index, $subnet := .Etcd.PrivateSubnets}}
-    {{with $etcdSubnetLogicalName := printf "Etcd%s" $subnet.LogicalName}}
+    {{range $etcdIndex, $etcdInstance := .EtcdInstances}}
     ,
-    "{{$etcdSubnetLogicalName}}": {
+    "{{$etcdInstance.SubnetLogicalNamePrefix}}{{$etcdInstance.Subnet.LogicalName}}": {
       "Properties": {
-        "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
-        "CidrBlock": "{{$subnet.InstanceCIDR}}",
+        "AvailabilityZone": "{{$etcdInstance.Subnet.AvailabilityZone}}",
+        "CidrBlock": "{{$etcdInstance.Subnet.InstanceCIDR}}",
         "MapPublicIpOnLaunch": {{not $.Etcd.TopologyPrivate}},
         "Tags": [
           {
             "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$etcdSubnetLogicalName}}"
+            "Value": "{{$.ClusterName}}-{{$etcdInstance.SubnetLogicalNamePrefix}}{{$etcdInstance.Subnet.LogicalName}}"
           },
           {
             "Key": "KubernetesCluster",
@@ -1166,29 +1141,27 @@
       "Type": "AWS::EC2::Subnet"
     }
     ,
-    "{{$etcdSubnetLogicalName}}RouteTableAssociation": {
+    "{{$etcdInstance.SubnetLogicalNamePrefix}}{{$etcdInstance.Subnet.LogicalName}}RouteTableAssociation": {
       "Properties": {
         "RouteTableId":
-          {{if not $subnet.RouteTableID}}
-          {"Ref" : "PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}"},
+          {{if not $etcdInstance.Subnet.RouteTableID}}
+          {"Ref" : "PrivateRouteTable{{$etcdInstance.Subnet.AvailabilityZoneLogicalName}}"},
           {{else}}
-          "{{$subnet.RouteTableID}}",
+          "{{$etcdInstance.Subnet.RouteTableID}}",
           {{end}}
         "SubnetId": {
-          "Ref": "{{$etcdSubnetLogicalName}}"
+          "Ref": "{{$etcdInstance.SubnetLogicalNamePrefix}}{{$etcdInstance.Subnet.LogicalName}}"
         }
       },
       "Type": "AWS::EC2::SubnetRouteTableAssociation"
     }
     {{end}}
     {{end}}
-    {{end}}
 
     {{if $.Controller.TopologyPrivate}}
-    {{range $index, $subnet := .Controller.PrivateSubnets}}
-    {{with $controllerSubnetLogicalName := printf "Controller%s" $subnet.LogicalName}}
+    {{range $index, $subnet := .Controller.Subnets}}
     ,
-    "{{$controllerSubnetLogicalName}}": {
+    "{{$.Controller.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}": {
       "Properties": {
         "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
         "CidrBlock": "{{$subnet.InstanceCIDR}}",
@@ -1196,7 +1169,7 @@
         "Tags": [
           {
             "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$controllerSubnetLogicalName}}"
+            "Value": "{{$.ClusterName}}-{{$.Controller.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}"
           },
           {
             "Key": "KubernetesCluster",
@@ -1208,7 +1181,7 @@
       "Type": "AWS::EC2::Subnet"
     }
     ,
-    "{{$controllerSubnetLogicalName}}RouteTableAssociation": {
+    "{{$.Controller.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}RouteTableAssociation": {
       "Properties": {
         "RouteTableId":
           {{if not $subnet.RouteTableID}}
@@ -1217,12 +1190,11 @@
           "{{$subnet.RouteTableID}}",
           {{end}}
         "SubnetId": {
-          "Ref": "{{$controllerSubnetLogicalName}}"
+          "Ref": "{{$.Controller.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}"
         }
       },
       "Type": "AWS::EC2::SubnetRouteTableAssociation"
     }
-    {{end}}
     {{end}}
     {{end}}
 

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -12,12 +12,6 @@
     {{if .MinWorkerCount}}
     "AutoScaleWorker": {
       "Properties": {
-        "AvailabilityZones": [
-          {{range $index, $workerSubnet := .Worker.Subnets}}
-          {{if gt $index 0}},{{end}}
-          "{{$workerSubnet.AvailabilityZone}}"
-          {{end}}
-        ],
         "HealthCheckGracePeriod": 600,
         "HealthCheckType": "EC2",
         "LaunchConfigurationName": {
@@ -92,19 +86,6 @@
     "AutoScaleController": {
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "Properties": {
-        "AvailabilityZones": [
-          {{if $.Controller.TopologyPrivate}}
-          {{range $index, $controllerSubnet := .Controller.PrivateSubnets}}
-          {{if gt $index 0}},{{end}}
-          "{{$controllerSubnet.AvailabilityZone}}"
-          {{end}}
-          {{else}}
-          {{range $index, $subnet := .Subnets}}
-          {{if gt $index 0}},{{end}}
-          "{{$subnet.AvailabilityZone}}"
-          {{end}}
-          {{end}}
-        ],
         "HealthCheckGracePeriod": 600,
         "HealthCheckType": "EC2",
         "LaunchConfigurationName": {

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -1247,7 +1247,7 @@
       "Type": "AWS::EC2::Route"
     }
 
-    {{if (or .WorkerTopologyPrivate .Etcd.TopologyPrivate .Controller.TopologyPrivate)}}
+    {{if (or .WorkerTopologyPrivate .Worker.TopologyPrivate .Etcd.TopologyPrivate .Controller.TopologyPrivate)}}
     {{range $index, $subnet := .Subnets}}
     {{if not $subnet.NatGateway.EIPAllocationID}}
     ,

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -13,16 +13,9 @@
     "AutoScaleWorker": {
       "Properties": {
         "AvailabilityZones": [
-          {{if $.Worker.TopologyPrivate}}
-          {{range $index, $workerSubnet := .Worker.PrivateSubnets}}
+          {{range $index, $workerSubnet := .Worker.Subnets}}
           {{if gt $index 0}},{{end}}
           "{{$workerSubnet.AvailabilityZone}}"
-          {{end}}
-          {{else}}
-          {{range $index, $subnet := .Subnets}}
-          {{if gt $index 0}},{{end}}
-          "{{$subnet.AvailabilityZone}}"
-          {{end}}
           {{end}}
         ],
         "HealthCheckGracePeriod": 600,
@@ -58,22 +51,11 @@
         ],
         {{end}}
         "VPCZoneIdentifier": [
-          {{if $.Worker.TopologyPrivate}}
-          {{range $index, $workerSubnet := .Worker.PrivateSubnets}}
-          {{with $workerSubnetLogicalName := printf "Worker%s" $workerSubnet.LogicalName}}
+          {{range $index, $workerSubnet := .Worker.Subnets}}
           {{if gt $index 0}},{{end}}
           {
-            "Ref": "{{$workerSubnetLogicalName}}"
+            "Ref": "{{$.Worker.SubnetLogicalNamePrefix}}{{$workerSubnet.LogicalName}}"
           }
-          {{end}}
-          {{end}}
-          {{else}}
-          {{range $index, $subnet := .Subnets}}
-          {{if gt $index 0}},{{end}}
-          {
-            "Ref": "{{$subnet.LogicalName}}"
-          }
-          {{end}}
           {{end}}
         ]
       },
@@ -1059,30 +1041,16 @@
       },
       "Type": "AWS::EC2::SecurityGroup"
     }
-    {{if .Worker.TopologyPrivate}}
-    {{range $index, $subnet := .Worker.PrivateSubnets}}
+    {{range $index, $workerSubnet := .Worker.Subnets}}
     ,
-    "{{$subnet.LogicalName}}MountTarget": {
+    "{{$workerSubnet.LogicalName}}MountTarget": {
       "Properties" : {
         "FileSystemId": "{{$.ElasticFileSystemID}}",
-        "SubnetId": { "Ref": "{{$subnet.LogicalName}}" },
+        "SubnetId": { "Ref": "{{$workerSubnet.LogicalName}}" },
         "SecurityGroups": [ { "Ref": "SecurityGroupMountTarget" } ]
       },
       "Type" : "AWS::EFS::MountTarget"
     }
-    {{end}}
-    {{else}}
-    {{range $index, $subnet := .Subnets}}
-    ,
-    "{{$subnet.LogicalName}}MountTarget": {
-      "Properties" : {
-        "FileSystemId": "{{$.ElasticFileSystemID}}",
-        "SubnetId": { "Ref": "{{$subnet.LogicalName}}" },
-        "SecurityGroups": [ { "Ref": "SecurityGroupMountTarget" } ]
-      },
-      "Type" : "AWS::EFS::MountTarget"
-    }
-    {{end}}
     {{end}}
     {{end}}
 
@@ -1208,10 +1176,9 @@
     {{end}}
 
     {{if $.Worker.TopologyPrivate}}
-    {{range $index, $subnet := .Worker.PrivateSubnets}}
-    {{with $workerSubnetLogicalName := printf "Worker%s" $subnet.LogicalName}}
+    {{range $index, $subnet := .Worker.Subnets}}
     ,
-    "{{$workerSubnetLogicalName}}": {
+    "{{$.Worker.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}": {
       "Properties": {
         "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
         "CidrBlock": "{{$subnet.InstanceCIDR}}",
@@ -1219,7 +1186,7 @@
         "Tags": [
           {
             "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$workerSubnetLogicalName}}"
+            "Value": "{{$.ClusterName}}-{{$.Worker.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}"
           },
           {
             "Key": "KubernetesCluster",
@@ -1231,7 +1198,7 @@
       "Type": "AWS::EC2::Subnet"
     }
     ,
-    "{{$workerSubnetLogicalName}}RouteTableAssociation": {
+    "{{$.Worker.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}RouteTableAssociation": {
       "Properties": {
         "RouteTableId":
           {{if not $subnet.RouteTableID}}
@@ -1240,12 +1207,11 @@
           "{{$subnet.RouteTableID}}",
           {{end}}
         "SubnetId": {
-          "Ref": "{{$workerSubnetLogicalName}}"
+          "Ref": "{{$.Worker.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}"
         }
       },
       "Type": "AWS::EC2::SubnetRouteTableAssociation"
     }
-    {{end}}
     {{end}}
     {{end}}
     ,
@@ -1396,7 +1362,7 @@
       "Value" :  { "Ref" : "PublicRouteTable" },
       "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-PublicRouteTable" }}
     },
-    {{if .WorkerTopologyPrivate}}
+    {{if (or .WorkerTopologyPrivate .Worker.TopologyPrivate .Etcd.TopologyPrivate .Controller.TopologyPrivate)}}
     {{range $index, $subnet := .Subnets}}
     "PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}" : {
       "Description" : "The private route table assigned to the nat gateway for worker nodes",

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -9,6 +9,7 @@
     }
   },
   "Resources": {
+    {{if .MinWorkerCount}}
     "AutoScaleWorker": {
       "Properties": {
         "AvailabilityZones": [
@@ -51,12 +52,10 @@
         {{end}}
         "VPCZoneIdentifier": [
           {{range $index, $subnet := .Subnets}}
-          {{with $subnetLogicalName := printf "Subnet%d" $index}}
           {{if gt $index 0}},{{end}}
           {
-            "Ref": "{{$subnetLogicalName}}"
+            "Ref": "{{$subnet.LogicalName}}"
           }
-          {{end}}
           {{end}}
         ]
       },
@@ -89,10 +88,17 @@
       },
       "DependsOn" : ["AutoScaleController"]
     },
+    {{end}}
     "AutoScaleController": {
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "Properties": {
         "AvailabilityZones": [
+          {{if $.Controller.TopologyPrivate}}
+          {{range $index, $controllerSubnet := .Controller.PrivateSubnets}}
+          {{if gt $index 0}},{{end}}
+          "{{$controllerSubnet.AvailabilityZone}}"
+          {{end}}
+          {{else}}
           {{range $index, $subnet := .Subnets}}
           {{if gt $index 0}},{{end}}
           "{{$subnet.AvailabilityZone}}"
@@ -123,11 +129,20 @@
           }
         ],
         "VPCZoneIdentifier": [
-          {{range $index, $subnet := .Subnets}}
-          {{with $subnetLogicalName := printf "Subnet%d" $index}}
+          {{if $.Controller.TopologyPrivate}}
+          {{range $index, $controllerSubnet := .Controller.PrivateSubnets}}
+          {{with $controllerSubnetLogicalName := printf "Controller%s" $controllerSubnet.LogicalName}}
           {{if gt $index 0}},{{end}}
           {
-            "Ref": "{{$subnetLogicalName}}"
+            "Ref": "{{$controllerSubnetLogicalName}}"
+          }
+          {{end}}
+          {{end}}
+          {{else}}
+          {{range $index, $subnet := .Subnets}}
+          {{if gt $index 0}},{{end}}
+          {
+            "Ref": "{{$subnet.LogicalName}}"
           }
           {{end}}
           {{end}}
@@ -451,7 +466,7 @@
         "KeyName": "{{$.KeyName}}",
         "NetworkInterfaces": [
           {
-            "AssociatePublicIpAddress": {{$.MapPublicIPs}},
+            "AssociatePublicIpAddress": {{not $.Etcd.TopologyPrivate}},
             "DeleteOnTermination": true,
             "DeviceIndex": "0",
             "GroupSet": [
@@ -461,7 +476,11 @@
             ],
             "PrivateIpAddress": "{{$etcdInstance.IPAddress}}",
             "SubnetId": {
-              "Ref": "Subnet{{$etcdInstance.SubnetIndex}}"
+              {{if $.Etcd.TopologyPrivate}}
+              "Ref": "Etcd{{$etcdInstance.Subnet.LogicalName}}"
+              {{else}}
+              "Ref": "{{$etcdInstance.Subnet.LogicalName}}"
+              {{end}}
             }
           }
         ],
@@ -585,36 +604,36 @@
     "ElbAPIServer" : {
       "Type" : "AWS::ElasticLoadBalancing::LoadBalancer",
       "Properties" : {
-	"CrossZone" : true,
-	"HealthCheck" : {
-	  "HealthyThreshold" : "3",
-	  "Interval" : "10",
-	  "Target" : "TCP:443",
-	  "Timeout" : "8",
-	  "UnhealthyThreshold" : "3"
-	},
-	"Subnets" : [
+	    "CrossZone" : true,
+        "HealthCheck" : {
+          "HealthyThreshold" : "3",
+          "Interval" : "10",
+          "Target" : "TCP:443",
+          "Timeout" : "8",
+          "UnhealthyThreshold" : "3"
+        },
+        "Subnets" : [
           {{range $index, $subnet := .Subnets}}
           {{if gt $index 0}},{{end}}
-          { "Ref" : "Subnet{{$index}}" }
+          { "Ref" : "{{$subnet.LogicalName}}" }
           {{end}}
-	],
-	"Listeners" : [
-	  {
-	    "InstancePort" : "443",
-	    "InstanceProtocol" : "TCP",
-	    "LoadBalancerPort" : "443",
-	    "Protocol" : "TCP"
-	  }
-	],
-	{{if .MapPublicIPs}}
-	"Scheme": "internet-facing",
-	{{else}}
-	"Scheme": "internal",
-	{{end}}
-	"SecurityGroups" : [
-	  { "Ref" : "SecurityGroupElbAPIServer" }
-	]
+        ],
+        "Listeners" : [
+          {
+            "InstancePort" : "443",
+            "InstanceProtocol" : "TCP",
+            "LoadBalancerPort" : "443",
+            "Protocol" : "TCP"
+          }
+        ],
+        {{if .MapPublicIPs}}
+        "Scheme": "internet-facing",
+        {{else}}
+        "Scheme": "internal",
+        {{end}}
+        "SecurityGroups" : [
+          { "Ref" : "SecurityGroupElbAPIServer" }
+        ]
       }
     },
     "SecurityGroupElbAPIServer" : {
@@ -998,11 +1017,22 @@
       },
       "Type": "AWS::EC2::SecurityGroup"
     }
-    {{end}}
     {{range $index, $subnet := .Subnets}}
-    {{with $subnetLogicalName := printf "Subnet%d" $index}}
     ,
-    "{{$subnetLogicalName}}": {
+    "{{$subnet.LogicalName}}MountTarget": {
+      "Properties" : {
+        "FileSystemId": "{{$.ElasticFileSystemID}}",
+        "SubnetId": { "Ref": "{{$subnet.LogicalName}}" },
+        "SecurityGroups": [ { "Ref": "SecurityGroupMountTarget" } ]
+      },
+      "Type" : "AWS::EFS::MountTarget"
+    }
+    {{end}}
+    {{end}}
+
+    {{range $index, $subnet := .Subnets}}
+    ,
+    "{{$subnet.LogicalName}}": {
       "Properties": {
         "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
         "CidrBlock": "{{$subnet.InstanceCIDR}}",
@@ -1010,7 +1040,7 @@
         "Tags": [
           {
             "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$subnetLogicalName}}"
+            "Value": "{{$.ClusterName}}-{{$subnet.LogicalName}}"
           },
           {
             "Key": "KubernetesCluster",
@@ -1021,19 +1051,245 @@
       },
       "Type": "AWS::EC2::Subnet"
     }
-    {{if $.ElasticFileSystemID}}
+    {{if not $subnet.RouteTableID}}
     ,
-    "{{$subnetLogicalName}}MountTarget": {
-      "Properties" : {
-        "FileSystemId": "{{$.ElasticFileSystemID}}",
-        "SubnetId": { "Ref": "{{$subnetLogicalName}}" },
-        "SecurityGroups": [ { "Ref": "SecurityGroupMountTarget" } ]
+    "{{$subnet.LogicalName}}RouteTable": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "{{$.ClusterName}}-{{$subnet.LogicalName}}-route-table"
+          },
+          {
+            "Key": "KubernetesCluster",
+            "Value": "{{$.ClusterName}}"
+          }
+        ],
+        "VpcId": {{$.VPCRef}}
       },
-      "Type" : "AWS::EFS::MountTarget"
+      "Type": "AWS::EC2::RouteTable"
+    },
+    "{{$subnet.LogicalName}}RouteToInternet": {
+      "Properties": {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": {{$.InternetGatewayRef}},
+        "RouteTableId": {"Ref" : "{{$subnet.LogicalName}}RouteTable"}
+      },
+      "Type": "AWS::EC2::Route"
+    }
+    {{end}}
+    ,
+    "{{$subnet.LogicalName}}RouteTableAssociation": {
+      "Properties": {
+        "RouteTableId":
+          {{if not $subnet.RouteTableID}}
+          {"Ref" : "{{$subnet.LogicalName}}RouteTable"},
+          {{else}}
+          "{{$subnet.RouteTableID}}",
+          {{end}}
+        "SubnetId": {
+          "Ref": "{{$subnet.LogicalName}}"
+        }
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation"
+    }
+    {{end}}
+
+    {{if $.Etcd.TopologyPrivate}}
+    {{range $index, $subnet := .Etcd.PrivateSubnets}}
+    {{with $etcdSubnetLogicalName := printf "Etcd%d" $subnet.LogicalName}}
+    ,
+    "{{$etcdSubnetLogicalName}}": {
+      "Properties": {
+        "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
+        "CidrBlock": "{{$subnet.InstanceCIDR}}",
+        "MapPublicIpOnLaunch": {{not $.Etcd.TopologyPrivate}},
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "{{$.ClusterName}}-{{$etcdSubnetLogicalName}}"
+          },
+          {
+            "Key": "KubernetesCluster",
+            "Value": "{{$.ClusterName}}"
+          }
+        ],
+        "VpcId": {{$.VPCRef}}
+      },
+      "Type": "AWS::EC2::Subnet"
+    }
+    {{if not $subnet.RouteTableID}}
+    ,
+    "{{$etcdSubnetLogicalName}}RouteTable": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "{{$.ClusterName}}-{{$etcdSubnetLogicalName}}-route-table"
+          },
+          {
+            "Key": "KubernetesCluster",
+            "Value": "{{$.ClusterName}}"
+          }
+        ],
+        "VpcId": {{$.VPCRef}}
+      },
+      "Type": "AWS::EC2::RouteTable"
+    },
+    "{{$etcdSubnetLogicalName}}RouteToNatGateway": {
+      "Properties": {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "NatGatewayId":
+          {{if not $subnet.NatGateway.ID}}
+          {"Ref": "{{$subnet.LogicalName}}NatGateway"},
+          {{else}}
+          "{{$subnet.NatGateway.ID}}",
+          {{end}}
+        "RouteTableId": {"Ref" : "{{$etcdSubnetLogicalName}}RouteTable"}
+      },
+      "Type": "AWS::EC2::Route"
+    }
+    {{end}}
+    ,
+    "{{$etcdSubnetLogicalName}}RouteTableAssociation": {
+      "Properties": {
+        "RouteTableId":
+          {{if not $subnet.RouteTableID}}
+          {"Ref" : "{{$etcdSubnetLogicalName}}RouteTable"},
+          {{else}}
+          "{{$subnet.RouteTableID}}",
+          {{end}}
+        "SubnetId": {
+          "Ref": "{{$etcdSubnetLogicalName}}"
+        }
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation"
     }
     {{end}}
     {{end}}
     {{end}}
+
+    {{if $.Controller.TopologyPrivate}}
+    {{range $index, $subnet := .Controller.PrivateSubnets}}
+    {{with $controllerSubnetLogicalName := printf "Controller%s" $subnet.LogicalName}}
+    ,
+    "{{$controllerSubnetLogicalName}}": {
+      "Properties": {
+        "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
+        "CidrBlock": "{{$subnet.InstanceCIDR}}",
+        "MapPublicIpOnLaunch": {{not $.Controller.TopologyPrivate}},
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "{{$.ClusterName}}-{{$controllerSubnetLogicalName}}"
+          },
+          {
+            "Key": "KubernetesCluster",
+            "Value": "{{$.ClusterName}}"
+          }
+        ],
+        "VpcId": {{$.VPCRef}}
+      },
+      "Type": "AWS::EC2::Subnet"
+    }
+    {{if not $subnet.RouteTableID}}
+    "{{$controllerSubnetLogicalName}}RouteTable": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "{{$.ClusterName}}-{{$controllerSubnetLogicalName}}-route-table"
+          },
+          {
+            "Key": "KubernetesCluster",
+            "Value": "{{$.ClusterName}}"
+          }
+        ],
+        "VpcId": {{$.VPCRef}}
+      },
+      "Type": "AWS::EC2::RouteTable"
+    },
+    "{{$controllerSubnetLogicalName}}RouteToNatGateway": {
+      "Properties": {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "NatGatewayId":
+          {{if not $subnet.NatGateway.ID}}
+          {"Ref": "{{$subnet.LogicalName}}NatGateway"},
+          {{else}}
+          "{{$subnet.NatGateway.ID}}",
+          {{end}}
+        "RouteTableId": {"Ref" : "{{$controllerSubnetLogicalName}}RouteTable"}
+      },
+      "Type": "AWS::EC2::Route"
+    }
+    {{end}}
+    ,
+    "{{$controllerSubnetLogicalName}}RouteTableAssociation": {
+      "Properties": {
+        "RouteTableId":
+          {{if not $subnet.RouteTableID}}
+          {"Ref" : "{{$controllerSubnetLogicalName}}RouteTable"},
+          {{else}}
+          "{{$subnet.RouteTableID}}",
+          {{end}}
+        "SubnetId": {
+          "Ref": "{{$controllerSubnetLogicalName}}"
+        }
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation"
+    }
+    {{end}}
+    {{end}}
+    {{end}}
+
+    {{if (or .Worker.TopologyPrivate .Etcd.TopologyPrivate .Controller.TopologyPrivate)}}
+    {{range $index, $subnet := .Subnets}}
+    {{if not $subnet.NatGateway.EIPAllocationID}}
+    ,
+    "{{$subnet.LogicalName}}EIPNatGateway": {
+      "Properties": {
+        "Domain": "vpc"
+      },
+      "Type": "AWS::EC2::EIP"
+    }
+    {{end}}
+    {{if not $subnet.NatGateway.ID}}
+    ,
+    "{{$subnet.LogicalName}}NatGateway": {
+      "Properties": {
+        "AllocationId":
+          {{if not $subnet.NatGateway.EIPAllocationID}}
+          {"Fn::GetAtt": ["{{$subnet.LogicalName}}EIPNatGateway", "AllocationId"]},
+          {{else}}
+          "{{$subnet.NatGateway.EIPAllocationID}}",
+          {{end}}
+        "SubnetId": { "Ref": "{{$subnet.LogicalName}}" }
+      },
+      "Type": "AWS::EC2::NatGateway"
+    }
+    {{end}}
+    {{end}}
+    {{end}}
+
+    {{if not .InternetGatewayID}}
+    ,
+    "{{.InternetGatewayLogicalName}}": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "{{$.ClusterName}}-igw"
+          },
+          {
+            "Key": "KubernetesCluster",
+            "Value": "{{.ClusterName}}"
+          }
+        ]
+      },
+      "Type": "AWS::EC2::InternetGateway"
+    }
+    {{end}}
+
     {{if not .VPCID}}
     ,
     "{{.VPCLogicalName}}": {
@@ -1055,103 +1311,34 @@
       },
       "Type": "AWS::EC2::VPC"
     },
-    "RouteTable": {
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "{{$.ClusterName}}-route-table"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{.ClusterName}}"
-          }
-        ],
-        "VpcId": {{.VPCRef}}
-      },
-      "Type": "AWS::EC2::RouteTable"
-    },
-    "RouteToInternet": {
-      "Properties": {
-        "DestinationCidrBlock": "0.0.0.0/0",
-        "GatewayId": {
-          "Ref": "InternetGateway"
-        },
-        "RouteTableId": { "Ref" : "RouteTable" }
-      },
-      "Type": "AWS::EC2::Route"
-    },
-    "InternetGateway": {
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "{{$.ClusterName}}-igw"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{.ClusterName}}"
-          }
-        ]
-      },
-      "Type": "AWS::EC2::InternetGateway"
-    },
     "VPCGatewayAttachment": {
       "Properties": {
         "InternetGatewayId": {
-          "Ref": "InternetGateway"
+          "Ref": {{.InternetGatewayRef}}
         },
         "VpcId": {{.VPCRef}}
       },
       "Type": "AWS::EC2::VPCGatewayAttachment"
     }
-    {{range $index, $subnet := .Subnets}}
-    {{with $subnetLogicalName := printf "Subnet%d" $index}}
-    ,
-    "{{$subnetLogicalName}}RouteTableAssociation": {
-      "Properties": {
-        "RouteTableId": { "Ref" : "RouteTable"},
-        "SubnetId": {
-          "Ref": "{{$subnetLogicalName}}"
-        }
-      },
-      "Type": "AWS::EC2::SubnetRouteTableAssociation"
-    }
     {{end}}
-    {{end}}
-    {{else}}
-    {{if .RouteTableID}}
-    {{range $index, $subnet := .Subnets}}
-    {{with $subnetLogicalName := printf "Subnet%d" $index}}
-    ,
-    "{{$subnetLogicalName}}RouteTableAssociation": {
-      "Properties": {
-        "RouteTableId": "{{$.RouteTableID}}",
-        "SubnetId": {
-          "Ref": "{{$subnetLogicalName}}"
-        }
-      },
-      "Type": "AWS::EC2::SubnetRouteTableAssociation"
-    }
-    {{end}}
-    {{end}}
-    {{end}}
-    {{end}}
-
   },
 
   "Outputs": {
     {{if not .VPCID}}
-    "RouteTable" : {
-      "Description" : "The route table assigned managed by this stack",
-      "Value" :  { "Ref" : "RouteTable" },
-      "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-RouteTable" }}
-    },
     "VPC" : {
       "Description" : "The VPC managed by this stack",
       "Value" :  { "Ref" : "{{.VPCLogicalName}}" },
       "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-VPC" }}
     },
+    {{end}}
+    {{if (or .Worker.TopologyPrivate .Etcd.TopologyPrivate .Controller.TopologyPrivate)}}
+    {{range $index, $subnet := .Subnets}}
+    "{{$subnet.LogicalName}}NatGateway" : {
+      "Description" : "The nat gateway assignedd managed by this stack subnet",
+      "Value" :  { "Ref" : "{{$subnet.LogicalName}}NatGateway" },
+      "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-{{$subnet.LogicalName}}NatGateway" }}
+    },
+    {{end}}
     {{end}}
     "WorkerSecurityGroup" : {
       "Description" : "The security group assigned to worker nodes",

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -121,6 +121,7 @@
           {{if gt $index 0}},{{end}}
           "{{$subnet.AvailabilityZone}}"
           {{end}}
+          {{end}}
         ],
         "HealthCheckGracePeriod": 600,
         "HealthCheckType": "EC2",

--- a/model/controller.go
+++ b/model/controller.go
@@ -2,7 +2,7 @@ package model
 
 type Controller struct {
 	AutoScalingGroup `yaml:"autoScalingGroup,omitempty"`
-	PrivateSubnets   []*Subnet `yaml:"privateSubnets,omitempty"`
+	PrivateSubnets   []*PrivateSubnet `yaml:"privateSubnets,omitempty"`
 }
 
 func (c Controller) TopologyPrivate() bool {

--- a/model/controller.go
+++ b/model/controller.go
@@ -2,4 +2,9 @@ package model
 
 type Controller struct {
 	AutoScalingGroup `yaml:"autoScalingGroup,omitempty"`
+	PrivateSubnets   []*Subnet `yaml:"privateSubnets,omitempty"`
+}
+
+func (c Controller) TopologyPrivate() bool {
+	return len(c.PrivateSubnets) > 0
 }

--- a/model/controller.go
+++ b/model/controller.go
@@ -2,13 +2,35 @@ package model
 
 type Controller struct {
 	AutoScalingGroup `yaml:"autoScalingGroup,omitempty"`
-	PrivateSubnets   []*PrivateSubnet `yaml:"privateSubnets,omitempty"`
+	Subnets          []*Subnet `yaml:"subnets,omitempty"`
 }
 
 func (c Controller) TopologyPrivate() bool {
-	return len(c.PrivateSubnets) > 0
+	if len(c.Subnets) > 0 {
+		return !c.Subnets[0].TopLevel
+	}
+	return false
 }
 
 func (c Controller) LogicalName() string {
 	return "Controllers"
+}
+
+func (c Controller) SubnetLogicalNamePrefix() string {
+	if c.TopologyPrivate() == true {
+		return "Controller"
+	}
+	return ""
+}
+
+type ControllerElb struct {
+	Private bool
+	Subnets []*Subnet
+}
+
+func (c ControllerElb) SubnetLogicalNamePrefix() string {
+	if c.Private == true {
+		return "Controller"
+	}
+	return ""
 }

--- a/model/etcd.go
+++ b/model/etcd.go
@@ -1,7 +1,7 @@
 package model
 
 type Etcd struct {
-	PrivateSubnets   []*Subnet `yaml:"privateSubnets,omitempty"`
+	PrivateSubnets   []*PrivateSubnet `yaml:"privateSubnets,omitempty"`
 }
 
 func (c Etcd) TopologyPrivate() bool {

--- a/model/etcd.go
+++ b/model/etcd.go
@@ -9,5 +9,5 @@ func (c Etcd) TopologyPrivate() bool {
 }
 
 type EtcdInstance struct {
-	Subnet  Subneter
+	Subnet Subneter
 }

--- a/model/etcd.go
+++ b/model/etcd.go
@@ -1,7 +1,7 @@
 package model
 
 type Etcd struct {
-	PrivateSubnets   []*PrivateSubnet `yaml:"privateSubnets,omitempty"`
+	PrivateSubnets []*PrivateSubnet `yaml:"privateSubnets,omitempty"`
 }
 
 func (c Etcd) TopologyPrivate() bool {

--- a/model/etcd.go
+++ b/model/etcd.go
@@ -1,13 +1,20 @@
 package model
 
 type Etcd struct {
-	PrivateSubnets []*PrivateSubnet `yaml:"privateSubnets,omitempty"`
+	Subnets []*Subnet `yaml:"subnets,omitempty"`
 }
 
 func (c Etcd) TopologyPrivate() bool {
-	return len(c.PrivateSubnets) > 0
+	return len(c.Subnets) > 0
 }
 
 type EtcdInstance struct {
-	Subnet Subneter
+	Subnet Subnet
+}
+
+func (c EtcdInstance) SubnetLogicalNamePrefix() string {
+	if c.Subnet.TopLevel == false {
+		return "Etcd"
+	}
+	return ""
 }

--- a/model/etcd.go
+++ b/model/etcd.go
@@ -1,0 +1,9 @@
+package model
+
+type Etcd struct {
+	PrivateSubnets   []*Subnet `yaml:"privateSubnets,omitempty"`
+}
+
+func (c Etcd) TopologyPrivate() bool {
+	return len(c.PrivateSubnets) > 0
+}

--- a/model/subnet.go
+++ b/model/subnet.go
@@ -10,10 +10,10 @@ type Subneter interface {
 
 type Subnet struct {
 	//ID                string `yaml:"id,omitempty"`
-	AvailabilityZone  string `yaml:"availabilityZone,omitempty"`
-	InstanceCIDR      string `yaml:"instanceCIDR,omitempty"`
-	RouteTableID      string `yaml:"routeTableId,omitempty"`
-	NatGateway        NatGateway `yaml:"natGateway,omitempty"`
+	AvailabilityZone string     `yaml:"availabilityZone,omitempty"`
+	InstanceCIDR     string     `yaml:"instanceCIDR,omitempty"`
+	RouteTableID     string     `yaml:"routeTableId,omitempty"`
+	NatGateway       NatGateway `yaml:"natGateway,omitempty"`
 }
 
 func (c Subnet) AvailabilityZoneLogicalName() string {

--- a/model/subnet.go
+++ b/model/subnet.go
@@ -1,6 +1,8 @@
 package model
 
-import "strings"
+import (
+	"strings"
+)
 
 type Subneter interface {
 	LogicalName() string
@@ -14,8 +16,12 @@ type Subnet struct {
 	NatGateway        NatGateway `yaml:"natGateway,omitempty"`
 }
 
+func (c Subnet) AvailabilityZoneLogicalName() string {
+	return strings.Replace(strings.Title(c.AvailabilityZone), "-", "", -1)
+}
+
 func (c Subnet) LogicalName() string {
-	return "Subnet" + strings.Replace(strings.Title(c.AvailabilityZone), "-", "", -1)
+	return "Subnet" + c.AvailabilityZoneLogicalName()
 }
 
 type PrivateSubnet struct {
@@ -23,7 +29,7 @@ type PrivateSubnet struct {
 }
 
 func (c PrivateSubnet) LogicalName() string {
-	return "PrivateSubnet" + strings.Replace(strings.Title(c.AvailabilityZone), "-", "", -1)
+	return "Private" + c.Subnet.LogicalName()
 }
 
 type NatGateway struct {

--- a/model/subnet.go
+++ b/model/subnet.go
@@ -2,18 +2,31 @@ package model
 
 import "strings"
 
+type Subneter interface {
+	LogicalName() string
+}
+
 type Subnet struct {
-	AvailabilityZone  string     `yaml:"availabilityZone,omitempty"`
-	InstanceCIDR      string     `yaml:"instanceCIDR,omitempty"`
-	RouteTableID      string     `yaml:"routeTableId,omitempty"`
+	//ID                string `yaml:"id,omitempty"`
+	AvailabilityZone  string `yaml:"availabilityZone,omitempty"`
+	InstanceCIDR      string `yaml:"instanceCIDR,omitempty"`
+	RouteTableID      string `yaml:"routeTableId,omitempty"`
 	NatGateway        NatGateway `yaml:"natGateway,omitempty"`
+}
+
+func (c Subnet) LogicalName() string {
+	return "Subnet" + strings.Replace(strings.Title(c.AvailabilityZone), "-", "", -1)
+}
+
+type PrivateSubnet struct {
+	Subnet `yaml:",inline"`
+}
+
+func (c PrivateSubnet) LogicalName() string {
+	return "PrivateSubnet" + strings.Replace(strings.Title(c.AvailabilityZone), "-", "", -1)
 }
 
 type NatGateway struct {
 	ID              string `yaml:"id,omitempty"`
 	EIPAllocationID string `yaml:"eipAllocationId,omitempty"`
-}
-
-func (c Subnet) LogicalName() string {
-	return "Subnet" + strings.Replace(strings.Title(c.AvailabilityZone), "-", "", -1)
 }

--- a/model/subnet.go
+++ b/model/subnet.go
@@ -1,0 +1,19 @@
+package model
+
+import "strings"
+
+type Subnet struct {
+	AvailabilityZone  string     `yaml:"availabilityZone,omitempty"`
+	InstanceCIDR      string     `yaml:"instanceCIDR,omitempty"`
+	RouteTableID      string     `yaml:"routeTableId,omitempty"`
+	NatGateway        NatGateway `yaml:"natGateway,omitempty"`
+}
+
+type NatGateway struct {
+	ID              string `yaml:"id,omitempty"`
+	EIPAllocationID string `yaml:"eipAllocationId,omitempty"`
+}
+
+func (c Subnet) LogicalName() string {
+	return "Subnet" + strings.Replace(strings.Title(c.AvailabilityZone), "-", "", -1)
+}

--- a/model/subnet.go
+++ b/model/subnet.go
@@ -4,16 +4,13 @@ import (
 	"strings"
 )
 
-type Subneter interface {
-	LogicalName() string
-}
-
 type Subnet struct {
 	//ID                string `yaml:"id,omitempty"`
 	AvailabilityZone string     `yaml:"availabilityZone,omitempty"`
 	InstanceCIDR     string     `yaml:"instanceCIDR,omitempty"`
 	RouteTableID     string     `yaml:"routeTableId,omitempty"`
 	NatGateway       NatGateway `yaml:"natGateway,omitempty"`
+	TopLevel         bool
 }
 
 func (c Subnet) AvailabilityZoneLogicalName() string {
@@ -21,15 +18,10 @@ func (c Subnet) AvailabilityZoneLogicalName() string {
 }
 
 func (c Subnet) LogicalName() string {
-	return "Subnet" + c.AvailabilityZoneLogicalName()
-}
-
-type PrivateSubnet struct {
-	Subnet `yaml:",inline"`
-}
-
-func (c PrivateSubnet) LogicalName() string {
-	return "Private" + c.Subnet.LogicalName()
+	if c.TopLevel == true {
+		return "Subnet" + c.AvailabilityZoneLogicalName()
+	}
+	return "PrivateSubnet" + c.AvailabilityZoneLogicalName()
 }
 
 type NatGateway struct {

--- a/model/worker.go
+++ b/model/worker.go
@@ -6,6 +6,7 @@ type Worker struct {
 	AutoScalingGroup  `yaml:"autoScalingGroup,omitempty"`
 	ClusterAutoscaler ClusterAutoscaler `yaml:"clusterAutoscaler"`
 	SpotFleet         `yaml:"spotFleet,omitempty"`
+	TopologyPrivate    bool `yaml:"topologyPrivate,omitempty"`
 }
 
 type ClusterAutoscaler struct {

--- a/model/worker.go
+++ b/model/worker.go
@@ -6,7 +6,11 @@ type Worker struct {
 	AutoScalingGroup  `yaml:"autoScalingGroup,omitempty"`
 	ClusterAutoscaler ClusterAutoscaler `yaml:"clusterAutoscaler"`
 	SpotFleet         `yaml:"spotFleet,omitempty"`
-	TopologyPrivate    bool `yaml:"topologyPrivate,omitempty"`
+	PrivateSubnets    []*PrivateSubnet `yaml:"privateSubnets,omitempty"`
+}
+
+func (c Worker) TopologyPrivate() bool {
+	return len(c.PrivateSubnets) > 0
 }
 
 type ClusterAutoscaler struct {

--- a/model/worker.go
+++ b/model/worker.go
@@ -6,28 +6,19 @@ type Worker struct {
 	AutoScalingGroup  `yaml:"autoScalingGroup,omitempty"`
 	ClusterAutoscaler ClusterAutoscaler `yaml:"clusterAutoscaler"`
 	SpotFleet         `yaml:"spotFleet,omitempty"`
-	PrivateSubnets    []*PrivateSubnet `yaml:"privateSubnets,omitempty"`
-	PublicSubnets     []*Subnet
+	Subnets           []*Subnet `yaml:"subnets,omitempty"`
 }
 
 func (c Worker) TopologyPrivate() bool {
-	return len(c.PrivateSubnets) > 0
-}
-
-func (c Worker) Subnets() []*Subnet {
-	if len(c.PrivateSubnets) > 0 {
-		var subnets []*Subnet
-		for _, privateSubnet := range c.PrivateSubnets {
-			subnets = append(subnets, &privateSubnet.Subnet)
-		}
-		return subnets
+	if len(c.Subnets) > 0 {
+		return !c.Subnets[0].TopLevel
 	}
-	return c.PublicSubnets
+	return false
 }
 
 func (c Worker) SubnetLogicalNamePrefix() string {
-	if len(c.PrivateSubnets) > 0 {
-		return "WorkerPrivate"
+	if c.TopologyPrivate() == true {
+		return "Worker"
 	}
 	return ""
 }

--- a/model/worker.go
+++ b/model/worker.go
@@ -7,10 +7,29 @@ type Worker struct {
 	ClusterAutoscaler ClusterAutoscaler `yaml:"clusterAutoscaler"`
 	SpotFleet         `yaml:"spotFleet,omitempty"`
 	PrivateSubnets    []*PrivateSubnet `yaml:"privateSubnets,omitempty"`
+	PublicSubnets     []*Subnet
 }
 
 func (c Worker) TopologyPrivate() bool {
 	return len(c.PrivateSubnets) > 0
+}
+
+func (c Worker) Subnets() []*Subnet {
+	if len(c.PrivateSubnets) > 0 {
+		var subnets []*Subnet
+		for _, privateSubnet := range c.PrivateSubnets {
+			subnets = append(subnets, &privateSubnet.Subnet)
+		}
+		return subnets
+	}
+	return c.PublicSubnets
+}
+
+func (c Worker) SubnetLogicalNamePrefix() string {
+	if len(c.PrivateSubnets) > 0 {
+		return "WorkerPrivate"
+	}
+	return ""
 }
 
 type ClusterAutoscaler struct {

--- a/nodepool/config/config.go
+++ b/nodepool/config/config.go
@@ -154,7 +154,7 @@ func ClusterFromBytes(data []byte) (*ProvidedConfig, error) {
 
 	// For backward-compatibility
 	if len(c.Subnets) == 0 {
-		c.Subnets = []*cfg.Subnet{
+		c.Subnets = []*model.Subnet{
 			{
 				AvailabilityZone: c.AvailabilityZone,
 				InstanceCIDR:     c.InstanceCIDR,

--- a/nodepool/config/config.go
+++ b/nodepool/config/config.go
@@ -162,6 +162,11 @@ func ClusterFromBytes(data []byte) (*ProvidedConfig, error) {
 		}
 	}
 
+	// Populate subnets
+	if len(c.Subnets) > 0 && c.WorkerSettings.TopologyPrivate() == false {
+		c.WorkerSettings.PublicSubnets = c.Subnets
+	}
+
 	return c, nil
 }
 

--- a/nodepool/config/config.go
+++ b/nodepool/config/config.go
@@ -225,13 +225,6 @@ func (c ComputedConfig) VPCRef() string {
 	return fmt.Sprintf(`{"Fn::ImportValue" : {"Fn::Sub" : "%s-VPC"}}`, c.ClusterName)
 }
 
-func (c ComputedConfig) RouteTableRef() string {
-	if c.RouteTableID != "" {
-		return fmt.Sprintf("%q", c.RouteTableID)
-	}
-	return fmt.Sprintf(`{"Fn::ImportValue" : {"Fn::Sub" : "%s-RouteTable"}}`, c.ClusterName)
-}
-
 func (c ComputedConfig) WorkerSecurityGroupRefs() []string {
 	refs := c.WorkerDeploymentSettings().WorkerSecurityGroupRefs()
 

--- a/nodepool/config/config.go
+++ b/nodepool/config/config.go
@@ -183,9 +183,9 @@ func ClusterFromBytes(data []byte, main *cfg.Config) (*ProvidedConfig, error) {
 		}
 	}
 
-	// Populate subnets
-	if len(c.Subnets) > 0 && c.WorkerSettings.TopologyPrivate() == false {
-		c.WorkerSettings.PublicSubnets = c.Subnets
+	// Mark top-level subnets appropriately
+	for _, subnet := range c.Subnets {
+		subnet.TopLevel = true
 	}
 
 	c.EtcdInstances = main.EtcdInstances
@@ -203,6 +203,11 @@ func (c ProvidedConfig) Config() (*ComputedConfig, error) {
 		}
 	} else {
 		config.AMI = c.AmiId
+	}
+
+	// Populate top-level subnets to model
+	if len(c.Subnets) > 0 && c.WorkerSettings.TopologyPrivate() == false {
+		c.WorkerSettings.Subnets = c.Subnets
 	}
 
 	return &config, nil

--- a/nodepool/config/templates/stack-template.json
+++ b/nodepool/config/templates/stack-template.json
@@ -57,12 +57,6 @@
 {{define "AutoScaling"}}
     "AutoScaleWorker": {
       "Properties": {
-        "AvailabilityZones": [
-          {{range $index, $workerSubnet := .Worker.Subnets}}
-          {{if gt $index 0}},{{end}}
-          "{{$workerSubnet.AvailabilityZone}}"
-          {{end}}
-        ],
         "HealthCheckGracePeriod": 600,
         "HealthCheckType": "EC2",
         "LaunchConfigurationName": {

--- a/nodepool/config/templates/stack-template.json
+++ b/nodepool/config/templates/stack-template.json
@@ -96,10 +96,10 @@
         ],
         {{if .Experimental.LoadBalancer.Enabled}}
         "LoadBalancerNames" : [
-        {{range $index, $elb := .Experimental.LoadBalancer.Names}}
-        {{if $index}},{{end}}
+          {{range $index, $elb := .Experimental.LoadBalancer.Names}}
+          {{if $index}},{{end}}
           "{{$elb}}"
-        {{end}}
+          {{end}}
         ],
         {{end}}
         "VPCZoneIdentifier": [

--- a/nodepool/config/templates/stack-template.json
+++ b/nodepool/config/templates/stack-template.json
@@ -8,8 +8,7 @@
         "TargetCapacity": {{$.Worker.SpotFleet.TargetCapacity}},
         "SpotPrice": "{{$.Worker.SpotFleet.SpotPrice}}",
         "LaunchSpecifications": [
-          {{if .Worker.TopologyPrivate}}
-          {{range $subnetIndex, $subnet := $.Worker.PrivateSubnets}}
+          {{range $subnetIndex, $workerSubnet := $.Worker.Subnets}}
           {{range $specIndex, $spec := $.Worker.SpotFleet.LaunchSpecifications}}
           {{if or (gt $subnetIndex 0) (gt $specIndex 0) }},{{end}}
           {
@@ -44,53 +43,10 @@
               {{end}}
             ],
             "SubnetId": {
-              "Ref": "{{$subnet.LogicalName}}"
+              "Ref": "{{$.Worker.SubnetLogicalNamePrefix}}{{$workerSubnet.LogicalName}}"
             },
             "UserData": "{{$.UserDataWorker}}"
           }
-          {{end}}
-          {{end}}
-          {{else}}
-          {{range $subnetIndex, $subnet := $.Subnets}}
-          {{range $specIndex, $spec := $.Worker.SpotFleet.LaunchSpecifications}}
-          {{if or (gt $subnetIndex 0) (gt $specIndex 0) }},{{end}}
-          {
-            "ImageId": "{{$.AMI}}",
-            "InstanceType": "{{$spec.InstanceType}}",
-            "KeyName": "{{$.KeyName}}",
-            "WeightedCapacity": {{$spec.WeightedCapacity}},
-            {{if $spec.SpotPrice}}
-            "SpotPrice": "{{$spec.SpotPrice}}",
-            {{end}}
-            "IamInstanceProfile": {
-              "Arn": {
-                "Fn::GetAtt" : ["IAMInstanceProfileWorker", "Arn"]
-              }
-            },
-            "BlockDeviceMappings": [
-              {
-                "DeviceName": "/dev/xvda",
-                "Ebs": {
-                  "VolumeSize": "{{$spec.RootVolumeSize}}",
-                  {{if gt $spec.RootVolumeIOPS 0}}
-                  "Iops": "{{$spec.RootVolumeIOPS}}",
-                  {{end}}
-                  "VolumeType": "{{$spec.RootVolumeType}}"
-                }
-              }
-            ],
-            "SecurityGroups": [
-              {{range $sgIndex, $sgRef := $.WorkerSecurityGroupRefs}}
-              {{if gt $sgIndex 0}},{{end}}
-              {"GroupId":{{$sgRef}}}
-              {{end}}
-            ],
-            "SubnetId": {
-              "Ref": "{{$subnet.LogicalName}}"
-            },
-            "UserData": "{{$.UserDataWorker}}"
-          }
-          {{end}}
           {{end}}
           {{end}}
         ]
@@ -102,16 +58,9 @@
     "AutoScaleWorker": {
       "Properties": {
         "AvailabilityZones": [
-          {{if .Worker.TopologyPrivate}}
-          {{range $index, $subnet := .Worker.PrivateSubnets}}
+          {{range $index, $workerSubnet := .Worker.Subnets}}
           {{if gt $index 0}},{{end}}
-          "{{$subnet.AvailabilityZone}}"
-          {{end}}
-          {{else}}
-          {{range $index, $subnet := .Subnets}}
-          {{if gt $index 0}},{{end}}
-          "{{$subnet.AvailabilityZone}}"
-          {{end}}
+          "{{$workerSubnet.AvailabilityZone}}"
           {{end}}
         ],
         "HealthCheckGracePeriod": 600,
@@ -152,20 +101,11 @@
         ],
         {{end}}
         "VPCZoneIdentifier": [
-          {{if .Worker.TopologyPrivate}}
-          {{range $index, $subnet := .Worker.PrivateSubnets}}
+          {{range $index, $workerSubnet := .Worker.Subnets}}
           {{if gt $index 0}},{{end}}
           {
-            "Ref": "{{$subnet.LogicalName}}"
+            "Ref": "{{$.Worker.SubnetLogicalNamePrefix}}{{$workerSubnet.LogicalName}}"
           }
-          {{end}}
-          {{else}}
-          {{range $index, $subnet := .Subnets}}
-          {{if gt $index 0}},{{end}}
-          {
-            "Ref": "{{$subnet.LogicalName}}"
-          }
-          {{end}}
           {{end}}
         ]
       },
@@ -375,37 +315,22 @@
     }
 
     {{if $.ElasticFileSystemID}}
-    {{if $.Worker.TopologyPrivate}}
-    {{range $index, $subnet := .Worker.PrivateSubnets}}
+    {{range $index, $subnet := .Worker.Subnets}}
     ,
-    "{{$subnet.LogicalName}}MountTarget": {
+    "{{$.Worker.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}MountTarget": {
       "Properties" : {
         "FileSystemId": "{{$.ElasticFileSystemID}}",
-        "SubnetId": { "Ref": "{{$subnet.LogicalName}}" },
+        "SubnetId": { "Ref": "{{$.Worker.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}" },
         "SecurityGroups": [ { "Ref": "SecurityGroupMountTarget" } ]
       },
       "Type" : "AWS::EFS::MountTarget"
     }
-    {{end}}
-    {{else}}
-    {{range $index, $subnet := .Subnets}}
-    ,
-    "{{$subnet.LogicalName}}MountTarget": {
-      "Properties" : {
-        "FileSystemId": "{{$.ElasticFileSystemID}}",
-        "SubnetId": { "Ref": "{{$subnet.LogicalName}}" },
-        "SecurityGroups": [ { "Ref": "SecurityGroupMountTarget" } ]
-      },
-      "Type" : "AWS::EFS::MountTarget"
-    }
-    {{end}}
     {{end}}
     {{end}}
 
-    {{if $.Worker.TopologyPrivate}}
-    {{range $index, $subnet := .Worker.PrivateSubnets}}
+    {{range $index, $subnet := .Worker.Subnets}}
     ,
-    "{{$subnet.LogicalName}}": {
+    "{{$.Worker.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}": {
       "Properties": {
         "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
         "CidrBlock": "{{$subnet.InstanceCIDR}}",
@@ -413,7 +338,7 @@
         "Tags": [
           {
             "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$.NodePoolName}}-{{$subnet.LogicalName}}"
+            "Value": "{{$.ClusterName}}-{{$.NodePoolName}}-{{$.Worker.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}"
           },
           {
             "Key": "KubernetesCluster",
@@ -424,7 +349,7 @@
       },
       "Type": "AWS::EC2::Subnet"
     },
-    "{{$subnet.LogicalName}}RouteTableAssociation": {
+    "{{$.Worker.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}RouteTableAssociation": {
       "Properties": {
         "RouteTableId":
           {{if not $subnet.RouteTableID}}
@@ -433,49 +358,11 @@
           "{{$subnet.RouteTableID}}",
           {{end}}
         "SubnetId": {
-          "Ref": "{{$subnet.LogicalName}}"
+          "Ref": "{{$.Worker.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}"
         }
       },
       "Type": "AWS::EC2::SubnetRouteTableAssociation"
     }
-    {{end}}
-    {{else}}
-    {{range $index, $subnet := .Subnets}}
-    ,
-    "{{$subnet.LogicalName}}": {
-      "Properties": {
-        "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
-        "CidrBlock": "{{$subnet.InstanceCIDR}}",
-        "MapPublicIpOnLaunch": {{$.MapPublicIPs}},
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$.NodePoolName}}-{{$subnet.LogicalName}}"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{$.ClusterName}}"
-          }
-        ],
-        "VpcId": {{$.VPCRef}}
-      },
-      "Type": "AWS::EC2::Subnet"
-    },
-    "{{$subnet.LogicalName}}RouteTableAssociation": {
-      "Properties": {
-        "RouteTableId":
-          {{if not $.RouteTableID}}
-          {"Fn::ImportValue" : {"Fn::Sub" : "{{$.ClusterName}}-PublicRouteTable"}},
-          {{else}}
-          "{{$.RouteTableID}}",
-          {{end}}
-        "SubnetId": {
-          "Ref": "{{$subnet.LogicalName}}"
-        }
-      },
-      "Type": "AWS::EC2::SubnetRouteTableAssociation"
-    }
-    {{end}}
     {{end}}
   }
 }

--- a/nodepool/config/templates/stack-template.json
+++ b/nodepool/config/templates/stack-template.json
@@ -8,8 +8,8 @@
         "TargetCapacity": {{$.Worker.SpotFleet.TargetCapacity}},
         "SpotPrice": "{{$.Worker.SpotFleet.SpotPrice}}",
         "LaunchSpecifications": [
-          {{range $subnetIndex, $subnet := $.Subnets}}
-          {{with $subnetLogicalName := printf "Subnet%d" $subnetIndex}}
+          {{if .Worker.TopologyPrivate}}
+          {{range $subnetIndex, $subnet := $.Worker.PrivateSubnets}}
           {{range $specIndex, $spec := $.Worker.SpotFleet.LaunchSpecifications}}
           {{if or (gt $subnetIndex 0) (gt $specIndex 0) }},{{end}}
           {
@@ -44,7 +44,49 @@
               {{end}}
             ],
             "SubnetId": {
-              "Ref": "{{$subnetLogicalName}}"
+              "Ref": "{{$subnet.LogicalName}}"
+            },
+            "UserData": "{{$.UserDataWorker}}"
+          }
+          {{end}}
+          {{end}}
+          {{else}}
+          {{range $subnetIndex, $subnet := $.Subnets}}
+          {{range $specIndex, $spec := $.Worker.SpotFleet.LaunchSpecifications}}
+          {{if or (gt $subnetIndex 0) (gt $specIndex 0) }},{{end}}
+          {
+            "ImageId": "{{$.AMI}}",
+            "InstanceType": "{{$spec.InstanceType}}",
+            "KeyName": "{{$.KeyName}}",
+            "WeightedCapacity": {{$spec.WeightedCapacity}},
+            {{if $spec.SpotPrice}}
+            "SpotPrice": "{{$spec.SpotPrice}}",
+            {{end}}
+            "IamInstanceProfile": {
+              "Arn": {
+                "Fn::GetAtt" : ["IAMInstanceProfileWorker", "Arn"]
+              }
+            },
+            "BlockDeviceMappings": [
+              {
+                "DeviceName": "/dev/xvda",
+                "Ebs": {
+                  "VolumeSize": "{{$spec.RootVolumeSize}}",
+                  {{if gt $spec.RootVolumeIOPS 0}}
+                  "Iops": "{{$spec.RootVolumeIOPS}}",
+                  {{end}}
+                  "VolumeType": "{{$spec.RootVolumeType}}"
+                }
+              }
+            ],
+            "SecurityGroups": [
+              {{range $sgIndex, $sgRef := $.WorkerSecurityGroupRefs}}
+              {{if gt $sgIndex 0}},{{end}}
+              {"GroupId":{{$sgRef}}}
+              {{end}}
+            ],
+            "SubnetId": {
+              "Ref": "{{$subnet.LogicalName}}"
             },
             "UserData": "{{$.UserDataWorker}}"
           }
@@ -60,9 +102,16 @@
     "AutoScaleWorker": {
       "Properties": {
         "AvailabilityZones": [
+          {{if .Worker.TopologyPrivate}}
+          {{range $index, $subnet := .Worker.PrivateSubnets}}
+          {{if gt $index 0}},{{end}}
+          "{{$subnet.AvailabilityZone}}"
+          {{end}}
+          {{else}}
           {{range $index, $subnet := .Subnets}}
           {{if gt $index 0}},{{end}}
           "{{$subnet.AvailabilityZone}}"
+          {{end}}
           {{end}}
         ],
         "HealthCheckGracePeriod": 600,
@@ -103,11 +152,18 @@
         ],
         {{end}}
         "VPCZoneIdentifier": [
-          {{range $index, $subnet := .Subnets}}
-          {{with $subnetLogicalName := printf "Subnet%d" $index}}
+          {{if .Worker.TopologyPrivate}}
+          {{range $index, $subnet := .Worker.PrivateSubnets}}
           {{if gt $index 0}},{{end}}
           {
-            "Ref": "{{$subnetLogicalName}}"
+            "Ref": "{{$subnet.LogicalName}}"
+          }
+          {{end}}
+          {{else}}
+          {{range $index, $subnet := .Subnets}}
+          {{if gt $index 0}},{{end}}
+          {
+            "Ref": "{{$subnet.LogicalName}}"
           }
           {{end}}
           {{end}}
@@ -197,7 +253,7 @@
 {{end}}
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "kube-aws Kubernetes node pool {{.NodePoolName}}",
+  "Description": "kube-aws Kubernetes node pool {{.ClusterName}} {{.NodePoolName}}",
   "Resources": {
     {{if .Worker.SpotFleet.Enabled}}
     {{template "SpotFleet" .}}
@@ -317,18 +373,47 @@
       },
       "Type": "AWS::IAM::Role"
     }
-    {{range $index, $subnet := .Subnets}}
-    {{with $subnetLogicalName := printf "Subnet%d" $index}}
+
+    {{if $.ElasticFileSystemID}}
+    {{if $.Worker.TopologyPrivate}}
+    {{range $index, $subnet := .Worker.PrivateSubnets}}
     ,
-    "{{$subnetLogicalName}}": {
+    "{{$subnet.LogicalName}}MountTarget": {
+      "Properties" : {
+        "FileSystemId": "{{$.ElasticFileSystemID}}",
+        "SubnetId": { "Ref": "{{$subnet.LogicalName}}" },
+        "SecurityGroups": [ { "Ref": "SecurityGroupMountTarget" } ]
+      },
+      "Type" : "AWS::EFS::MountTarget"
+    }
+    {{end}}
+    {{else}}
+    {{range $index, $subnet := .Subnets}}
+    ,
+    "{{$subnet.LogicalName}}MountTarget": {
+      "Properties" : {
+        "FileSystemId": "{{$.ElasticFileSystemID}}",
+        "SubnetId": { "Ref": "{{$subnet.LogicalName}}" },
+        "SecurityGroups": [ { "Ref": "SecurityGroupMountTarget" } ]
+      },
+      "Type" : "AWS::EFS::MountTarget"
+    }
+    {{end}}
+    {{end}}
+    {{end}}
+
+    {{if $.Worker.TopologyPrivate}}
+    {{range $index, $subnet := .Worker.PrivateSubnets}}
+    ,
+    "{{$subnet.LogicalName}}": {
       "Properties": {
         "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
         "CidrBlock": "{{$subnet.InstanceCIDR}}",
-        "MapPublicIpOnLaunch": {{$.MapPublicIPs}},
+        "MapPublicIpOnLaunch": {{not $.Worker.TopologyPrivate}},
         "Tags": [
           {
             "Key": "Name",
-            "Value": "{{$.NodePoolName}}-{{$subnetLogicalName}}"
+            "Value": "{{$.ClusterName}}-{{$.NodePoolName}}-{{$subnet.LogicalName}}"
           },
           {
             "Key": "KubernetesCluster",
@@ -338,33 +423,34 @@
         "VpcId": {{$.VPCRef}}
       },
       "Type": "AWS::EC2::Subnet"
-    }
-    {{if $.ElasticFileSystemID}}
-    ,
-    "{{$subnetLogicalName}}MountTarget": {
-      "Properties" : {
-        "FileSystemId": "{{$.ElasticFileSystemID}}",
-        "SubnetId": { "Ref": "{{$subnetLogicalName}}" },
-        "SecurityGroups": [ { "Ref": "SecurityGroupMountTarget" } ]
-      },
-      "Type" : "AWS::EFS::MountTarget"
-    }
-    {{end}}
-    {{end}}
-    {{end}}
-
-    {{/*TODO: Add worker subnet specific logic */}}
-    {{if $.Worker.TopologyPrivate}}
-    {{range $index, $subnet := .Subnets}}
-    {{with $workerSubnetLogicalName := printf "Worker%s" $subnet.LogicalName}}
-    {{if not $subnet.RouteTableID}}
-    ,
-    "{{$workerSubnetLogicalName}}RouteTable": {
+    },
+    "{{$subnet.LogicalName}}RouteTableAssociation": {
       "Properties": {
+        "RouteTableId":
+          {{if not $subnet.RouteTableID}}
+          {"Fn::ImportValue" : {"Fn::Sub" : "{{$.ClusterName}}-PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}"}},
+          {{else}}
+          "{{$subnet.RouteTableID}}",
+          {{end}}
+        "SubnetId": {
+          "Ref": "{{$subnet.LogicalName}}"
+        }
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation"
+    }
+    {{end}}
+    {{else}}
+    {{range $index, $subnet := .Subnets}}
+    ,
+    "{{$subnet.LogicalName}}": {
+      "Properties": {
+        "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
+        "CidrBlock": "{{$subnet.InstanceCIDR}}",
+        "MapPublicIpOnLaunch": {{$.MapPublicIPs}},
         "Tags": [
           {
             "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$workerSubnetLogicalName}}-route-table"
+            "Value": "{{$.ClusterName}}-{{$.NodePoolName}}-{{$subnet.LogicalName}}"
           },
           {
             "Key": "KubernetesCluster",
@@ -373,61 +459,23 @@
         ],
         "VpcId": {{$.VPCRef}}
       },
-      "Type": "AWS::EC2::RouteTable"
-    }
-    {{end}}
-    ,
-    {{if not $subnet.NatGateway.ID && not $subnet.RouteTableID}}
-    "{{$workerSubnetLogicalName}}RouteToNatGateway": {
-      "Properties": {
-        "DestinationCidrBlock": "0.0.0.0/0",
-        "NatGatewayId":
-          {{if not $subnet.NatGateway.ID}}
-          {"Ref": "{{$subnet.LogicalName}}NatGateway"},
-          {{else}}
-          "{{$subnet.NatGateway.ID}}",
-          {{end}}
-        "RouteTableId":
-          {{if not $subnet.RouteTableID}}
-          {"Ref" : "{{$workerSubnetLogicalName}}RouteTable"}
-          {{else}}
-          "{{$subnet.RouteTableID}}"
-          {{end}}
-      },
-      "Type": "AWS::EC2::Route"
+      "Type": "AWS::EC2::Subnet"
     },
-    {{end}}
-    "{{$workerSubnetLogicalName}}RouteTableAssociation": {
+    "{{$subnet.LogicalName}}RouteTableAssociation": {
       "Properties": {
         "RouteTableId":
-          {{if not $subnet.RouteTableID}}
-          {"Ref" : "{{$workerSubnetLogicalName}}RouteTable"},
+          {{if not $.RouteTableID}}
+          {"Fn::ImportValue" : {"Fn::Sub" : "{{$.ClusterName}}-PublicRouteTable"}},
           {{else}}
-          "{{$subnet.RouteTableID}}",
+          "{{$.RouteTableID}}",
           {{end}}
         "SubnetId": {
-          "Ref": "{{$workerSubnetLogicalName}}"
+          "Ref": "{{$subnet.LogicalName}}"
         }
       },
       "Type": "AWS::EC2::SubnetRouteTableAssociation"
     }
     {{end}}
     {{end}}
-
-    {{range $index, $subnet := .Subnets}}
-    {{with $subnetLogicalName := printf "Subnet%d" $index}}
-    ,
-    "{{$subnetLogicalName}}RouteTableAssociation": {
-      "Properties": {
-        "RouteTableId": {{$.RouteTableRef}},
-        "SubnetId": {
-          "Ref": "{{$subnetLogicalName}}"
-        }
-      },
-      "Type": "AWS::EC2::SubnetRouteTableAssociation"
-    }
-    {{end}}
-    {{end}}
-
   }
 }

--- a/nodepool/config/templates/stack-template.json
+++ b/nodepool/config/templates/stack-template.json
@@ -353,6 +353,67 @@
     {{end}}
     {{end}}
 
+    {{/*TODO: Add worker subnet specific logic */}}
+    {{if $.Worker.TopologyPrivate}}
+    {{range $index, $subnet := .Subnets}}
+    {{with $workerSubnetLogicalName := printf "Worker%s" $subnet.LogicalName}}
+    {{if not $subnet.RouteTableID}}
+    ,
+    "{{$workerSubnetLogicalName}}RouteTable": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "{{$.ClusterName}}-{{$workerSubnetLogicalName}}-route-table"
+          },
+          {
+            "Key": "KubernetesCluster",
+            "Value": "{{$.ClusterName}}"
+          }
+        ],
+        "VpcId": {{$.VPCRef}}
+      },
+      "Type": "AWS::EC2::RouteTable"
+    }
+    {{end}}
+    ,
+    {{if not $subnet.NatGateway.ID && not $subnet.RouteTableID}}
+    "{{$workerSubnetLogicalName}}RouteToNatGateway": {
+      "Properties": {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "NatGatewayId":
+          {{if not $subnet.NatGateway.ID}}
+          {"Ref": "{{$subnet.LogicalName}}NatGateway"},
+          {{else}}
+          "{{$subnet.NatGateway.ID}}",
+          {{end}}
+        "RouteTableId":
+          {{if not $subnet.RouteTableID}}
+          {"Ref" : "{{$workerSubnetLogicalName}}RouteTable"}
+          {{else}}
+          "{{$subnet.RouteTableID}}"
+          {{end}}
+      },
+      "Type": "AWS::EC2::Route"
+    },
+    {{end}}
+    "{{$workerSubnetLogicalName}}RouteTableAssociation": {
+      "Properties": {
+        "RouteTableId":
+          {{if not $subnet.RouteTableID}}
+          {"Ref" : "{{$workerSubnetLogicalName}}RouteTable"},
+          {{else}}
+          "{{$subnet.RouteTableID}}",
+          {{end}}
+        "SubnetId": {
+          "Ref": "{{$workerSubnetLogicalName}}"
+        }
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation"
+    }
+    {{end}}
+    {{end}}
+
     {{range $index, $subnet := .Subnets}}
     {{with $subnetLogicalName := printf "Subnet%d" $index}}
     ,


### PR DESCRIPTION
This PR belongs to issue #152 

The issue talks about the following use-cases supported by the PR:
- Place worker nodes in their own private subnet
- Place controller nodes in their own private subnet
- Place etcd nodes in their own private subnet
- Place node-pools on non pre-allocated private subnets
- Create NAT gateways to give Internet access to private subnets
- Use pre-allocated EIP's for the NAT gateways
- Use pre-allocated NAT gateways