### PR TITLE
Correct node pool command inconsistencies

### DIFF
--- a/Documentation/kubernetes-on-aws-node-pool.md
+++ b/Documentation/kubernetes-on-aws-node-pool.md
@@ -69,6 +69,14 @@ subnets:
     instanceCIDR: "10.0.2.0/24"
 ```
 
+Render the assets for the node pools including [cloud-init](https://github.com/coreos/coreos-cloudinit) cloud-config userdata and [AWS CloudFormation](https://aws.amazon.com/cloudformation/) template:
+
+```
+$ kube-aws node-pools render stack --node-pool-name first-pool-in-1a
+
+$ kube-aws node-pools render stack --node-pool-name second-pool-in-1b
+```
+
 Launch the node pools:
 
 ```

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Node Pool:
 
 ```
 $ kube-aws node-pools init --node-pool-name my-pool
-$ kube-aws node-pools render --node-pool-name my-pool
+$ kube-aws node-pools render stack --node-pool-name my-pool
 $ kube-aws node-pools validate --node-pool-name my-pool \
   --s3-uri s3://<your-bucket>/<optional-prefix>
 $ kube-aws node-pools up --node-pool-name my-pool \
@@ -165,5 +165,3 @@ The following links can be useful for development:
 
 Submit a PR to this repository, following the [contributors guide](CONTRIBUTING.md).
 The documentation is published from [this source](Documentation/kubernetes-on-aws.md).
-
-

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -64,7 +64,7 @@ func runCmdInit(cmd *cobra.Command, args []string) error {
 
 Next steps:
 1. (Optional) Edit %s to parameterize the cluster.
-2. Use the "kube-aws render" command to render the stack template.
+2. Use the "kube-aws render" command to render the CloudFormation stack template and coreos-cloudinit userdata.
 `
 
 	fmt.Printf(successMsg, configPath, configPath)

--- a/cmd/nodepool/init.go
+++ b/cmd/nodepool/init.go
@@ -129,7 +129,7 @@ func runCmdInit(cmd *cobra.Command, args []string) error {
 
 Next steps:
 1. (Optional) Edit %s to parameterize the cluster.
-2. Use the "kube-aws node-pools render" command to render the stack template.
+2. Use the "kube-aws node-pools render stack" command to render the CloudFormation stack template and coreos-cloudinit userdata.
 `
 
 	fmt.Printf(successMsg, nodePoolClusterConfigFilePath(), nodePoolClusterConfigFilePath())

--- a/cmd/nodepool/render.go
+++ b/cmd/nodepool/render.go
@@ -39,7 +39,7 @@ func init() {
 }
 
 func runCmdRender(cmd *cobra.Command, args []string) error {
-	fmt.Printf("WARNING: 'kube-aws render' is deprecated. See 'kube-aws render --help' for usage\n")
+	fmt.Printf("WARNING: 'kube-aws node-pools render' is deprecated. See 'kube-aws render --help' for usage\n")
 
 	if len(args) != 0 {
 		return fmt.Errorf("render takes no arguments\n")
@@ -95,7 +95,7 @@ func runCmdRenderStack(cmd *cobra.Command, args []string) error {
 		`Success! Stack rendered to nodepools/%s/stack-template.json.
 
 Next steps:
-1. (Optional) Validate your changes to %s with "kube-aws nodepool validate --pool-name %s"
+1. (Optional) Validate your changes to %s with "kube-aws node-pools validate --node-pool-name %s"
 2. (Optional) Further customize the cluster by modifying stack-template.json or files in ./userdata.
 3. Start the cluster with "kube-aws up".
 `

--- a/cmd/nodepool/render.go
+++ b/cmd/nodepool/render.go
@@ -19,13 +19,12 @@ var (
 		Use:          "render",
 		Short:        "Render deployment artifacts",
 		Long:         ``,
-		RunE:         runCmdRender,
 		SilenceUsage: true,
 	}
 
 	cmdRenderStack = &cobra.Command{
 		Use:          "stack",
-		Short:        "Render CloudFormation stack",
+		Short:        "Render CloudFormation stack template and coreos-cloudinit userdata",
 		Long:         ``,
 		RunE:         runCmdRenderStack,
 		SilenceUsage: true,
@@ -38,19 +37,6 @@ func init() {
 	cmdRender.AddCommand(cmdRenderStack)
 }
 
-func runCmdRender(cmd *cobra.Command, args []string) error {
-	fmt.Printf("WARNING: 'kube-aws node-pools render' is deprecated. See 'kube-aws render --help' for usage\n")
-
-	if len(args) != 0 {
-		return fmt.Errorf("render takes no arguments\n")
-	}
-
-	if err := runCmdRenderStack(cmd, args); err != nil {
-		return err
-	}
-
-	return nil
-}
 func runCmdRenderStack(cmd *cobra.Command, args []string) error {
 	if len(args) != 0 {
 		return fmt.Errorf("render stack takes no arguments\n")

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -42,7 +42,7 @@ var (
 
 	cmdRenderStack = &cobra.Command{
 		Use:          "stack",
-		Short:        "Render CloudFormation stack",
+		Short:        "Render CloudFormation stack template and coreos-cloudinit userdata",
 		Long:         ``,
 		RunE:         runCmdRenderStack,
 		SilenceUsage: true,


### PR DESCRIPTION
Corrects one of my comments from https://github.com/coreos/kube-aws/issues/44 now we actually have the node pool validation. I'm not sure we even need the `runCmdRender` method as isn't `kube-aws node-pool render` without any subcommand already deprecated? We shouldn't add deprecated things so if we want it to always be `kube-aws node-pool render stack` then I think we remove this part entirely.