### PR TITLE
Update kube-dns to the one bundled with k8s v1.5.1

### DIFF
--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -368,8 +368,8 @@ write_files:
     content: |
       #!/bin/bash -e
       /usr/bin/curl  -H "Content-Type: application/yaml" -XPOST \
-      -d"$(cat /srv/kubernetes/manifests/kube-dns-rc.yaml)" \
-      "http://127.0.0.1:8080/api/v1/namespaces/kube-system/replicationcontrollers"
+      -d"$(cat /srv/kubernetes/manifests/kube-dns-de.yaml)" \
+      "http://127.0.0.1:8080/apis/extensions/v1beta1/namespaces/kube-system/deployments"
 
       /usr/bin/curl  -H "Content-Type: application/yaml" -XPOST \
       -d"$(cat /srv/kubernetes/manifests/kube-dashboard-rc.yaml)" \
@@ -719,34 +719,39 @@ write_files:
         }
 {{ end }}
 
-  - path: /srv/kubernetes/manifests/kube-dns-rc.yaml
+  - path: /srv/kubernetes/manifests/kube-dns-de.yaml
     content: |
-        apiVersion: v1
-        kind: ReplicationController
+        apiVersion: extensions/v1beta1
+        kind: Deployment
         metadata:
-          name: kube-dns-v20
+          name: kube-dns
           namespace: kube-system
           labels:
             k8s-app: kube-dns
-            version: v20
             kubernetes.io/cluster-service: "true"
         spec:
-          replicas: 1
+          # replicas: not specified here:
+          # 1. In order to make Addon Manager do not reconcile this replicas parameter.
+          # 2. Default is 1.
+          # 3. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
+          strategy:
+            rollingUpdate:
+              maxSurge: 10%
+              maxUnavailable: 0
           selector:
-            k8s-app: kube-dns
-            version: v20
+            matchLabels:
+              k8s-app: kube-dns
           template:
             metadata:
               labels:
                 k8s-app: kube-dns
-                version: v20
               annotations:
                 scheduler.alpha.kubernetes.io/critical-pod: ''
                 scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
             spec:
               containers:
               - name: kubedns
-                image: gcr.io/google_containers/kubedns-amd64:1.8
+                image: gcr.io/google_containers/kubedns-amd64:1.9
                 resources:
                   limits:
                     memory: 170Mi
@@ -772,12 +777,22 @@ write_files:
                 args:
                 - --domain=cluster.local.
                 - --dns-port=10053
+                - --config-map=kube-dns
+                # This should be set to v=2 only after the new image (cut from 1.5) has
+                # been released, otherwise we will flood the logs.
+                - --v=2
+                env:
+                - name: PROMETHEUS_PORT
+                  value: "10055"
                 ports:
                 - containerPort: 10053
                   name: dns-local
                   protocol: UDP
                 - containerPort: 10053
                   name: dns-tcp-local
+                  protocol: TCP
+                - containerPort: 10055
+                  name: metrics
                   protocol: TCP
               - name: dnsmasq
                 image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4
@@ -802,6 +817,32 @@ write_files:
                 - containerPort: 53
                   name: dns-tcp
                   protocol: TCP
+                # see: https://github.com/kubernetes/kubernetes/issues/29055 for details
+                resources:
+                  requests:
+                    cpu: 150m
+                    memory: 10Mi
+              - name: dnsmasq-metrics
+                image: gcr.io/google_containers/dnsmasq-metrics-amd64:1.0
+                livenessProbe:
+                  httpGet:
+                    path: /metrics
+                    port: 10054
+                    scheme: HTTP
+                  initialDelaySeconds: 60
+                  timeoutSeconds: 5
+                  successThreshold: 1
+                  failureThreshold: 5
+                args:
+                - --v=2
+                - --logtostderr
+                ports:
+                - containerPort: 10054
+                  name: metrics
+                  protocol: TCP
+                resources:
+                  requests:
+                    memory: 10Mi
               - name: healthz
                 image: gcr.io/google_containers/exechealthz-amd64:1.2
                 resources:


### PR DESCRIPTION
* kube-dns is now deployed via a deployment instead of a replicaset
* kube-dns supports zero downtime rolling update (https://github.com/kubernetes/kubernetes/pull/37730)
* prometeus metris are exposed

fix #173 
ref #111 