### PR TITLE
Move from the old m3.medium instance type to the marginally better t2.medium

### DIFF
--- a/Documentation/kubernetes-on-aws-node-pool.md
+++ b/Documentation/kubernetes-on-aws-node-pool.md
@@ -154,7 +154,7 @@ worker:
     targetCapacity: 5
     launchSpecifications:
     - weightedCapacity: 1
-      instanceType: m3.medium
+      instanceType: t2.medium
     - weightedCapacity: 2
       instanceType: m3.large
     - weightedCapacity: 2
@@ -163,7 +163,7 @@ worker:
 
 This configuration would normally result in Spot Fleet to bring up 3 instances to meet your target capacity:
 
-* 1x m3.medium = 1 capacity
+* 1x t2.medium = 1 capacity
 * 1x m3.large = 2 capacity
 * 1x m4.large = 2 capacity
 

--- a/Documentation/kubernetes-on-aws-prerequisites.md
+++ b/Documentation/kubernetes-on-aws-prerequisites.md
@@ -2,7 +2,7 @@
 
 If you're deploying a cluster with kube-aws:
 
-* [EC2 instances whose types are larger than or equal to `m3.medium` should be chosen for the cluster to work reliably](https://github.com/coreos/kube-aws/issues/138)
+* [EC2 instances whose types are larger than or equal to `t2.medium` should be chosen for the cluster to work reliably](https://github.com/coreos/kube-aws/issues/138)
 * [At least 3 etcd, 2 controller, 2 worker nodes are required to achieve high availability](https://github.com/coreos/kube-aws/issues/138#issuecomment-266432162)
 
 ## Deploying to an existing VPC

--- a/config/config.go
+++ b/config/config.go
@@ -86,7 +86,7 @@ func NewDefaultCluster() *Cluster {
 			Worker:                 model.NewDefaultWorker(),
 			WorkerCount:            1,
 			WorkerCreateTimeout:    "PT15M",
-			WorkerInstanceType:     "m3.medium",
+			WorkerInstanceType:     "t2.medium",
 			WorkerRootVolumeType:   "gp2",
 			WorkerRootVolumeIOPS:   0,
 			WorkerRootVolumeSize:   30,
@@ -96,7 +96,7 @@ func NewDefaultCluster() *Cluster {
 		ControllerSettings: ControllerSettings{
 			ControllerCount:          1,
 			ControllerCreateTimeout:  "PT15M",
-			ControllerInstanceType:   "m3.medium",
+			ControllerInstanceType:   "t2.medium",
 			ControllerRootVolumeType: "gp2",
 			ControllerRootVolumeIOPS: 0,
 			ControllerRootVolumeSize: 30,
@@ -104,7 +104,7 @@ func NewDefaultCluster() *Cluster {
 		},
 		EtcdSettings: EtcdSettings{
 			EtcdCount:          1,
-			EtcdInstanceType:   "m3.medium",
+			EtcdInstanceType:   "t2.medium",
 			EtcdRootVolumeSize: 30,
 			EtcdRootVolumeType: "gp2",
 			EtcdRootVolumeIOPS: 0,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -981,7 +981,7 @@ func TestConfig(t *testing.T) {
 	hasDefaultEtcdSettings := func(c *Cluster, t *testing.T) {
 		expected := EtcdSettings{
 			EtcdCount:               1,
-			EtcdInstanceType:        "m3.medium",
+			EtcdInstanceType:        "t2.medium",
 			EtcdRootVolumeSize:      30,
 			EtcdRootVolumeType:      "gp2",
 			EtcdRootVolumeIOPS:      0,
@@ -1276,7 +1276,7 @@ etcdDataVolumeIOPS: 104
 				func(c *Cluster, t *testing.T) {
 					expected := EtcdSettings{
 						EtcdCount:               2,
-						EtcdInstanceType:        "m3.medium",
+						EtcdInstanceType:        "t2.medium",
 						EtcdRootVolumeSize:      101,
 						EtcdRootVolumeType:      "io1",
 						EtcdRootVolumeIOPS:      102,

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -64,7 +64,7 @@ controller:
 #controlerCreateTimeout: PT15M
 
 # Instance type for controller node
-#controllerInstanceType: m3.medium
+#controllerInstanceType: t2.medium
 
 # Disk size (GiB) for controller node
 #controllerRootVolumeSize: 30
@@ -89,7 +89,7 @@ controller:
 #workerCreateTimeout: PT15M
 
 # Instance type for worker nodes
-#workerInstanceType: m3.medium
+#workerInstanceType: t2.medium
 
 # Disk size (GiB) for worker nodes
 #workerRootVolumeSize: 30
@@ -122,7 +122,7 @@ controller:
 # etcdCount: 1
 
 # Instance type for etcd node
-# etcdInstanceType: m3.medium
+# etcdInstanceType: t2.medium
 
 # Root volume size (GiB) for etcd node
 # etcdRootVolumeSize: 30

--- a/model/worker.go
+++ b/model/worker.go
@@ -51,7 +51,7 @@ func newDefaultSpotFleet() SpotFleet {
 		UnitRootVolumeSize: 30,
 		RootVolumeType:     "gp2",
 		LaunchSpecifications: []LaunchSpecification{
-			NewLaunchSpecification(1, "m3.medium"),
+			NewLaunchSpecification(1, "t2.medium"),
 			NewLaunchSpecification(2, "m3.large"),
 			NewLaunchSpecification(2, "m4.large"),
 		},

--- a/nodepool/config/config_test.go
+++ b/nodepool/config/config_test.go
@@ -44,7 +44,7 @@ etcdEndpoints: "10.0.0.1"
 		expected := []model.LaunchSpecification{
 			{
 				WeightedCapacity: 1,
-				InstanceType:     "m3.medium",
+				InstanceType:     "t2.medium",
 				RootVolumeSize:   30,
 				RootVolumeIOPS:   0,
 				RootVolumeType:   "gp2",
@@ -247,7 +247,7 @@ worker:
     unitRootVolumeSize: 40
     launchSpecifications:
     - weightedCapacity: 1
-      instanceType: m3.medium
+      instanceType: t2.medium
     - weightedCapacity: 2
       instanceType: m3.large
       rootVolumeSize: 100
@@ -258,7 +258,7 @@ worker:
 					expected := []model.LaunchSpecification{
 						{
 							WeightedCapacity: 1,
-							InstanceType:     "m3.medium",
+							InstanceType:     "t2.medium",
 							// RootVolumeSize was not specified in the configYaml but should default to workerRootVolumeSize * weightedCapacity hence:
 							RootVolumeSize: 40,
 							RootVolumeIOPS: 0,
@@ -295,7 +295,7 @@ worker:
     unitRootVolumeIOPS: 100
     launchSpecifications:
     - weightedCapacity: 1
-      instanceType: m3.medium
+      instanceType: t2.medium
     - weightedCapacity: 2
       instanceType: m3.large
       rootVolumeIOPS: 500
@@ -306,7 +306,7 @@ worker:
 					expected := []model.LaunchSpecification{
 						{
 							WeightedCapacity: 1,
-							InstanceType:     "m3.medium",
+							InstanceType:     "t2.medium",
 							// RootVolumeSize was not specified in the configYaml but should default to workerRootVolumeSize * weightedCapacity hence:
 							RootVolumeSize: 40,
 							// RootVolumeIOPS was not specified in the configYaml but should default to workerRootVolumeIOPS * weightedCapacity hence:
@@ -498,7 +498,7 @@ worker:
     targetCapacity: 10
     launchSpecifications:
     - weightedCapacity: 1
-      instanceType: m3.medium
+      instanceType: t2.medium
       rootVolumeType: foo
 `,
 		},
@@ -510,7 +510,7 @@ worker:
     targetCapacity: 10
     launchSpecifications:
     - weightedCapacity: 1
-      instanceType: m3.medium
+      instanceType: t2.medium
       rootVolumeType: io1
       # must be 100~2000
       rootVolumeIOPS: 50
@@ -524,7 +524,7 @@ worker:
     targetCapacity: 10
     launchSpecifications:
     - weightedCapacity: 1
-      instanceType: m3.medium
+      instanceType: t2.medium
       rootVolumeType: gp2
       rootVolumeIOPS: 1000
 `,

--- a/nodepool/config/templates/cluster.yaml
+++ b/nodepool/config/templates/cluster.yaml
@@ -50,7 +50,7 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #workerCount: 1
 
 # Instance type for worker nodes
-#workerInstanceType: m3.medium
+#workerInstanceType: t2.medium
 
 # Disk size (GiB) for worker nodes
 #workerRootVolumeSize: 30
@@ -120,7 +120,7 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #    launchSpecifications:
 #    - # Number of units provided by an EC2 instance of the instanceType.
 #      weightedCapacity: 1
-#      instanceType: m3.medium
+#      instanceType: t2.medium
 #
 #      # Price per unit hour = Price per instance hour / num of weighted capacity for the instance
 #      #spotPrice:

--- a/test/integration/aws_test.go
+++ b/test/integration/aws_test.go
@@ -161,7 +161,7 @@ worker:
     unitRootVolumeSize: 40
     launchSpecifications:
     - weightedCapacity: 1
-      instanceType: m3.medium
+      instanceType: t2.medium
     - weightedCapacity: 2
       instanceType: m3.large
       rootVolumeSize: 100
@@ -178,7 +178,7 @@ worker:
     unitRootVolumeIOPS: 100
     launchSpecifications:
     - weightedCapacity: 1
-      instanceType: m3.medium
+      instanceType: t2.medium
     - weightedCapacity: 2
       instanceType: m3.large
       rootVolumeIOPS: 500


### PR DESCRIPTION
ref #181 