### PR TITLE
Node Pool Nested Stack Name

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -148,7 +148,7 @@ func (c *Cluster) stackProvisioner() *cfnstack.Provisioner {
   ]
 }
 `
-	return cfnstack.NewProvisioner(c.ClusterName, c.WorkerDeploymentSettings().StackTags(), stackPolicyBody, c.session)
+	return cfnstack.NewProvisioner(c.StackName(), c.WorkerDeploymentSettings().StackTags(), stackPolicyBody, c.session)
 }
 
 func (c *Cluster) Create(stackBody string, s3URI string) error {
@@ -209,7 +209,7 @@ func (c *Cluster) lockEtcdResources(cfSvc *cloudformation.CloudFormation, stackB
 
 	//Fetch and unmarshal existing stack resource defintions
 	res, err := cfSvc.GetTemplate(&cloudformation.GetTemplateInput{
-		StackName: aws.String(c.ClusterName),
+		StackName: aws.String(c.StackName()),
 	})
 	if err != nil {
 		return "", fmt.Errorf("error getting stack template: %v", err)
@@ -269,7 +269,7 @@ func (c *Cluster) Info() (*Info, error) {
 		resp, err := cfSvc.DescribeStackResource(
 			&cloudformation.DescribeStackResourceInput{
 				LogicalResourceId: aws.String("ElbAPIServer"),
-				StackName:         aws.String(c.ClusterName),
+				StackName:         aws.String(c.StackName()),
 			},
 		)
 		if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -693,7 +693,7 @@ type Config struct {
 
 // CloudFormation stack name which is unique in an AWS account.
 // This is intended to be used to reference stack name from cloud-config as the target of awscli or cfn-bootstrap-tools commands e.g. `cfn-init` and `cfn-signal`
-func (c Config) StackName() string {
+func (c Cluster) StackName() string {
 	return c.ClusterName
 }
 

--- a/nodepool/cluster/cluster.go
+++ b/nodepool/cluster/cluster.go
@@ -59,7 +59,7 @@ func (c *Cluster) stackProvisioner() *cfnstack.Provisioner {
   ]
 }`
 
-	return cfnstack.NewProvisioner(c.NodePoolName, c.WorkerDeploymentSettings().StackTags(), stackPolicyBody, c.session)
+	return cfnstack.NewProvisioner(c.StackName(), c.WorkerDeploymentSettings().StackTags(), stackPolicyBody, c.session)
 }
 
 func (c *Cluster) Create(stackBody string, s3URI string) error {

--- a/nodepool/config/config.go
+++ b/nodepool/config/config.go
@@ -213,8 +213,8 @@ func (c ProvidedConfig) valid() error {
 
 // CloudFormation stack name which is unique in an AWS account.
 // This is intended to be used to reference stack name from cloud-config as the target of awscli or cfn-bootstrap-tools commands e.g. `cfn-init` and `cfn-signal`
-func (c ComputedConfig) StackName() string {
-	return c.NodePoolName
+func (c ProvidedConfig) StackName() string {
+	return c.ClusterName + "-" + c.NodePoolName
 }
 
 func (c ComputedConfig) VPCRef() string {


### PR DESCRIPTION
Nest node pool stack name by cluster name to avoid conflict when running multiple clusters.

e.g.
```
cluster-1
cluster-1-pool-1
cluster-1-pool-2
```

```
cluster-2
cluster-2-pool-1
cluster-2-pool-2
```