### PR TITLE
Handle error from ReadOrCreateEncryptedTLSAssets gracefully.

### DIFF
--- a/config/tls_config.go
+++ b/config/tls_config.go
@@ -7,14 +7,15 @@ import (
 	"net"
 	"time"
 
+	"io/ioutil"
+	"path/filepath"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/coreos/kube-aws/gzipcompressor"
 	"github.com/coreos/kube-aws/netutil"
 	"github.com/coreos/kube-aws/tlsutil"
-	"io/ioutil"
-	"path/filepath"
 )
 
 // PEM encoded TLS assets.
@@ -433,6 +434,9 @@ func ReadOrCreateEncryptedTLSAssets(tlsAssetsDir string, kmsConfig KMSConfig) (*
 
 func ReadOrCreateCompactTLSAssets(tlsAssetsDir string, kmsConfig KMSConfig) (*CompactTLSAssets, error) {
 	encryptedAssets, err := ReadOrCreateEncryptedTLSAssets(tlsAssetsDir, kmsConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read/create TLS assets: %v", err)
+	}
 
 	compactAssets, err := encryptedAssets.Compact()
 	if err != nil {


### PR DESCRIPTION
Causes panic when ReadOrCreateEncryptedTLSAssets, for example when you enter a bad `kmsKeyArn`. 

Ever considered using Dave Cheney's error package? 
https://dave.cheney.net/2016/04/27/dont-just-check-errors-handle-them-gracefully