### PR TITLE
Fix typo "etcdDataVolumeEphemeral": fix #192

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -270,7 +270,7 @@ type EtcdSettings struct {
 	EtcdDataVolumeSize      int    `yaml:"etcdDataVolumeSize,omitempty"`
 	EtcdDataVolumeType      string `yaml:"etcdDataVolumeType,omitempty"`
 	EtcdDataVolumeIOPS      int    `yaml:"etcdDataVolumeIOPS,omitempty"`
-	EtcdDataVolumeEphemeral bool   `yaml:"etcdDataVolumEphemeral,omitempty"`
+	EtcdDataVolumeEphemeral bool   `yaml:"etcdDataVolumeEphemeral,omitempty"`
 	EtcdTenancy             string `yaml:"etcdTenancy,omitempty"`
 }
 


### PR DESCRIPTION
Match spelling in config/templates/cluster.yaml