### PR TITLE
Controller node not being properly tainted

### DIFF
--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -476,7 +476,7 @@ write_files:
            hostname="'${hostname}'"; \
            kubectl="/kubectl --server=http://127.0.0.1:8080"; \
            taint="$kubectl taint node $hostname"; \
-           $taint "node.alpha.kubernetes.io/role:master:NoSchedule"; \
+           $taint "node.alpha.kubernetes.io/role=master:NoSchedule"; \
            echo done. ;\
            echo uncordoning this node; \
            $kubectl uncordon $hostname;\

--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -463,30 +463,20 @@ write_files:
 
       hostname=$(hostname)
 
-      sudo rkt run \
-        --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
-        --mount=volume=kube,target=/etc/kubernetes \
-        --uuid-file-save=/var/run/coreos/taint-and-uncordon.uuid \
-        --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
-        --net=host \
-        --trust-keys-from-https \
-        {{.HyperkubeImageRepo}}:{{.K8sVer}} --exec=/bin/bash -- \
-          -vxc \
-          'echo tainting this node; \
+      docker run --rm --net=host \
+        -v /etc/kubernetes:/etc/kubernetes \
+        -v /etc/resolv.conf:/etc/resolv.conf \
+        {{.HyperkubeImageRepo}}:{{.K8sVer}} /bin/bash \
+          -vxec \
+          'echo "tainting this node."; \
            hostname="'${hostname}'"; \
            kubectl="/kubectl --server=http://127.0.0.1:8080"; \
-           taint="$kubectl taint node $hostname"; \
-           $taint "node.alpha.kubernetes.io/role=master:NoSchedule"; \
-           echo done. ;\
-           echo uncordoning this node; \
-           $kubectl uncordon $hostname;\
-           echo done.'
-
-      echo cleaning pod resources.
-
-      sudo rkt rm --uuid-file=/var/run/coreos/taint-and-uncordon.uuid
-
-      echo done.
+           taint="$kubectl taint node --overwrite"; \
+           $taint "$hostname" "node.alpha.kubernetes.io/role=master:NoSchedule"; \
+           echo "done."; \
+           echo "uncordoning this node."; \
+           $kubectl uncordon "$hostname"; \
+           echo "done."'
 
   - path: /etc/kubernetes/manifests/kube-proxy.yaml
     content: |


### PR DESCRIPTION
/opt/bin/taint-and-uncordon had a syntax issue with the kubectl taint command. Was failing with `error: at least one taint update is required` and the controller node was still getting pods scheduled to it. PR fixes the syntax as per http://kubernetes.io/docs/user-guide/kubectl/kubectl_taint/