### PR TITLE
Add customSettings field

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -123,6 +123,7 @@ func NewDefaultCluster() *Cluster {
 		TLSCertDurationDays: 365,
 		CreateRecordSet:     false,
 		RecordSetTTL:        300,
+		CustomSettings:      make(map[string]interface{}),
 	}
 }
 
@@ -294,6 +295,7 @@ type Cluster struct {
 	HostedZone             string `yaml:"hostedZone,omitempty"`
 	HostedZoneID           string `yaml:"hostedZoneId,omitempty"`
 	providedEncryptService EncryptService
+	CustomSettings         map[string]interface{} `yaml:"customSettings,omitempty"`
 }
 
 type Subnet struct {

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -253,3 +253,7 @@ controller:
 #stackTags:
 #  Name: "Kubernetes"
 #  Environment: "Production"
+
+# User-provided YAML map available in stack-template.json
+#customSettings:
+#  key1: [ 1, 2, 3 ]


### PR DESCRIPTION
This feature is useful to experiment with new setups, have in house customizations etc without resorting to full '--export', so config still remains manageable and flexible.

Example use in stack-template.json:
```
{{ .CfgMap.myCustomOpt }}
```