### PR TITLE
Don't block ICMP for API ELB

### DIFF
--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -628,6 +628,12 @@
             "FromPort": 443,
             "IpProtocol": "tcp",
             "ToPort": 443
+          },
+          {
+             "CidrIp": "0.0.0.0/0",
+             "FromPort": -1,
+             "IpProtocol": "icmp",
+             "ToPort": -1
           }
         ],
         "Tags": [


### PR DESCRIPTION
As discussed in issue #214, stop blocking ICMP for the API ELB. Among other things ICMP is required for MTU discovery to for TCP / HTTPS connections with the API server.