### PR TITLE
Fix kubectl logs problem due to apiserver config

### DIFF
--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -546,6 +546,7 @@ write_files:
           - --allow-privileged=true
           - --service-cluster-ip-range={{.ServiceCIDR}}
           - --secure-port=443
+          - --kubelet-preferred-address-types=InternalIP,Hostname,ExternalIP
           {{if .Experimental.AuditLog.Enabled}}
           - --audit-log-maxage={{.Experimental.AuditLog.MaxAge}}
           - --audit-log-path={{.Experimental.AuditLog.LogPath}}


### PR DESCRIPTION
Fixes issue #222 with the workaround proposed in https://github.com/kubernetes/kubernetes/issues/22770#issuecomment-266215007