### PR TITLE
Typo in node-pools render stack message

### DIFF
--- a/cmd/nodepool/render.go
+++ b/cmd/nodepool/render.go
@@ -78,7 +78,7 @@ func runCmdRenderStack(cmd *cobra.Command, args []string) error {
 	}
 
 	successMsg :=
-		`Success! Stack rendered to nodepools/%s/stack-template.json.
+		`Success! Stack rendered to node-pools/%s/stack-template.json.
 
 Next steps:
 1. (Optional) Validate your changes to %s with "kube-aws node-pools validate --node-pool-name %s"


### PR DESCRIPTION
Folder is actually `node-pools`. Could you call nodePoolExportedStackTemplatePath() here instead, to ensure the correct path is in the message?