### PR TITLE
Don't precalculate etcd static IP addresses

### DIFF
--- a/cmd/nodepool/init.go
+++ b/cmd/nodepool/init.go
@@ -105,10 +105,6 @@ func runCmdInit(cmd *cobra.Command, args []string) error {
 		initOpts.RouteTableID = main.RouteTableID
 	}
 
-	if initOpts.EtcdEndpoints == "" {
-		initOpts.EtcdEndpoints = main.EtcdEndpoints
-	}
-
 	initOpts.ClusterName = main.ClusterName
 
 	// Required and shared settings for the node pool.

--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -137,7 +137,7 @@ coreos:
                        --cert-file /etc/kubernetes/ssl/etcd-client.pem \
                        --endpoints "${ETCD_ENDPOINTS}" \
                        cluster-health
-        ExecStartPre=/bin/bas -ec "shopts -s nullglob; sed -i 's|#ETCD_ENDPOINTS#|${ETCD_ENDPOINTS}|' /etc/kubernetes/manifests/* /srv/kubernetes/manifests/*"
+        ExecStartPre=/bin/bash -ec "shopt -s nullglob; sed -i 's|#ETCD_ENDPOINTS#|${ETCD_ENDPOINTS}|' /etc/kubernetes/manifests/* /srv/kubernetes/manifests/*"
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
         --api-servers=http://localhost:8080 \
         --cni-conf-dir=/etc/kubernetes/cni/net.d \

--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -19,9 +19,9 @@ coreos:
         After=network-online.target
 
         [Service]
-        Type=oneshot
+        Restart=on-failure
         RemainAfterExit=true
-        ExecStart=/usr/bin/rkt run \
+        ExecStartPre=/usr/bin/rkt run \
           --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
           --volume=awsenv,kind=host,source=/var/run/coreos,readOnly=false --mount volume=awsenv,target=/var/run/coreos \
           --net=host \
@@ -80,13 +80,14 @@ coreos:
         - name: 10-etcd.conf
           content: |
             [Unit]
-            Requires=cfn-etcd-environment.service
+            Wants=cfn-etcd-environment.service
             After=cfn-etcd-environment.service
 
             [Service]
-            EnvironmentFile=/etc/etcd-environment
+            EnvironmentFile=-/etc/etcd-environment
             Environment="ETCD_SSL_DIR=/etc/kubernetes/ssl"
             EnvironmentFile=-/run/flannel/etcd-endpoints.opts
+            ExecStartPre=/usr/bin/systemctl is-active cfn-etcd-environment.service
             ExecStartPre=/bin/sh -ec "echo FLANNELD_ETCD_ENDPOINTS=${ETCD_ENDPOINTS} >/run/flannel/etcd-endpoints.opts"
             ExecStartPre=/opt/bin/decrypt-tls-assets
             ExecStartPre=/usr/bin/etcdctl \
@@ -102,11 +103,10 @@ coreos:
       runtime: true
       content: |
         [Unit]
-        Wants=flanneld.service
-        Requires=cfn-etcd-environment.service
+        Wants=flanneld.service cfn-etcd-environment.service
         After=cfn-etcd-environment.service
         [Service]
-        EnvironmentFile=/etc/etcd-environment
+        EnvironmentFile=-/etc/etcd-environment
         Environment=KUBELET_VERSION={{.K8sVer}}
         Environment=KUBELET_ACI={{.HyperkubeImageRepo}}
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
@@ -127,6 +127,7 @@ coreos:
         --volume cni-bin,kind=host,source=/opt/cni/bin \
         --mount volume=cni-bin,target=/opt/cni/bin{{ end }}"
         ExecStartPre=/usr/bin/systemctl is-active flanneld.service
+        ExecStartPre=/usr/bin/systemctl is-active cfn-etcd-environment.service
         ExecStartPre=/usr/bin/mkdir -p /var/lib/cni
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin

--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -4,12 +4,35 @@ coreos:
     reboot-strategy: "off"
   flannel:
     interface: $private_ipv4
-    etcd_endpoints: {{ .EtcdEndpoints }}
     etcd_cafile: /etc/kubernetes/ssl/ca.pem
     etcd_certfile: /etc/kubernetes/ssl/etcd-client.pem
     etcd_keyfile: /etc/kubernetes/ssl/etcd-client-key.pem
 
   units:
+    - name: cfn-etcd-environment.service
+      enable: true
+      command: start
+      runtime: true
+      content: |
+        [Unit]
+        Description=Fetches etcd static IP addresses list from CF
+        After=network-online.target
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        ExecStart=/usr/bin/rkt run \
+          --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
+          --volume=awsenv,kind=host,source=/var/run/coreos,readOnly=false --mount volume=awsenv,target=/var/run/coreos \
+          --net=host \
+          --trust-keys-from-https \
+          {{.AWSCliImageRepo}}:{{.AWSCliTag}} -- cfn-init -v \
+              -c "etcd-client" \
+              --region {{.Region}} \
+              --resource LaunchConfigurationController \
+              --stack {{ .ClusterName }}
+        ExecStart=/usr/bin/mv -f /var/run/coreos/etcd-environment /etc/etcd-environment
+
 {{if .Experimental.AwsEnvironment.Enabled}}
     - name: set-aws-environment.service
       enable: true
@@ -56,14 +79,21 @@ coreos:
       drop-ins:
         - name: 10-etcd.conf
           content: |
+            [Unit]
+            Requires=cfn-etcd-environment.service
+            After=cfn-etcd-environment.service
+
             [Service]
+            EnvironmentFile=/etc/etcd-environment
             Environment="ETCD_SSL_DIR=/etc/kubernetes/ssl"
+            EnvironmentFile=-/run/flannel/etcd-endpoints.opts
+            ExecStartPre=/bin/sh -ec "echo FLANNELD_ETCD_ENDPOINTS=${ETCD_ENDPOINTS} >/run/flannel/etcd-endpoints.opts"
             ExecStartPre=/opt/bin/decrypt-tls-assets
             ExecStartPre=/usr/bin/etcdctl \
             --ca-file=/etc/kubernetes/ssl/ca.pem \
             --cert-file=/etc/kubernetes/ssl/etcd-client.pem \
             --key-file=/etc/kubernetes/ssl/etcd-client-key.pem \
-            --endpoints="{{.EtcdEndpoints}}" \
+            --endpoints="${ETCD_ENDPOINTS}" \
             set /coreos.com/network/config '{"Network" : "{{.PodCIDR}}", "Backend" : {"Type" : "vxlan"}}'
             TimeoutStartSec=120
 
@@ -73,7 +103,10 @@ coreos:
       content: |
         [Unit]
         Wants=flanneld.service
+        Requires=cfn-etcd-environment.service
+        After=cfn-etcd-environment.service
         [Service]
+        EnvironmentFile=/etc/etcd-environment
         Environment=KUBELET_VERSION={{.K8sVer}}
         Environment=KUBELET_ACI={{.HyperkubeImageRepo}}
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
@@ -97,6 +130,13 @@ coreos:
         ExecStartPre=/usr/bin/mkdir -p /var/lib/cni
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
+        ExecStartPre=/usr/bin/etcdctl \
+                       --ca-file /etc/kubernetes/ssl/ca.pem \
+                       --key-file /etc/kubernetes/ssl/etcd-client-key.pem \
+                       --cert-file /etc/kubernetes/ssl/etcd-client.pem \
+                       --endpoints "${ETCD_ENDPOINTS}" \
+                       cluster-health
+        ExecStartPre=/bin/sh -ec "sed -i 's|#ETCD_ENDPOINTS#|${ETCD_ENDPOINTS}|' /etc/kubernetes/manifests/* /etc/kubernetes/cni/net.d/* /srv/kubernetes/manifests/*" 
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
         --api-servers=http://localhost:8080 \
         --cni-conf-dir=/etc/kubernetes/cni/net.d \
@@ -366,7 +406,7 @@ write_files:
         name: calico-config 
         namespace: kube-system
       data:
-        etcd_endpoints: "{{ .EtcdEndpoints }}"
+        etcd_endpoints: "#ETCD_ENDPOINTS#"
         cni_network_config: |-
           {
               "name": "calico",
@@ -706,7 +746,7 @@ write_files:
           - /hyperkube
           - apiserver
           - --bind-address=0.0.0.0
-          - --etcd-servers={{.EtcdEndpoints}}
+          - --etcd-servers=#ETCD_ENDPOINTS#
           - --etcd-cafile=/etc/kubernetes/ssl/ca.pem
           - --etcd-certfile=/etc/kubernetes/ssl/etcd-client.pem
           - --etcd-keyfile=/etc/kubernetes/ssl/etcd-client-key.pem
@@ -861,7 +901,7 @@ write_files:
               - name: ETCD_KEY_FILE
                 value: "/etc/etcd2/ssl/etcd-client-key.pem"
               - name: ETCD_ENDPOINTS
-                value: "{{ .EtcdEndpoints }}"
+                value: "#ETCD_ENDPOINTS#"
               - name: K8S_API
                 value: "http://127.0.0.1:8080"
               - name: LEADER_ELECTION

--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -137,7 +137,7 @@ coreos:
                        --cert-file /etc/kubernetes/ssl/etcd-client.pem \
                        --endpoints "${ETCD_ENDPOINTS}" \
                        cluster-health
-        ExecStartPre=/bin/sh -ec "sed -i 's|#ETCD_ENDPOINTS#|${ETCD_ENDPOINTS}|' /etc/kubernetes/manifests/* /etc/kubernetes/cni/net.d/* /srv/kubernetes/manifests/*" 
+        ExecStartPre=/bin/bas -ec "shopts -s nullglob; sed -i 's|#ETCD_ENDPOINTS#|${ETCD_ENDPOINTS}|' /etc/kubernetes/manifests/* /srv/kubernetes/manifests/*"
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
         --api-servers=http://localhost:8080 \
         --cni-conf-dir=/etc/kubernetes/cni/net.d \

--- a/config/templates/cloud-config-etcd
+++ b/config/templates/cloud-config-etcd
@@ -13,9 +13,9 @@ coreos:
         After=network-online.target
 
         [Service]
-        Type=oneshot
+        Restart=on-failure
         RemainAfterExit=true
-        ExecStart=/usr/bin/rkt run \
+        ExecStartPre=/usr/bin/rkt run \
           --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
           --volume=awsenv,kind=host,source=/var/run/coreos,readOnly=false --mount volume=awsenv,target=/var/run/coreos \
           --net=host \
@@ -32,7 +32,7 @@ coreos:
         - name: 20-etcd2-aws-cluster.conf
           content: |
             [Unit]
-            Requires=decrypt-tls-assets.service cfn-etcd-environment.service
+            Wants=decrypt-tls-assets.service cfn-etcd-environment.service
             After=decrypt-tls-assets.service cfn-etcd-environment.service
 
             [Service]
@@ -48,13 +48,15 @@ coreos:
             Environment=ETCD_KEY_FILE=/etc/etcd2/ssl/etcd-key.pem
 
             Environment=ETCD_INITIAL_CLUSTER_STATE=new
-            EnvironmentFile=/etc/etcd-environment
+            EnvironmentFile=-/etc/etcd-environment
             Environment=ETCD_DATA_DIR=/var/lib/etcd2
             Environment=ETCD_LISTEN_CLIENT_URLS=https://%H:2379
             Environment=ETCD_ADVERTISE_CLIENT_URLS=https://%H:2379
             Environment=ETCD_LISTEN_PEER_URLS=https://%H:2380
             Environment=ETCD_INITIAL_ADVERTISE_PEER_URLS=https://%H:2380
             PermissionsStartOnly=true
+            ExecStartPre=/usr/bin/systemctl is-active cfn-etcd-environment.service
+            ExecStartPre=/usr/bin/systemctl is-active decrypt-tls-assets.service
             ExecStartPre=/usr/bin/sed -i 's/^ETCDCTL_ENDPOINT.*$/ETCDCTL_ENDPOINT=https:\/\/%H:2379/' /etc/environment
             ExecStartPre=/usr/bin/chown -R etcd:etcd /var/lib/etcd2
       enable: true
@@ -99,9 +101,9 @@ coreos:
         Before=etcd2.service
 
         [Service]
-        Type=oneshot
+        Restart=on-failure
         RemainAfterExit=yes
-        ExecStart=/usr/bin/rkt run \
+        ExecStartPre=/usr/bin/rkt run \
           --uuid-file-save=/var/run/coreos/decrypt-tls-assets.uuid \
           --volume=ssl,kind=host,source=/etc/etcd2/ssl,readOnly=false \
           --mount=volume=ssl,target=/etc/etcd2/ssl \

--- a/config/templates/cloud-config-etcd
+++ b/config/templates/cloud-config-etcd
@@ -3,13 +3,37 @@ coreos:
   update:
     reboot-strategy: etcd-lock
   units:
+    - name: cfn-etcd-environment.service
+      enable: true
+      command: start
+      runtime: true
+      content: |
+        [Unit]
+        Description=Fetches etcd static IP addresses list from CF
+        After=network-online.target
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        ExecStart=/usr/bin/rkt run \
+          --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
+          --volume=awsenv,kind=host,source=/var/run/coreos,readOnly=false --mount volume=awsenv,target=/var/run/coreos \
+          --net=host \
+          --trust-keys-from-https \
+          {{.AWSCliImageRepo}}:{{.AWSCliTag}} -- cfn-init -v \
+              -c "etcd-server" \
+              --region {{.Region}} \
+              --resource LaunchConfigurationController \
+              --stack {{ .ClusterName }}
+        ExecStart=/usr/bin/mv -f /var/run/coreos/etcd-environment /etc/etcd-environment
+
     - name: etcd2.service
       drop-ins:
         - name: 20-etcd2-aws-cluster.conf
           content: |
             [Unit]
-            Requires=decrypt-tls-assets.service
-            After=decrypt-tls-assets.service
+            Requires=decrypt-tls-assets.service cfn-etcd-environment.service
+            After=decrypt-tls-assets.service cfn-etcd-environment.service
 
             [Service]
             Environment=ETCD_NAME=%H
@@ -24,14 +48,14 @@ coreos:
             Environment=ETCD_KEY_FILE=/etc/etcd2/ssl/etcd-key.pem
 
             Environment=ETCD_INITIAL_CLUSTER_STATE=new
-            Environment=ETCD_INITIAL_CLUSTER={{.EtcdInitialCluster}}
+            EnvironmentFile=/etc/etcd-environment
             Environment=ETCD_DATA_DIR=/var/lib/etcd2
             Environment=ETCD_LISTEN_CLIENT_URLS=https://%H:2379
             Environment=ETCD_ADVERTISE_CLIENT_URLS=https://%H:2379
             Environment=ETCD_LISTEN_PEER_URLS=https://%H:2380
             Environment=ETCD_INITIAL_ADVERTISE_PEER_URLS=https://%H:2380
             PermissionsStartOnly=true
-            ExecStartPre=/usr/bin/bash -c "sed -i \"s/^ETCDCTL_ENDPOINT.*$/ETCDCTL_ENDPOINT=https:\/\/$(hostname):2379/\" /etc/environment"
+            ExecStartPre=/usr/bin/sed -i 's/^ETCDCTL_ENDPOINT.*$/ETCDCTL_ENDPOINT=https:\/\/%H:2379/' /etc/environment
             ExecStartPre=/usr/bin/chown -R etcd:etcd /var/lib/etcd2
       enable: true
       command: start
@@ -73,14 +97,33 @@ coreos:
         [Unit]
         Description=decrypt etcd2 tls assets using amazon kms
         Before=etcd2.service
-        After=early-docker.service
-        Requires=early-docker.service
 
         [Service]
         Type=oneshot
         RemainAfterExit=yes
-        Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
-        ExecStart=/opt/bin/decrypt-tls-assets
+        ExecStart=/usr/bin/rkt run \
+          --uuid-file-save=/var/run/coreos/decrypt-tls-assets.uuid \
+          --volume=ssl,kind=host,source=/etc/etcd2/ssl,readOnly=false \
+          --mount=volume=ssl,target=/etc/etcd2/ssl \
+          --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true \
+          --mount volume=dns,target=/etc/resolv.conf \
+          --net=host \
+          --trust-keys-from-https \
+          {{.AWSCliImageRepo}}:{{.AWSCliTag}} --exec=/bin/bash -- \
+            -ec \
+            'echo decrypting tls assets; \
+             shopt -s nullglob; \
+             for encKey in /etc/etcd2/ssl/*.pem.enc; do \
+             echo decrypting $encKey; \
+             /usr/bin/aws \
+               --region {{.Region}} kms decrypt \
+               --ciphertext-blob fileb://$encKey \
+               --output text \
+               --query Plaintext \
+             | base64 -d > $${encKey%.enc}; \
+             done; \
+             echo done.'
+        ExecStart=-/usr/bin/rkt rm --uuid-file=/var/run/coreos/decrypt-tls-assets.uuid
 
         [Install]
         RequiredBy=etcd2.service
@@ -114,18 +157,6 @@ write_files:
       else
         echo "volume $1 is already formatted"
       fi
-
-  - path: /opt/bin/decrypt-tls-assets
-    owner: root:root
-    permissions: 0700
-    content: |
-      #!/bin/bash -e
-
-      for encKey in $(find /etc/etcd2/ssl/*.pem.enc);do
-        tmpPath="/tmp/$(basename $encKey).tmp"
-        docker run --net host --rm -v /etc/etcd2/ssl:/etc/etcd2/ssl --rm {{.AWSCliImageRepo}}:{{.AWSCliTag}} aws --region {{.Region}} kms decrypt --ciphertext-blob fileb://$encKey --output text --query Plaintext | base64 --decode > $tmpPath
-        mv  $tmpPath /etc/etcd2/ssl/$(basename $encKey .enc)
-      done
 
   - path: /etc/etcd2/ssl/ca.pem.enc
     encoding: gzip+base64

--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -19,9 +19,9 @@ coreos:
         After=network-online.target
 
         [Service]
-        Type=oneshot
+        Restart=on-failure
         RemainAfterExit=true
-        ExecStart=/usr/bin/rkt run \
+        ExecStartPre=/usr/bin/rkt run \
           --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
           --volume=awsenv,kind=host,source=/var/run/coreos,readOnly=false --mount volume=awsenv,target=/var/run/coreos \
           --net=host \
@@ -55,12 +55,13 @@ coreos:
         - name: 10-etcd.conf
           content: |
             [Unit]
-            Requires=cfn-etcd-environment.service
+            Wants=cfn-etcd-environment.service
             After=cfn-etcd-environment.service
 
             [Service]
-            EnvironmentFile=/etc/etcd-environment
+            EnvironmentFile=-/etc/etcd-environment
             EnvironmentFile=-/run/flannel/etcd-endpoints.opts
+            ExecStartPre=/usr/bin/systemctl is-active cfn-etcd-environment.service
             ExecStartPre=/bin/sh -ec "echo FLANNELD_ETCD_ENDPOINTS=${ETCD_ENDPOINTS} >/run/flannel/etcd-endpoints.opts"
             ExecStartPre=/opt/bin/decrypt-tls-assets
             Environment="ETCD_SSL_DIR=/etc/kubernetes/ssl"
@@ -71,11 +72,10 @@ coreos:
       runtime: true
       content: |
         [Unit]
-        Wants=flanneld.service
-        Requires=cfn-etcd-environment.service
+        Wants=flanneld.service cfn-etcd-environment.service
         After=cfn-etcd-environment.service
         [Service]
-        EnvironmentFile=/etc/etcd-environment
+        EnvironmentFile=-/etc/etcd-environment
         Environment=KUBELET_VERSION={{.K8sVer}}
         Environment=KUBELET_ACI={{.HyperkubeImageRepo}}
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
@@ -96,6 +96,7 @@ coreos:
         --volume cni-bin,kind=host,source=/opt/cni/bin \
         --mount volume=cni-bin,target=/opt/cni/bin{{ end }}"
         ExecStartPre=/usr/bin/systemctl is-active flanneld.service
+        ExecStartPre=/usr/bin/systemctl is-active cfn-etcd-environment.service
         ExecStartPre=/usr/bin/mkdir -p /var/lib/cni
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin

--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -100,7 +100,7 @@ coreos:
         ExecStartPre=/usr/bin/mkdir -p /var/lib/cni
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
-        ExecStartPre=/bin/sh -ec "sed -i 's|#ETCD_ENDPOINTS#|${ETCD_ENDPOINTS}|' /etc/kubernetes/manifests/* /etc/kubernetes/cni/net.d/*" 
+        ExecStartPre=/bin/bash -ec "shopt -s nullglob; sed -i 's|#ETCD_ENDPOINTS#|${ETCD_ENDPOINTS}|' /etc/kubernetes/manifests/* /etc/kubernetes/cni/net.d/*"
         ExecStartPre=/usr/bin/etcdctl \
                        --ca-file /etc/kubernetes/ssl/ca.pem \
                        --key-file /etc/kubernetes/ssl/etcd-client-key.pem \

--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -4,12 +4,35 @@ coreos:
     reboot-strategy: "off"
   flannel:
     interface: $private_ipv4
-    etcd_endpoints: {{ .EtcdEndpoints }}
     etcd_cafile: /etc/kubernetes/ssl/ca.pem
     etcd_certfile: /etc/kubernetes/ssl/etcd-client.pem
     etcd_keyfile: /etc/kubernetes/ssl/etcd-client-key.pem
 
   units:
+    - name: cfn-etcd-environment.service
+      enable: true
+      command: start
+      runtime: true
+      content: |
+        [Unit]
+        Description=Fetches etcd static IP addresses list from CF
+        After=network-online.target
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=true
+        ExecStart=/usr/bin/rkt run \
+          --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
+          --volume=awsenv,kind=host,source=/var/run/coreos,readOnly=false --mount volume=awsenv,target=/var/run/coreos \
+          --net=host \
+          --trust-keys-from-https \
+          {{.AWSCliImageRepo}}:{{.AWSCliTag}} -- cfn-init -v \
+              -c "etcd-client" \
+              --region {{.Region}} \
+              --resource LaunchConfigurationController \
+              --stack {{ .ClusterName }}
+        ExecStart=/usr/bin/mv -f /var/run/coreos/etcd-environment /etc/etcd-environment
+
     - name: docker.service
       drop-ins:
 {{if .Experimental.EphemeralImageStorage.Enabled}}
@@ -31,7 +54,14 @@ coreos:
       drop-ins:
         - name: 10-etcd.conf
           content: |
+            [Unit]
+            Requires=cfn-etcd-environment.service
+            After=cfn-etcd-environment.service
+
             [Service]
+            EnvironmentFile=/etc/etcd-environment
+            EnvironmentFile=-/run/flannel/etcd-endpoints.opts
+            ExecStartPre=/bin/sh -ec "echo FLANNELD_ETCD_ENDPOINTS=${ETCD_ENDPOINTS} >/run/flannel/etcd-endpoints.opts"
             ExecStartPre=/opt/bin/decrypt-tls-assets
             Environment="ETCD_SSL_DIR=/etc/kubernetes/ssl"
             TimeoutStartSec=120
@@ -42,7 +72,10 @@ coreos:
       content: |
         [Unit]
         Wants=flanneld.service
+        Requires=cfn-etcd-environment.service
+        After=cfn-etcd-environment.service
         [Service]
+        EnvironmentFile=/etc/etcd-environment
         Environment=KUBELET_VERSION={{.K8sVer}}
         Environment=KUBELET_ACI={{.HyperkubeImageRepo}}
         Environment="RKT_OPTS=--volume dns,kind=host,source=/etc/resolv.conf \
@@ -66,6 +99,13 @@ coreos:
         ExecStartPre=/usr/bin/mkdir -p /var/lib/cni
         ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
+        ExecStartPre=/bin/sh -ec "sed -i 's|#ETCD_ENDPOINTS#|${ETCD_ENDPOINTS}|' /etc/kubernetes/manifests/* /etc/kubernetes/cni/net.d/*" 
+        ExecStartPre=/usr/bin/etcdctl \
+                       --ca-file /etc/kubernetes/ssl/ca.pem \
+                       --key-file /etc/kubernetes/ssl/etcd-client-key.pem \
+                       --cert-file /etc/kubernetes/ssl/etcd-client.pem \
+                       --endpoints "${ETCD_ENDPOINTS}" \
+                       cluster-health
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
         --api-servers={{.APIServerEndpoint}} \
         --network-plugin-dir=/etc/kubernetes/cni/net.d \

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -412,9 +412,23 @@
           }
         ]
       },
+
       "Type": "AWS::IAM::Role"
     },
     {{range $etcdIndex, $etcdInstance := .EtcdInstances}}
+    "InstanceEtcd{{$etcdIndex}}eni": {
+      "Properties": {
+          "SubnetId": {
+            "Ref": "Subnet{{$etcdInstance.SubnetIndex}}"
+          },
+          "GroupSet": [
+            {
+              "Ref": "SecurityGroupEtcd"
+            }
+          ]
+      },
+      "Type": "AWS::EC2::NetworkInterface"
+    },
     "InstanceEtcd{{$etcdIndex}}": {
       "Properties": {
         "BlockDeviceMappings": [
@@ -451,18 +465,8 @@
         "KeyName": "{{$.KeyName}}",
         "NetworkInterfaces": [
           {
-            "AssociatePublicIpAddress": {{$.MapPublicIPs}},
-            "DeleteOnTermination": true,
-            "DeviceIndex": "0",
-            "GroupSet": [
-              {
-                "Ref": "SecurityGroupEtcd"
-              }
-            ],
-            "PrivateIpAddress": "{{$etcdInstance.IPAddress}}",
-            "SubnetId": {
-              "Ref": "Subnet{{$etcdInstance.SubnetIndex}}"
-            }
+            "NetworkInterfaceId": { "Ref": "InstanceEtcd{{$etcdIndex}}eni" },
+            "DeviceIndex": "0"
           }
         ],
         "Tags": [
@@ -563,9 +567,13 @@
         "PlacementTenancy": "{{ .ControllerTenancy }}",
         "UserData": "{{ .UserDataController }}"
       },
-  {{ if .Experimental.AwsEnvironment.Enabled }}
       "Metadata" : {
         "AWS::CloudFormation::Init" : {
+          "configSets" : {
+              "etcd-server": [ "etcd-server-env" ],
+              "etcd-client": [ "etcd-client-env" ]
+          },
+  {{ if .Experimental.AwsEnvironment.Enabled }}
           "config" : {
             "commands": {
               "write-environment": {
@@ -576,10 +584,41 @@
 "' > /etc/aws-environment" ] ] }
               }
             }
+          },
+  {{ end }}
+          "etcd-server-env": {
+            "files" : {
+              "/var/run/coreos/etcd-environment": {
+                "content": { "Fn::Join" : [ "", [
+                  "ETCD_INITIAL_CLUSTER='",
+{{range $index, $_ := $.EtcdInstances}}
+                  {{if $index}}",", {{end}}
+                  { "Fn::GetAtt" : [ "InstanceEtcd{{$index}}", "PrivateDnsName" ] },
+                  "=https://",
+                  { "Fn::GetAtt" : [ "InstanceEtcd{{$index}}", "PrivateDnsName" ] },
+                  ":2380",
+{{end}}
+                  "'\n"
+                ]]}
+              }
+            }
+          },
+          "etcd-client-env": {
+            "files" : {
+              "/var/run/coreos/etcd-environment": {
+                "content": { "Fn::Join" : [ "", [
+                  "ETCD_ENDPOINTS='",
+{{range $index, $_ := $.EtcdInstances}}
+                  {{if $index}}",", {{end}} "https://",
+                    { "Fn::GetAtt" : [ "InstanceEtcd{{$index}}", "PrivateDnsName" ] }, ":2379", 
+{{end}}
+                  "'\n"
+                ]]}
+              }
+            }
           }
         }
       },
-  {{end}}
       "Type": "AWS::AutoScaling::LaunchConfiguration"
     },
     "ElbAPIServer" : {

--- a/nodepool/config/config.go
+++ b/nodepool/config/config.go
@@ -30,7 +30,6 @@ type ProvidedConfig struct {
 	cfg.KubeClusterSettings `yaml:",inline"`
 	cfg.WorkerSettings      `yaml:",inline"`
 	cfg.DeploymentSettings  `yaml:",inline"`
-	EtcdEndpoints           string `yaml:"etcdEndpoints,omitempty"`
 	NodePoolName            string `yaml:"nodePoolName,omitempty"`
 	providedEncryptService  cfg.EncryptService
 }

--- a/nodepool/config/templates/cluster.yaml
+++ b/nodepool/config/templates/cluster.yaml
@@ -161,8 +161,6 @@ vpcCIDR: "{{.VPCCIDR}}"
 #   - availabilityZone: us-west-1b
 #     instanceCIDR: "10.0.1.0/24"
 
-etcdEndpoints: "{{.EtcdEndpoints}}"
-
 # Required by kubelet to locate the cluster-internal dns hosted on controller nodes in the base cluster
 dnsServiceIP: "{{.DNSServiceIP}}"
 


### PR DESCRIPTION
As part of effort to add support for provisioning into existing VPCs and subnets, kube-aws should stop trying to calculate static IPs itself: it is likely to cause conflicts for a first cluster in subnet and it is guaranteed not to work when provisioning second one.

This PR works by changing CF to save IP addresses  of InstanceEtcd in CF metadata which is then pulled by `cfn-init` scripts on nodes and placed in the right places.

It also adds explicit `AWS::EC2::NetworkInterface` resource which is then used as eth0 on Etcd instances.  Strictly speaking this change is not needed, but since `kube-aws`  decided not to manage Etcd instances after creation, in the real world they might need changes - having an explicit network interface resource allows instance to be recreated keeping same static IP.

Also few cleanups were done to etcd controller scripts.

