### PR TITLE
Use existing subnets when creating/updating cluster

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -259,10 +259,6 @@ func (c *Cluster) lockEtcdResources(cfSvc *cloudformation.CloudFormation, stackB
 }
 
 func (c *Cluster) Update(stackBody string, s3URI string) (string, error) {
-	if err := c.Validate(stackBody, s3URI); err != nil {
-		return "", err
-	}
-
 	cfSvc := cloudformation.New(c.session)
 	s3Svc := s3.New(c.session)
 

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -152,11 +152,6 @@ func (c *Cluster) stackProvisioner() *cfnstack.Provisioner {
 }
 
 func (c *Cluster) Validate(stackBody string, s3URI string) error {
-	r53Svc := route53.New(c.session)
-	if err := c.validateDNSConfig(r53Svc); err != nil {
-		return err
-	}
-
 	ec2Svc := ec2.New(c.session)
 	if c.KeyName != "" {
 		if err := c.validateKeyPair(ec2Svc); err != nil {
@@ -180,6 +175,11 @@ func (c *Cluster) Validate(stackBody string, s3URI string) error {
 }
 
 func (c *Cluster) Create(stackBody string, s3URI string) error {
+	r53Svc := route53.New(c.session)
+	if err := c.validateDNSConfig(r53Svc); err != nil {
+		return err
+	}
+
 	if err := c.Validate(stackBody, s3URI); err != nil {
 		return err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -302,9 +302,9 @@ type Cluster struct {
 type Subnet struct {
 	AvailabilityZone  string `yaml:"availabilityZone,omitempty"`
 	InstanceCIDR      string `yaml:"instanceCIDR,omitempty"`
+	lastAllocatedAddr *net.IP
 	SubnetId          string `yaml:"subnetId,omitempty"`
 	SubnetLogicalName string
-	lastAllocatedAddr *net.IP
 }
 
 type Experimental struct {

--- a/config/config.go
+++ b/config/config.go
@@ -302,6 +302,8 @@ type Cluster struct {
 type Subnet struct {
 	AvailabilityZone  string `yaml:"availabilityZone,omitempty"`
 	InstanceCIDR      string `yaml:"instanceCIDR,omitempty"`
+	SubnetId          string `yaml:"subnetId,omitempty"`
+	SubnetLogicalName string
 	lastAllocatedAddr *net.IP
 }
 
@@ -812,7 +814,11 @@ func (c DeploymentSettings) Valid() (*DeploymentValidationResult, error) {
 		}
 
 		var instanceCIDRs = make([]*net.IPNet, 0)
+
 		for i, subnet := range c.Subnets {
+			if subnet.SubnetId != "" {
+				continue
+			}
 			if subnet.AvailabilityZone == "" {
 				return nil, fmt.Errorf("availabilityZone must be set for subnet #%d", i)
 			}
@@ -935,7 +941,6 @@ Validates the an existing VPC and it's existing subnets do not conflict with thi
 cluster configuration
 */
 func (c *Cluster) ValidateExistingVPC(existingVPCCIDR string, existingSubnetCIDRS []string) error {
-
 	_, existingVPC, err := net.ParseCIDR(existingVPCCIDR)
 	if err != nil {
 		return fmt.Errorf("error parsing existing vpc cidr %s : %v", existingVPCCIDR, err)
@@ -970,19 +975,23 @@ func (c *Cluster) ValidateExistingVPC(existingVPCCIDR string, existingSubnetCIDR
 	// Loop through all subnets
 	// Note: legacy instanceCIDR/availabilityZone stuff has already been marshalled into this format
 	for _, subnet := range c.Subnets {
-		_, instanceNet, err := net.ParseCIDR(subnet.InstanceCIDR)
-		if err != nil {
-			return fmt.Errorf("error parsing instances cidr %s : %v", c.InstanceCIDR, err)
-		}
+		if subnet.SubnetId != "" {
+			continue
+		} else {
+			_, instanceNet, err := net.ParseCIDR(subnet.InstanceCIDR)
+			if err != nil {
+				return fmt.Errorf("error parsing instances cidr %s : %v", c.InstanceCIDR, err)
+			}
 
-		//Loop through all existing subnets in the VPC and look for conflicting CIDRS
-		for _, existingSubnet := range existingSubnets {
-			if netutil.CidrOverlap(instanceNet, existingSubnet) {
-				return fmt.Errorf(
-					"instance cidr (%s) conflicts with existing subnet cidr=%s",
-					instanceNet,
-					existingSubnet,
-				)
+			//Loop through all existing subnets in the VPC and look for conflicting CIDRS
+			for _, existingSubnet := range existingSubnets {
+				if netutil.CidrOverlap(instanceNet, existingSubnet) {
+					return fmt.Errorf(
+						"instance cidr (%s) conflicts with existing subnet cidr=%s",
+						instanceNet,
+						existingSubnet,
+					)
+				}
 			}
 		}
 	}
@@ -1074,4 +1083,12 @@ func withHostedZoneIDPrefix(id string) string {
 		return fmt.Sprintf("%s%s", hostedZoneIDPrefix, id)
 	}
 	return id
+}
+
+// Ref returns SubnetId or ref to newly created resource
+func (s Subnet) Ref() string {
+	if s.SubnetId != "" {
+		return fmt.Sprintf("%q", s.SubnetId)
+	}
+	return fmt.Sprintf(`{"Ref" : "%s"}`, s.SubnetLogicalName)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,14 +3,15 @@ package config
 import (
 	"bytes"
 	"fmt"
-	"github.com/coreos/kube-aws/netutil"
-	"github.com/coreos/kube-aws/test/helper"
-	"gopkg.in/yaml.v2"
 	"net"
 	"reflect"
 	"strings"
 	"testing"
 	"text/template"
+
+	"github.com/coreos/kube-aws/netutil"
+	"github.com/coreos/kube-aws/test/helper"
+	"gopkg.in/yaml.v2"
 )
 
 const minimalConfigYaml = `externalDNSName: test.staging.core-os.net
@@ -874,8 +875,8 @@ func TestValidateExistingVPC(t *testing.T) {
 
 	cluster.VPCCIDR = "10.0.0.0/16"
 	cluster.Subnets = []*Subnet{
-		{"ap-northeast-1a", "10.0.1.0/24", nil},
-		{"ap-northeast-1a", "10.0.2.0/24", nil},
+		{"ap-northeast-1a", "10.0.1.0/24", nil, "", ""},
+		{"ap-northeast-1a", "10.0.2.0/24", nil, "", ""},
 	}
 
 	for _, testCase := range validCases {
@@ -900,8 +901,8 @@ func TestValidateUserData(t *testing.T) {
 
 	cluster.Region = "us-west-1"
 	cluster.Subnets = []*Subnet{
-		{"us-west-1a", "10.0.1.0/16", nil},
-		{"us-west-1b", "10.0.2.0/16", nil},
+		{"us-west-1a", "10.0.1.0/16", nil, "", ""},
+		{"us-west-1b", "10.0.2.0/16", nil, "", ""},
 	}
 
 	helper.WithDummyCredentials(func(dir string) {
@@ -924,8 +925,8 @@ func TestRenderStackTemplate(t *testing.T) {
 
 	cluster.Region = "us-west-1"
 	cluster.Subnets = []*Subnet{
-		{"us-west-1a", "10.0.1.0/16", nil},
-		{"us-west-1b", "10.0.2.0/16", nil},
+		{"us-west-1a", "10.0.1.0/16", nil, "", ""},
+		{"us-west-1b", "10.0.2.0/16", nil, "", ""},
 	}
 
 	helper.WithDummyCredentials(func(dir string) {

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -171,8 +171,10 @@ controller:
 # subnets:
 #   - availabilityZone: us-west-1a
 #     instanceCIDR: "10.0.0.0/24"
+#     subnetId: "subnet-xxxxxxxx" #optional
 #   - availabilityZone: us-west-1b
 #     instanceCIDR: "10.0.1.0/24"
+#     subnetId: "subnet-xxxxxxxx" #optional
 
 # CIDR for all service IP addresses
 # serviceCIDR: "10.3.0.0/24"

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -51,12 +51,8 @@
         {{end}}
         "VPCZoneIdentifier": [
           {{range $index, $subnet := .Subnets}}
-          {{with $subnetLogicalName := printf "Subnet%d" $index}}
           {{if gt $index 0}},{{end}}
-          {
-            "Ref": "{{$subnetLogicalName}}"
-          }
-          {{end}}
+          {{$subnet.Ref}}
           {{end}}
         ]
       },
@@ -159,12 +155,8 @@
         ],
         "VPCZoneIdentifier": [
           {{range $index, $subnet := .Subnets}}
-          {{with $subnetLogicalName := printf "Subnet%d" $index}}
           {{if gt $index 0}},{{end}}
-          {
-            "Ref": "{{$subnetLogicalName}}"
-          }
-          {{end}}
+          {{$subnet.Ref}}
           {{end}}
         ],
         "LoadBalancerNames" : [
@@ -660,7 +652,7 @@
 	"Subnets" : [
           {{range $index, $subnet := .Subnets}}
           {{if gt $index 0}},{{end}}
-          { "Ref" : "Subnet{{$index}}" }
+          {{$subnet.Ref}}
           {{end}}
 	],
 	"Listeners" : [
@@ -1084,9 +1076,9 @@
     }
     {{end}}
     {{range $index, $subnet := .Subnets}}
-    {{with $subnetLogicalName := printf "Subnet%d" $index}}
+    {{if not $subnet.SubnetId }}
     ,
-    "{{$subnetLogicalName}}": {
+    "{{$subnet.SubnetLogicalName}}": {
       "Properties": {
         "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
         "CidrBlock": "{{$subnet.InstanceCIDR}}",
@@ -1094,7 +1086,7 @@
         "Tags": [
           {
             "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$subnetLogicalName}}"
+            "Value": "{{$.ClusterName}}-{{$subnet.SubnetLogicalName}}"
           },
           {
             "Key": "KubernetesCluster",
@@ -1105,17 +1097,17 @@
       },
       "Type": "AWS::EC2::Subnet"
     }
+    {{end}}
     {{if $.ElasticFileSystemID}}
     ,
-    "{{$subnetLogicalName}}MountTarget": {
+    "{{$subnet.SubnetLogicalName}}MountTarget": {
       "Properties" : {
         "FileSystemId": "{{$.ElasticFileSystemID}}",
-        "SubnetId": { "Ref": "{{$subnetLogicalName}}" },
+        "SubnetId": {{$subnet.Ref}},
         "SecurityGroups": [ { "Ref": "SecurityGroupMountTarget" } ]
       },
       "Type" : "AWS::EFS::MountTarget"
     }
-    {{end}}
     {{end}}
     {{end}}
     {{if not .VPCID}}
@@ -1190,14 +1182,12 @@
       "Type": "AWS::EC2::VPCGatewayAttachment"
     }
     {{range $index, $subnet := .Subnets}}
-    {{with $subnetLogicalName := printf "Subnet%d" $index}}
+    {{if not $subnet.SubnetId }}
     ,
-    "{{$subnetLogicalName}}RouteTableAssociation": {
+    "{{$subnet.SubnetLogicalName}}RouteTableAssociation": {
       "Properties": {
         "RouteTableId": { "Ref" : "RouteTable"},
-        "SubnetId": {
-          "Ref": "{{$subnetLogicalName}}"
-        }
+        "SubnetId": {{$subnet.Ref}}
       },
       "Type": "AWS::EC2::SubnetRouteTableAssociation"
     }
@@ -1206,14 +1196,12 @@
     {{else}}
     {{if .RouteTableID}}
     {{range $index, $subnet := .Subnets}}
-    {{with $subnetLogicalName := printf "Subnet%d" $index}}
+    {{if not $subnet.SubnetId }}
     ,
-    "{{$subnetLogicalName}}RouteTableAssociation": {
+    "{{$subnet.SubnetLogicalName}}RouteTableAssociation": {
       "Properties": {
         "RouteTableId": "{{$.RouteTableID}}",
-        "SubnetId": {
-          "Ref": "{{$subnetLogicalName}}"
-        }
+        "SubnetId": {{$subnet.Ref}}
       },
       "Type": "AWS::EC2::SubnetRouteTableAssociation"
     }

--- a/nodepool/config/config.go
+++ b/nodepool/config/config.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"path/filepath"
+
 	cfg "github.com/coreos/kube-aws/config"
 	"github.com/coreos/kube-aws/coreos/amiregistry"
 	"github.com/coreos/kube-aws/coreos/userdatavalidation"
@@ -14,7 +16,6 @@ import (
 	"github.com/coreos/kube-aws/filereader/userdatatemplate"
 	model "github.com/coreos/kube-aws/model"
 	"gopkg.in/yaml.v2"
-	"path/filepath"
 )
 
 type Ref struct {

--- a/nodepool/config/templates/stack-template.json
+++ b/nodepool/config/templates/stack-template.json
@@ -82,9 +82,7 @@
               {"GroupId":{{$sgRef}}}
               {{end}}
             ],
-            "SubnetId": {
-              {{$subnet.Ref}}
-            },
+            "SubnetId": {{$subnet.Ref}},
             "UserData": "{{$.UserDataWorker}}"
           }
           {{end}}
@@ -361,7 +359,7 @@
     "{{$subnet.SubnetLogicalName}}RouteTableAssociation": {
       "Properties": {
         "RouteTableId": {{$.RouteTableRef}},
-        "SubnetId": {{$subnet.Ref}},
+        "SubnetId": {{$subnet.Ref}}
       },
       "Type": "AWS::EC2::SubnetRouteTableAssociation"
     }

--- a/nodepool/config/templates/stack-template.json
+++ b/nodepool/config/templates/stack-template.json
@@ -49,7 +49,6 @@
         "SpotPrice": "{{$.Worker.SpotFleet.SpotPrice}}",
         "LaunchSpecifications": [
           {{range $subnetIndex, $subnet := $.Subnets}}
-          {{with $subnetLogicalName := printf "Subnet%d" $subnetIndex}}
           {{range $specIndex, $spec := $.Worker.SpotFleet.LaunchSpecifications}}
           {{if or (gt $subnetIndex 0) (gt $specIndex 0) }},{{end}}
           {
@@ -84,11 +83,10 @@
               {{end}}
             ],
             "SubnetId": {
-              "Ref": "{{$subnetLogicalName}}"
+              {{$subnet.Ref}}
             },
             "UserData": "{{$.UserDataWorker}}"
           }
-          {{end}}
           {{end}}
           {{end}}
         ]
@@ -145,12 +143,8 @@
         {{end}}
         "VPCZoneIdentifier": [
           {{range $index, $subnet := .Subnets}}
-          {{with $subnetLogicalName := printf "Subnet%d" $index}}
           {{if gt $index 0}},{{end}}
-          {
-            "Ref": "{{$subnetLogicalName}}"
-          }
-          {{end}}
+          {{$subnet.Ref}}
           {{end}}
         ]
       },
@@ -343,9 +337,9 @@
       "Type": "AWS::IAM::Role"
     }
     {{range $index, $subnet := .Subnets}}
-    {{with $subnetLogicalName := printf "Subnet%d" $index}}
+    {{if not $subnet.SubnetId }}
     ,
-    "{{$subnetLogicalName}}": {
+    "{{$subnet.SubnetLogicalName}}": {
       "Properties": {
         "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
         "CidrBlock": "{{$subnet.InstanceCIDR}}",
@@ -353,7 +347,7 @@
         "Tags": [
           {
             "Key": "Name",
-            "Value": "{{$.NodePoolName}}-{{$subnetLogicalName}}"
+            "Value": "{{$.NodePoolName}}-{{$subnet.SubnetLogicalName}}"
           },
           {
             "Key": "KubernetesCluster",
@@ -363,35 +357,26 @@
         "VpcId": {{$.VPCRef}}
       },
       "Type": "AWS::EC2::Subnet"
+    },
+    "{{$subnet.SubnetLogicalName}}RouteTableAssociation": {
+      "Properties": {
+        "RouteTableId": {{$.RouteTableRef}},
+        "SubnetId": {{$subnet.Ref}},
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation"
     }
+    {{end}}
     {{if $.ElasticFileSystemID}}
     ,
-    "{{$subnetLogicalName}}MountTarget": {
+    "{{$subnet.SubnetLogicalName}}MountTarget": {
       "Properties" : {
         "FileSystemId": "{{$.ElasticFileSystemID}}",
-        "SubnetId": { "Ref": "{{$subnetLogicalName}}" },
+        "SubnetId": { "Ref": "{{$subnet.SubnetLogicalName}}" },
         "SecurityGroups": [ { "Ref": "SecurityGroupMountTarget" } ]
       },
       "Type" : "AWS::EFS::MountTarget"
     }
     {{end}}
     {{end}}
-    {{end}}
-
-    {{range $index, $subnet := .Subnets}}
-    {{with $subnetLogicalName := printf "Subnet%d" $index}}
-    ,
-    "{{$subnetLogicalName}}RouteTableAssociation": {
-      "Properties": {
-        "RouteTableId": {{$.RouteTableRef}},
-        "SubnetId": {
-          "Ref": "{{$subnetLogicalName}}"
-        }
-      },
-      "Type": "AWS::EC2::SubnetRouteTableAssociation"
-    }
-    {{end}}
-    {{end}}
-
   }
 }


### PR DESCRIPTION
If you define `subnetId` you can reuse existing subnets.

```
subnets:
  - availabilityZone: us-east-1a
    instanceCIDR: "10.0.1.0/24"
    subnetId: "subnet-xxxxxxxx"
  - availabilityZone: us-east-1b
    instanceCIDR: "10.0.2.0/24"
    subnetId: "subnet-xxxxxxxx"
...
```

there is still some work needed to support node-pools, but I would love to hear opinions or any suggestions on this approach.

It's backward compatible and it uses CF Parameters to overload Subnets with existing subnet id's or references to new resources.

linked to #52