### PR TITLE
Change taint-and-uncordon worker task to use docker for now

### DIFF
--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -540,33 +540,23 @@ write_files:
 
       hostname=$(hostname)
 
-      sudo rkt run \
-        --volume=kube,kind=host,source=/etc/kubernetes,readOnly=true \
-        --mount=volume=kube,target=/etc/kubernetes \
-        --uuid-file-save=/var/run/coreos/taint-and-uncordon.uuid \
-        --volume=dns,kind=host,source=/etc/resolv.conf,readOnly=true --mount volume=dns,target=/etc/resolv.conf \
-        --net=host \
-        --trust-keys-from-https \
-        {{.HyperkubeImageRepo}}:{{.K8sVer}} --exec=/bin/bash -- \
-          -vxc \
-          'echo tainting this node; \
+      docker run --rm --net=host \
+        -v /etc/kubernetes:/etc/kubernetes \
+        -v /etc/resolv.conf:/etc/resolv.conf \
+        {{.HyperkubeImageRepo}}:{{.K8sVer}} /bin/bash \
+          -vxec \
+          'echo "tainting this node."; \
            hostname="'${hostname}'"; \
            taints=({{range $i, $taint := .Experimental.Taints}}"{{$taint.String}}" {{end}}); \
            kubectl="/kubectl --server=https://{{.ExternalDNSName}}:443 --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml"; \
-           taint="$kubectl taint node $hostname"; \
+           taint="$kubectl taint node --overwrite"; \
            for t in ${taints[@]}; do \
-             $taint "$t"; \
+             $taint "$hostname" "$t"; \
            done; \
-           echo done. ;\
-           echo uncordoning this node; \
+           echo "done."; \
+           echo "uncordoning this node."; \
            $kubectl uncordon $hostname;\
-           echo done.'
-
-      echo cleaning pod resources.
-
-      sudo rkt rm --uuid-file=/var/run/coreos/taint-and-uncordon.uuid
-
-      echo done.
+           echo "done."'
 
   - path: /etc/kubernetes/manifests/kube-proxy.yaml
     content: |


### PR DESCRIPTION
rkt has a gnarly bug (coreos/rkt#3181) that won't be fixed in a hurry (coreos/rkt#3486). It least to continuous task failures that eventually totally wreak worker nodes (#224). In the meantime we can use docker just as easily for this simple task. This work around was discussed in #199.

I tested deploying a node-pool or workers with this patch and the experimental.taint setting enabled and the right thing happened. The taint was applied and the node uncordoned. All looks good in the log and CPU load is nominal. 