### PR TITLE
Do not require keyName if sshAuthorizedKeys are set

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -158,8 +158,10 @@ func (c *Cluster) Create(stackBody string, s3URI string) error {
 	}
 
 	ec2Svc := ec2.New(c.session)
-	if err := c.validateKeyPair(ec2Svc); err != nil {
-		return err
+	if c.KeyName != "" {
+		if err := c.validateKeyPair(ec2Svc); err != nil {
+			return err
+		}
 	}
 
 	if err := c.validateExistingVPCState(ec2Svc); err != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -42,7 +42,6 @@ func runCmdInit(cmd *cobra.Command, args []string) error {
 		{"--external-dns-name", initOpts.ExternalDNSName},
 		{"--region", initOpts.Region},
 		{"--availability-zone", initOpts.AvailabilityZone},
-		{"--key-name", initOpts.KeyName},
 		{"--kms-key-arn", initOpts.KMSKeyARN},
 	}
 	var missing []string

--- a/cmd/nodepool/init.go
+++ b/cmd/nodepool/init.go
@@ -118,6 +118,7 @@ func runCmdInit(cmd *cobra.Command, args []string) error {
 	// because inconsistency between the main cluster and node pools result in
 	// unusable worker nodes that can't communicate with k8s apiserver, kube-dns, calico, etc.
 
+	initOpts.SSHAuthorizedKeys = main.SSHAuthorizedKeys
 	initOpts.KubeClusterSettings = main.KubeClusterSettings
 
 	if err := filegen.CreateFileFromTemplate(nodePoolClusterConfigFilePath(), initOpts, config.DefaultClusterConfig); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -830,8 +830,8 @@ func (c DeploymentSettings) Valid() (*DeploymentValidationResult, error) {
 		return nil, fmt.Errorf("releaseChannel %s is not supported", c.ReleaseChannel)
 	}
 
-	if c.KeyName == "" {
-		return nil, errors.New("keyName must be set")
+	if c.KeyName == "" && len(c.SSHAuthorizedKeys) == 0 {
+		return nil, errors.New("Either keyName or sshAuthorizedKeys must be set")
 	}
 	if c.ClusterName == "" {
 		return nil, errors.New("clusterName must be set")

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -448,7 +448,7 @@
         },
         "ImageId": "{{$.AMI}}",
         "InstanceType": "{{$.EtcdInstanceType}}",
-        "KeyName": "{{$.KeyName}}",
+        {{if $.KeyName}}"KeyName": "{{$.KeyName}}",{{end}}
         "NetworkInterfaces": [
           {
             "AssociatePublicIpAddress": {{$.MapPublicIPs}},
@@ -500,7 +500,7 @@
         },
         "ImageId": "{{.AMI}}",
         "InstanceType": "{{.WorkerInstanceType}}",
-        "KeyName": "{{.KeyName}}",
+        {{if .KeyName}}"KeyName": "{{.KeyName}}",{{end}}
         "SecurityGroups": [
           {{range $sgRef := .WorkerSecurityGroupRefs}}
             {{$sgRef}},
@@ -554,7 +554,7 @@
         },
         "ImageId": "{{.AMI}}",
         "InstanceType": "{{.ControllerInstanceType}}",
-        "KeyName": "{{.KeyName}}",
+        {{if .KeyName}}"KeyName": "{{.KeyName}}",{{end}}
         "SecurityGroups": [
           {
             "Ref": "SecurityGroupController"

--- a/nodepool/config/templates/cluster.yaml
+++ b/nodepool/config/templates/cluster.yaml
@@ -37,6 +37,15 @@ amiId: {{.AmiId}}
 # account being used to deploy this cluster.
 keyName: {{.KeyName}}
 
+# Additional keys to preload on the coreos account (keep this to a minimum)
+{{ if .SSHAuthorizedKeys }}
+sshAuthorizedKeys:
+{{ range $key := .SSHAuthorizedKeys}}- "{{$key}}"
+{{ end }}
+{{ else }}
+# sshAuthorizedKeys:
+{{ end }}
+
 # Region to provision Kubernetes cluster
 region: {{.Region}}
 

--- a/nodepool/config/templates/stack-template.json
+++ b/nodepool/config/templates/stack-template.json
@@ -15,7 +15,7 @@
           {
             "ImageId": "{{$.AMI}}",
             "InstanceType": "{{$spec.InstanceType}}",
-            "KeyName": "{{$.KeyName}}",
+            {{if $.KeyName}}"KeyName": "{{$.KeyName}}",{{end}}
             "WeightedCapacity": {{$spec.WeightedCapacity}},
             {{if $spec.SpotPrice}}
             "SpotPrice": "{{$spec.SpotPrice}}",
@@ -161,7 +161,7 @@
         },
         "ImageId": "{{.AMI}}",
         "InstanceType": "{{.WorkerInstanceType}}",
-        "KeyName": "{{.KeyName}}",
+        {{if .KeyName}}"KeyName": "{{.KeyName}}",{{end}}
         "SecurityGroups": [
           {{range $sgIndex, $sgRef := $.WorkerSecurityGroupRefs}}
           {{if gt $sgIndex 0}},{{end}}


### PR DESCRIPTION
AWS CF reference that it is not mandatory to have one:

http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#cfn-as-launchconfig-keyname