### PR TITLE
Bump calico policy controller to 0.5.2

### DIFF
--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -673,7 +673,7 @@ write_files:
         containers:
           # The Calico policy controller.
           - name: kube-policy-controller
-            image: calico/kube-policy-controller:v0.3.0
+            image: calico/kube-policy-controller:v0.5.2
             env:
               - name: ETCD_SCHEME
                 value: https


### PR DESCRIPTION
Fixes

```
2017-01-13 17:56:23,145 6 INFO Syncing 'NetworkPolicy' objects
2017-01-13 17:56:23,148 6 ERROR Unahandled exception killed NetworkPolicy manager
Traceback (most recent call last):
  File "<string>", line 295, in _manage_resource
  File "<string>", line 400, in _sync_resources
TypeError: object of type 'NoneType' has no len()
```

when there is no NetworkPolicy resource on a  new cluster