### PR TITLE
Fix node pools on master

### DIFF
--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -29,8 +29,8 @@ coreos:
           {{.AWSCliImageRepo}}:{{.AWSCliTag}} -- cfn-init -v \
               -c "etcd-client" \
               --region {{.Region}} \
-              --resource LaunchConfigurationController \
-              --stack {{ .ClusterName }}
+              --resource {{.Controller.LogicalName}} \
+              --stack {{ .StackName }}
         ExecStart=/usr/bin/mv -f /var/run/coreos/etcd-environment /etc/etcd-environment
 
 {{if .Experimental.AwsEnvironment.Enabled}}
@@ -54,8 +54,9 @@ coreos:
           --net=host \
           --trust-keys-from-https \
           {{.AWSCliImageRepo}}:{{.AWSCliTag}} -- cfn-init -v \
+              -c "aws-environment" \
               --region {{.Region}} \
-              --resource LaunchConfigurationController \
+              --resource {{.Controller.LogicalName}} \
               --stack {{.ClusterName}}
 {{end}}
     - name: docker.service
@@ -262,7 +263,7 @@ coreos:
           --trust-keys-from-https \
           quay.io/coreos/awscli:edge -- cfn-signal -e 0 \
               --region {{.Region}} \
-              --resource AutoScaleController \
+              --resource {{.Controller.LogicalName}} \
               --stack {{.ClusterName}}
 {{end}}
 {{if .Experimental.AwsNodeLabels.Enabled }}

--- a/config/templates/cloud-config-etcd
+++ b/config/templates/cloud-config-etcd
@@ -23,8 +23,8 @@ coreos:
           {{.AWSCliImageRepo}}:{{.AWSCliTag}} -- cfn-init -v \
               -c "etcd-server" \
               --region {{.Region}} \
-              --resource LaunchConfigurationController \
-              --stack {{ .ClusterName }}
+              --resource {{.Controller.LogicalName}} \
+              --stack {{ .StackName }}
         ExecStart=/usr/bin/mv -f /var/run/coreos/etcd-environment /etc/etcd-environment
 
     - name: etcd2.service

--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -29,8 +29,8 @@ coreos:
           {{.AWSCliImageRepo}}:{{.AWSCliTag}} -- cfn-init -v \
               -c "etcd-client" \
               --region {{.Region}} \
-              --resource LaunchConfigurationController \
-              --stack {{ .ClusterName }}
+              --resource {{.Worker.LogicalName}} \
+              --stack {{ .StackName }}
         ExecStart=/usr/bin/mv -f /var/run/coreos/etcd-environment /etc/etcd-environment
 
     - name: docker.service
@@ -212,8 +212,9 @@ coreos:
           --net=host \
           --trust-keys-from-https \
           {{.AWSCliImageRepo}}:{{.AWSCliTag}} -- cfn-init -v \
+              -c "aws-environment" \
               --region {{.Region}} \
-              --resource LaunchConfigurationWorker \
+              --resource {{.Worker.LogicalName}} \
               --stack {{.StackName}}
 {{end}}
 
@@ -310,7 +311,7 @@ coreos:
           --trust-keys-from-https \
           {{.AWSCliImageRepo}}:{{.AWSCliTag}} -- cfn-signal -e 0 \
               --region {{.Region}} \
-              --resource AutoScaleWorker \
+              --resource Workers \
               --stack {{.StackName}}
 {{end}}
 

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -9,7 +9,7 @@
     }
   },
   "Resources": {
-    "AutoScaleWorker": {
+    "{{.Worker.LogicalName}}": {
       "Properties": {
         "AvailabilityZones": [
           {{range $index, $subnet := .Subnets}}
@@ -87,9 +87,44 @@
           {{end}}
         }
       },
-      "DependsOn" : ["AutoScaleController"]
+      "Metadata" : {
+        "AWS::CloudFormation::Init" : {
+          "configSets" : {
+              "etcd-client": [ "etcd-client-env" ]{{if .Experimental.AwsEnvironment.Enabled}},
+              "aws-environment": [ "aws-environment-env" ]{{end}}
+          },
+          {{ if .Experimental.AwsEnvironment.Enabled }}
+          "aws-environment-env" : {
+            "commands": {
+              "write-environment": {
+                "command": { "Fn::Join" : ["", [ "echo '",
+                  {{range $variable, $function := .Experimental.AwsEnvironment.Environment}}
+                  "{{$variable}}=", {{$function}} , "\n",
+                  {{end}}
+                  "' > /etc/aws-environment" ] ] }
+              }
+            }
+          },
+          {{ end }}
+          "etcd-client-env": {
+            "files" : {
+              "/var/run/coreos/etcd-environment": {
+                "content": { "Fn::Join" : [ "", [
+                  "ETCD_ENDPOINTS='",
+{{range $index, $_ := $.EtcdInstances}}
+                  {{if $index}}",", {{end}} "https://",
+                    { "Fn::GetAtt" : [ "InstanceEtcd{{$index}}", "PrivateDnsName" ] }, ":2379",
+{{end}}
+                  "'\n"
+                ]]}
+              }
+            }
+          }
+        }
+      },
+      "DependsOn" : ["{{.Controller.LogicalName}}"]
     },
-    "AutoScaleController": {
+    "{{.Controller.LogicalName}}": {
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "Properties": {
         "AvailabilityZones": [
@@ -154,6 +189,59 @@
           {{else}}
           "PauseTime": "PT2M"
           {{end}}
+        }
+      },
+      "Metadata" : {
+        "AWS::CloudFormation::Init" : {
+          "configSets" : {
+              "etcd-server": [ "etcd-server-env" ],
+              "etcd-client": [ "etcd-client-env" ]{{if .Experimental.AwsEnvironment.Enabled}},
+              "aws-environment": [ "aws-environment-env" ]{{end}}
+          },
+          {{ if .Experimental.AwsEnvironment.Enabled }}
+          "aws-environment-env" : {
+            "commands": {
+              "write-environment": {
+                "command": { "Fn::Join" : ["", [ "echo '",
+                  {{range $variable, $function := .Experimental.AwsEnvironment.Environment}}
+                  "{{$variable}}=", {{$function}} , "\n",
+                  {{end}}
+                  "' > /etc/aws-environment" ] ] }
+              }
+            }
+          },
+          {{ end }}
+          "etcd-server-env": {
+            "files" : {
+              "/var/run/coreos/etcd-environment": {
+                "content": { "Fn::Join" : [ "", [
+                  "ETCD_INITIAL_CLUSTER='",
+                  {{range $index, $_ := $.EtcdInstances}}
+                  {{if $index}}",", {{end}}
+                  { "Fn::GetAtt" : [ "InstanceEtcd{{$index}}", "PrivateDnsName" ] },
+                  "=https://",
+                  { "Fn::GetAtt" : [ "InstanceEtcd{{$index}}", "PrivateDnsName" ] },
+                  ":2380",
+                  {{end}}
+                  "'\n"
+                ]]}
+              }
+            }
+          },
+          "etcd-client-env": {
+            "files" : {
+              "/var/run/coreos/etcd-environment": {
+                "content": { "Fn::Join" : [ "", [
+                  "ETCD_ENDPOINTS='",
+{{range $index, $_ := $.EtcdInstances}}
+                  {{if $index}}",", {{end}} "https://",
+                    { "Fn::GetAtt" : [ "InstanceEtcd{{$index}}", "PrivateDnsName" ] }, ":2379",
+{{end}}
+                  "'\n"
+                ]]}
+              }
+            }
+          }
         }
       }
     },
@@ -526,23 +614,6 @@
         {{end}}
         "UserData": "{{ .UserDataWorker }}"
       },
-{{ if .Experimental.AwsEnvironment.Enabled }}
-      "Metadata" : {
-        "AWS::CloudFormation::Init" : {
-          "config" : {
-            "commands": {
-              "write-environment": {
-                "command": { "Fn::Join" : ["", [ "echo '",
-{{range $variable, $function := .Experimental.AwsEnvironment.Environment}}
-"{{$variable}}=", {{$function}} , "\n",
-{{end}}
-"' > /etc/aws-environment" ] ] }
-              }
-            }
-          }
-        }
-      },
-{{end}}
       "Type": "AWS::AutoScaling::LaunchConfiguration"
     },
     "LaunchConfigurationController": {
@@ -572,58 +643,6 @@
         ],
         "PlacementTenancy": "{{ .ControllerTenancy }}",
         "UserData": "{{ .UserDataController }}"
-      },
-      "Metadata" : {
-        "AWS::CloudFormation::Init" : {
-          "configSets" : {
-              "etcd-server": [ "etcd-server-env" ],
-              "etcd-client": [ "etcd-client-env" ]
-          },
-  {{ if .Experimental.AwsEnvironment.Enabled }}
-          "config" : {
-            "commands": {
-              "write-environment": {
-                "command": { "Fn::Join" : ["", [ "echo '",
-{{range $variable, $function := .Experimental.AwsEnvironment.Environment}}
-"{{$variable}}=", {{$function}} , "\n",
-{{end}}
-"' > /etc/aws-environment" ] ] }
-              }
-            }
-          },
-  {{ end }}
-          "etcd-server-env": {
-            "files" : {
-              "/var/run/coreos/etcd-environment": {
-                "content": { "Fn::Join" : [ "", [
-                  "ETCD_INITIAL_CLUSTER='",
-{{range $index, $_ := $.EtcdInstances}}
-                  {{if $index}}",", {{end}}
-                  { "Fn::GetAtt" : [ "InstanceEtcd{{$index}}", "PrivateDnsName" ] },
-                  "=https://",
-                  { "Fn::GetAtt" : [ "InstanceEtcd{{$index}}", "PrivateDnsName" ] },
-                  ":2380",
-{{end}}
-                  "'\n"
-                ]]}
-              }
-            }
-          },
-          "etcd-client-env": {
-            "files" : {
-              "/var/run/coreos/etcd-environment": {
-                "content": { "Fn::Join" : [ "", [
-                  "ETCD_ENDPOINTS='",
-{{range $index, $_ := $.EtcdInstances}}
-                  {{if $index}}",", {{end}} "https://",
-                    { "Fn::GetAtt" : [ "InstanceEtcd{{$index}}", "PrivateDnsName" ] }, ":2379", 
-{{end}}
-                  "'\n"
-                ]]}
-              }
-            }
-          }
-        }
       },
       "Type": "AWS::AutoScaling::LaunchConfiguration"
     },
@@ -1222,6 +1241,13 @@
       "Description" : "The security group assigned to worker nodes",
       "Value" :  { "Ref" : "SecurityGroupWorker" },
       "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-WorkerSecurityGroup" }}
+    },
+    {{range $index, $_ := $.EtcdInstances}}
+    {{if $index}},{{end}}"InstanceEtcd{{$index}}PrivateDnsName": {
+      "Description": "The resolvable hostname of etcd node {{$index}}",
+      "Value": { "Fn::GetAtt" : [ "InstanceEtcd{{$index}}", "PrivateDnsName" ] },
+      "Export": { "Name" : "{{$.ClusterName}}-InstanceEtcd{{$index}}PrivateDnsName" }
     }
+    {{end}}
   }
 }

--- a/e2e/run
+++ b/e2e/run
@@ -4,10 +4,6 @@ KUBE_AWS_CMD=${KUBE_AWS_CMD:-$GOPATH/src/github.com/coreos/kube-aws/bin/kube-aws
 E2E_DIR=$(cd $(dirname $0); pwd)
 WORK_DIR=${E2E_DIR}/assets/${KUBE_AWS_CLUSTER_NAME}
 TESTINFRA_DIR=${E2E_DIR}/testinfra
-KUBE_AWS_NODE_POOL_INDEX=${KUBE_AWS_NODE_POOL_INDEX:-1}
-KUBE_AWS_NODE_POOL_NAME=${KUBE_AWS_CLUSTER_NAME}-nodepool${KUBE_AWS_NODE_POOL_INDEX}
-KUBE_AWS_NODE_POOL_STACK_NAME=${KUBE_AWS_CLUSTER_NAME}-${KUBE_AWS_NODE_POOL_NAME}
-NODE_POOL_ASSETS_DIR=${E2E_DIR}/assets/${KUBE_AWS_CLUSTER_NAME}/node-pools/${KUBE_AWS_NODE_POOL_NAME}
 KUBE_AWS_TEST_INFRA_STACK_NAME=${KUBE_AWS_TEST_INFRA_STACK_NAME:-${KUBE_AWS_CLUSTER_NAME}-testinfra}
 SRC_DIR=$(cd $(dirname $0); cd ..; pwd)
 KUBECONFIG=${WORK_DIR}/kubeconfig
@@ -54,6 +50,22 @@ build() {
   echo Building kube-aws
   cd ${SRC_DIR}
   ./build
+}
+
+main_stack_name() {
+  echo $KUBE_AWS_CLUSTER_NAME
+}
+
+main_all() {
+  status=$(aws cloudformation describe-stacks --stack-name $(main_stack_name) --output json | jq -rc '.Stacks[0].StackStatus')
+  if [ "$status" = "" ]; then
+    prepare
+    configure
+    up
+    if [ "$KUBE_AWS_UPDATE" != "" ]; then
+      update
+    fi
+  fi
 }
 
 prepare() {
@@ -254,11 +266,11 @@ first_host_for_asg() {
 }
 
 controller_host() {
-  first_host_for_asg AutoScaleController
+  first_host_for_asg Controllers
 }
 
 worker_host() {
-  first_host_for_asg AutoScaleWorker
+  first_host_for_asg Workers
 }
 
 ssh_controller() {
@@ -269,17 +281,29 @@ ssh_worker() {
   ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${KUBE_AWS_SSH_KEY} core@$(worker_host) "$@"
 }
 
+nodepool_stack_name() {
+  echo ${KUBE_AWS_CLUSTER_NAME}-$(nodepool_name)
+}
+
+nodepool_name() {
+  echo nodepool${KUBE_AWS_NODE_POOL_INDEX}
+}
+
+nodepool_assets_dir() {
+  echo ${E2E_DIR}/assets/${KUBE_AWS_CLUSTER_NAME}/node-pools/$(nodepool_name)
+}
+
 nodepool_init() {
   cd ${WORK_DIR}
 
-  ${KUBE_AWS_CMD} node-pools init --node-pool-name ${KUBE_AWS_NODE_POOL_NAME} \
+  ${KUBE_AWS_CMD} node-pools init --node-pool-name $(nodepool_name) \
       --availability-zone ${KUBE_AWS_AVAILABILITY_ZONE} \
       --key-name ${KUBE_AWS_KEY_NAME} \
       --kms-key-arn ${KUBE_AWS_KMS_KEY_ARN}
 
-  cd ${NODE_POOL_ASSETS_DIR}
+  cd $(nodepool_assets_dir)
 
-  echo -e "instanceCIDR: 10.0.${KUBE_AWS_NODE_POOL_INDEX}.0/24" >> ${NODE_POOL_ASSETS_DIR}/cluster.yaml
+  echo -e "instanceCIDR: 10.0.${KUBE_AWS_NODE_POOL_INDEX}.0/24" >> $(nodepool_assets_dir)/cluster.yaml
 
   customize_worker
 
@@ -294,26 +318,26 @@ nodepool_init() {
 nodepool_render() {
   cd ${WORK_DIR}
 
-  ${KUBE_AWS_CMD} node-pools render stack --node-pool-name ${KUBE_AWS_NODE_POOL_NAME}
+  ${KUBE_AWS_CMD} node-pools render stack --node-pool-name $(nodepool_name)
 }
 
 nodepool_validate() {
   cd ${WORK_DIR}
 
-  ${KUBE_AWS_CMD} node-pools validate --node-pool-name ${KUBE_AWS_NODE_POOL_NAME} --s3-uri ${KUBE_AWS_S3_URI}
+  ${KUBE_AWS_CMD} node-pools validate --node-pool-name $(nodepool_name) --s3-uri ${KUBE_AWS_S3_URI}
 }
 
 nodepool_up() {
   cd ${WORK_DIR}
 
-  ${KUBE_AWS_CMD} node-pools up --node-pool-name ${KUBE_AWS_NODE_POOL_NAME} --export
-  ${KUBE_AWS_CMD} node-pools up --node-pool-name ${KUBE_AWS_NODE_POOL_NAME} --s3-uri ${KUBE_AWS_S3_URI}
+  ${KUBE_AWS_CMD} node-pools up --node-pool-name $(nodepool_name) --export
+  ${KUBE_AWS_CMD} node-pools up --node-pool-name $(nodepool_name) --s3-uri ${KUBE_AWS_S3_URI}
 }
 
 nodepool_update() {
   cd ${WORK_DIR}
 
-  pushd ${NODE_POOL_ASSETS_DIR}
+  pushd $(nodepool_assets_dir)
 
   if [ "${KUBE_AWS_SPOT_FLEET_ENABLED}" ]; then
     SED_CMD="sed -e 's/targetCapacity: 3/targetCapacity: 5/'"
@@ -325,32 +349,48 @@ nodepool_update() {
 
   popd
 
-  ${KUBE_AWS_CMD} node-pools update --node-pool-name ${KUBE_AWS_NODE_POOL_NAME} --s3-uri ${KUBE_AWS_S3_URI}
+  ${KUBE_AWS_CMD} node-pools update --node-pool-name $(nodepool_name) --s3-uri ${KUBE_AWS_S3_URI}
 }
 
 nodepool_destroy() {
   cd ${WORK_DIR}
 
-  status=$(aws cloudformation describe-stacks --stack-name ${KUBE_AWS_NODE_POOL_STACK_NAME} --output json | jq -rc '.Stacks[0].StackStatus')
+  status=$(aws cloudformation describe-stacks --stack-name $(nodepool_stack_name) --output json | jq -rc '.Stacks[0].StackStatus')
 
-  if [ "$status" != "DELETE_IN_PROGRESS" ]; then
-    ${KUBE_AWS_CMD} node-pools destroy --node-pool-name ${KUBE_AWS_NODE_POOL_NAME}
-    aws cloudformation wait stack-delete-complete \
-            --stack-name ${KUBE_AWS_NODE_POOL_STACK_NAME}
+  if [ "$status" != "" ]; then
+    if [ "$status" != "DELETE_IN_PROGRESS" ]; then
+      ${KUBE_AWS_CMD} node-pools destroy --node-pool-name $(nodepool_name)
+      aws cloudformation wait stack-delete-complete \
+            --stack-name $(nodepool_stack_name)
+    else
+      aws cloudformation wait stack-delete-complete \
+          --stack-name $(nodepool_stack_name)
+    fi
   else
-    aws cloudformation wait stack-delete-complete \
-        --stack-name ${KUBE_AWS_NODE_POOL_STACK_NAME}
+    echo ${nodepool_stack_name} does not exist. skipping.
   fi
+
+  rm -Rf $(nodepool_assets_dir)
+}
+
+nodepool_status() {
+  aws cloudformation describe-stacks --stack-name $(nodepool_stack_name) --output json | jq -rc '.Stacks[0].StackStatus'
 }
 
 nodepool() {
   cd ${WORK_DIR}
 
-  nodepool_init
+  if [ ! -e "$(nodepool_assets_dir)/cluster.yaml" ]; then
+    nodepool_init
+  fi
   nodepool_render
   nodepool_validate
-  nodepool_up
-  nodepool_update
+  if [ "$(nodepool_status)" = "" ]; then
+    nodepool_up
+  fi
+  if [ "$KUBE_AWS_UPDATE" != "" ]; then
+    nodepool_update
+  fi
 }
 
 testinfra_up() {
@@ -412,11 +452,9 @@ all() {
     testinfra_up
   fi
 
-  prepare
-  configure
-  up
-  nodepool
-  update
+  main_all
+  KUBE_AWS_NODE_POOL_INDEX=1 nodepool
+  KUBE_AWS_NODE_POOL_INDEX=2 KUBE_AWS_SPOT_FLEET_ENABLED=1 KUBE_AWS_WAIT_SIGNAL_ENABLED= nodepool
   conformance
 }
 

--- a/model/controller.go
+++ b/model/controller.go
@@ -3,3 +3,7 @@ package model
 type Controller struct {
 	AutoScalingGroup `yaml:"autoScalingGroup,omitempty"`
 }
+
+func (c Controller) LogicalName() string {
+	return "Controllers"
+}

--- a/model/etcd.go
+++ b/model/etcd.go
@@ -1,0 +1,8 @@
+package model
+
+import "net"
+
+type EtcdInstance struct {
+	IPAddress   net.IP
+	SubnetIndex int
+}

--- a/model/worker.go
+++ b/model/worker.go
@@ -51,9 +51,8 @@ func newDefaultSpotFleet() SpotFleet {
 		UnitRootVolumeSize: 30,
 		RootVolumeType:     "gp2",
 		LaunchSpecifications: []LaunchSpecification{
-			NewLaunchSpecification(1, "t2.medium"),
-			NewLaunchSpecification(2, "m3.large"),
-			NewLaunchSpecification(2, "m4.large"),
+			NewLaunchSpecification(1, "c4.large"),
+			NewLaunchSpecification(2, "c4.xlarge"),
 		},
 	}
 }

--- a/model/worker.go
+++ b/model/worker.go
@@ -68,6 +68,10 @@ func NewLaunchSpecification(weightedCapacity int, instanceType string) LaunchSpe
 	}
 }
 
+func (c Worker) LogicalName() string {
+	return "Workers"
+}
+
 func (c Worker) Valid() error {
 	if err := c.SpotFleet.Valid(); err != nil {
 		return err

--- a/nodepool/config/templates/cluster.yaml
+++ b/nodepool/config/templates/cluster.yaml
@@ -134,7 +134,7 @@ manageCertificates: {{.ManageCertificates}}
 #    launchSpecifications:
 #    - # Number of units provided by an EC2 instance of the instanceType.
 #      weightedCapacity: 1
-#      instanceType: t2.medium
+#      instanceType: c4.large
 #
 #      # Price per unit hour = Price per instance hour / num of weighted capacity for the instance
 #      #spotPrice:
@@ -150,9 +150,7 @@ manageCertificates: {{.ManageCertificates}}
 #      # Defaults to worker.spotFleet.unitRootVolumeIOPS * weightedCapacity if omitted
 #      #rootVolumeIOPS:
 #    - weightedCapacity: 2
-#      instanceType: m3.large
-#    - weightedCapacity: 2
-#      instanceType: m4.large
+#      instanceType: c4.xlarge
 
 ## Networking config
 

--- a/nodepool/config/templates/stack-template.json
+++ b/nodepool/config/templates/stack-template.json
@@ -1,5 +1,45 @@
+{{define "Metadata"}}
+
+{
+  "AWS::CloudFormation::Init" : {
+    "configSets" : {
+      "etcd-client": [ "etcd-client-env" ]{{ if .Experimental.AwsEnvironment.Enabled }},
+      "aws-environment": [ "aws-environment-env" ]{{end}}
+    },
+    {{ if .Experimental.AwsEnvironment.Enabled }}
+    "aws-environment-env" : {
+      "commands": {
+         "write-environment": {
+          "command": {
+            "Fn::Join" : ["", [ "echo '",
+            {{range $variable, $function := .Experimental.AwsEnvironment.Environment}}
+            "{{$variable}}=", {{$function}} , "\n",
+            {{end}}
+            "' > /etc/aws-environment" ] ]
+          }
+        }
+      }
+    },
+    {{end}}
+    "etcd-client-env": {
+      "files" : {
+        "/var/run/coreos/etcd-environment": {
+          "content": { "Fn::Join" : [ "", [
+            "ETCD_ENDPOINTS='",
+            {{range $index, $_ := $.EtcdInstances}}
+            {{if $index}}",", {{end}} "https://",
+              { "Fn::ImportValue" : "{{$.ClusterName}}-InstanceEtcd{{$index}}PrivateDnsName" }, ":2379",
+            {{end}}
+            "'\n"
+          ]]}
+        }
+      }
+    }
+  }
+}
+{{end}}
 {{define "SpotFleet"}}
-  "SpotFleet": {
+  "{{.Worker.LogicalName}}": {
     "Type": "AWS::EC2::SpotFleet",
     "Properties": {
       "SpotFleetRequestConfigData": {
@@ -53,11 +93,12 @@
           {{end}}
         ]
       }
-    }
+    },
+    "Metadata": {{template "Metadata" .}}
   },
 {{end}}
 {{define "AutoScaling"}}
-    "AutoScaleWorker": {
+    "{{.Worker.LogicalName}}": {
       "Properties": {
         "AvailabilityZones": [
           {{range $index, $subnet := .Subnets}}
@@ -139,7 +180,8 @@
           "PauseTime": "PT2M"
           {{end}}
         }
-      }
+      },
+      "Metadata": {{template "Metadata" .}}
     },
 
     "LaunchConfigurationWorker": {
@@ -175,23 +217,6 @@
         {{end}}
         "UserData": "{{ .UserDataWorker }}"
       },
-  {{ if .Experimental.AwsEnvironment.Enabled }}
-        "Metadata" : {
-          "AWS::CloudFormation::Init" : {
-            "config" : {
-              "commands": {
-                "write-environment": {
-                  "command": { "Fn::Join" : ["", [ "echo '",
-  {{range $variable, $function := .Experimental.AwsEnvironment.Environment}}
-  "{{$variable}}=", {{$function}} , "\n",
-  {{end}}
-  "' > /etc/aws-environment" ] ] }
-                }
-              }
-            }
-          }
-        },
-  {{end}}
       "Type": "AWS::AutoScaling::LaunchConfiguration"
     },
 {{end}}


### PR DESCRIPTION
This is a follow up for the PR #226 "Don't precalculate etcd static IP addresses"

To see why this follow up was needed, read the maintainer's comment at #226 (comment)

P.S. As the result of some refactorings done in order to implement this, worker nodes powered by a spot fleet now supports the `awsEnvironment` experimental feature

fixes #261 

cc @redbaron 