### PR TITLE
worker userdata template: availability zone is not pre-pended to the EFS name

### DIFF
--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -262,7 +262,7 @@ coreos:
         [Service]
         Type=oneshot
         ExecStartPre=-/usr/bin/mkdir -p /efs
-        ExecStart=/bin/sh -c 'grep -qs /efs /proc/mounts || /usr/bin/mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 $(/usr/bin/curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone).{{ $.ElasticFileSystemID }}.efs.{{ $.Region }}.amazonaws.com:/ /efs'
+        ExecStart=/bin/sh -c 'grep -qs /efs /proc/mounts || /usr/bin/mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 {{ $.ElasticFileSystemID }}.efs.{{ $.Region }}.amazonaws.com:/ /efs'
         ExecStop=/usr/bin/umount /efs
         RemainAfterExit=yes
         [Install]


### PR DESCRIPTION
The worker userdata template does not need to get the availability zone to prepend to the ElasticFileSystemID. 