### PR TITLE
Fix connection drop after 60 sec when executing commands inside containers

### DIFF
--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -657,6 +657,9 @@
 	  "Timeout" : "8",
 	  "UnhealthyThreshold" : "3"
 	},
+	"ConnectionSettings" : {
+	  "IdleTimeout" : "3600"
+	},
 	"Subnets" : [
           {{range $index, $subnet := .Subnets}}
           {{if gt $index 0}},{{end}}


### PR DESCRIPTION
By default, when watching container logs using "kubectl logs -f" or
executing a command inside a container, the connection is terminated
after 60 seconds, resulting in errors like "error: unexpected EOF".
This happens because the AWS ELB in front of the k8s api server has the
"IdleTimeout" parameter set to 60. But can be increased up to 3600
seconds.

Here is the official documentation:
http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/config-idle-timeout.html