### PR TITLE
Follow up: Use existing subnets when creating/updating cluster

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -179,6 +179,12 @@ func ClusterFromBytes(data []byte) (*Cluster, error) {
 		}
 	}
 
+	for index, s := range c.Subnets {
+		if s.SubnetLogicalName == "" {
+			s.SubnetLogicalName = fmt.Sprintf("Subnet%d", index)
+		}
+	}
+
 	return c, nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -330,12 +330,14 @@ subnets:
 `,
 			subnets: []*Subnet{
 				{
-					InstanceCIDR:     "10.4.3.0/24",
-					AvailabilityZone: "ap-northeast-1a",
+					InstanceCIDR:      "10.4.3.0/24",
+					AvailabilityZone:  "ap-northeast-1a",
+					SubnetLogicalName: "Subnet0",
 				},
 				{
-					InstanceCIDR:     "10.4.4.0/24",
-					AvailabilityZone: "ap-northeast-1c",
+					InstanceCIDR:      "10.4.4.0/24",
+					AvailabilityZone:  "ap-northeast-1c",
+					SubnetLogicalName: "Subnet1",
 				},
 			},
 		},
@@ -349,8 +351,9 @@ instanceCIDR: 10.4.3.0/24
 `,
 			subnets: []*Subnet{
 				{
-					AvailabilityZone: "ap-northeast-1a",
-					InstanceCIDR:     "10.4.3.0/24",
+					AvailabilityZone:  "ap-northeast-1a",
+					InstanceCIDR:      "10.4.3.0/24",
+					SubnetLogicalName: "Subnet0",
 				},
 			},
 		},
@@ -365,8 +368,9 @@ subnets: []
 `,
 			subnets: []*Subnet{
 				{
-					AvailabilityZone: "ap-northeast-1a",
-					InstanceCIDR:     "10.4.3.0/24",
+					AvailabilityZone:  "ap-northeast-1a",
+					InstanceCIDR:      "10.4.3.0/24",
+					SubnetLogicalName: "Subnet0",
 				},
 			},
 		},
@@ -378,8 +382,9 @@ subnets: []
 `,
 			subnets: []*Subnet{
 				{
-					AvailabilityZone: "ap-northeast-1a",
-					InstanceCIDR:     "10.0.0.0/24",
+					AvailabilityZone:  "ap-northeast-1a",
+					InstanceCIDR:      "10.0.0.0/24",
+					SubnetLogicalName: "Subnet0",
 				},
 			},
 		},
@@ -390,8 +395,9 @@ availabilityZone: "ap-northeast-1a"
 `,
 			subnets: []*Subnet{
 				{
-					AvailabilityZone: "ap-northeast-1a",
-					InstanceCIDR:     "10.0.0.0/24",
+					AvailabilityZone:  "ap-northeast-1a",
+					InstanceCIDR:      "10.0.0.0/24",
+					SubnetLogicalName: "Subnet0",
 				},
 			},
 		},
@@ -452,7 +458,7 @@ subnets:
 		}
 		if !reflect.DeepEqual(c.Subnets, conf.subnets) {
 			t.Errorf(
-				"parsed subnets %s does not expected subnets %s in config: %s",
+				"parsed subnets %s does not match expected subnets %s in config: %s",
 				c.Subnets,
 				conf.subnets,
 				confBody,

--- a/e2e/run
+++ b/e2e/run
@@ -56,12 +56,20 @@ main_stack_name() {
   echo $KUBE_AWS_CLUSTER_NAME
 }
 
+main_status() {
+  aws cloudformation describe-stacks --stack-name $(main_stack_name) --output json | jq -rc '.Stacks[0].StackStatus'
+}
+
 main_all() {
   status=$(aws cloudformation describe-stacks --stack-name $(main_stack_name) --output json | jq -rc '.Stacks[0].StackStatus')
   if [ "$status" = "" ]; then
-    prepare
-    configure
-    up
+    if [ ! -e "${WORK_DIR}/cluster.yaml" ]; then
+      prepare
+      configure
+    fi
+    if [ "$(main_status)" = "" ]; then
+      up
+    fi
     if [ "$KUBE_AWS_UPDATE" != "" ]; then
       update
     fi
@@ -174,9 +182,19 @@ up() {
   set -vx
 }
 
-destroy() {
-  aws cloudformation delete-stack --stack-name ${KUBE_AWS_CLUSTER_NAME}
-  aws cloudformation wait stack-delete-complete --stack-name ${KUBE_AWS_CLUSTER_NAME}
+main_destroy() {
+  status=$(main_status)
+
+  if [ "$status" != "" ]; then
+    if [ "$status" != "DELETE_IN_PROGRESS" ]; then
+        aws cloudformation delete-stack --stack-name $(main_stack_name)
+        aws cloudformation wait stack-delete-complete --stack-name $(main_stack_name)
+    else
+        aws cloudformation wait stack-delete-complete --stack-name $(main_stack_name)
+    fi
+  else
+    echo $(main_stack_name) does not exist. skipping.
+  fi
 }
 
 update() {
@@ -355,7 +373,7 @@ nodepool_update() {
 nodepool_destroy() {
   cd ${WORK_DIR}
 
-  status=$(aws cloudformation describe-stacks --stack-name $(nodepool_stack_name) --output json | jq -rc '.Stacks[0].StackStatus')
+  status=$(nodepool_status)
 
   if [ "$status" != "" ]; then
     if [ "$status" != "DELETE_IN_PROGRESS" ]; then
@@ -460,7 +478,7 @@ all() {
 
 all_destroy() {
   nodepool_destroy
-  destroy
+  main_destroy
   if [ "${KUBE_AWS_DEPLOY_TO_EXISTING_VPC}" != "" ]; then
     testinfra_destroy
   fi

--- a/nodepool/config/config.go
+++ b/nodepool/config/config.go
@@ -184,6 +184,12 @@ func ClusterFromBytes(data []byte, main *cfg.Config) (*ProvidedConfig, error) {
 		}
 	}
 
+	for index, s := range c.Subnets {
+		if s.SubnetLogicalName == "" {
+			s.SubnetLogicalName = fmt.Sprintf("Subnet%d", index)
+		}
+	}
+
 	c.EtcdInstances = main.EtcdInstances
 
 	return c, nil


### PR DESCRIPTION
This PR includes the follow-up described in my comment https://github.com/coreos/kube-aws/pull/227#issuecomment-274651054, which is merged immediately after #227
