### PR TITLE
Remove checks for dedicated spot instances

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -733,14 +733,6 @@ func (c Cluster) valid() error {
 		return err
 	}
 
-	if c.WorkerTenancy != "default" && c.Worker.SpotFleet.Enabled() {
-		return fmt.Errorf("selected worker tenancy (%s) is incompatible with spot fleet", c.WorkerTenancy)
-	}
-
-	if c.WorkerTenancy != "default" && c.WorkerSpotPrice != "" {
-		return fmt.Errorf("selected worker tenancy (%s) is incompatible with spot instances", c.WorkerTenancy)
-	}
-
 	if c.Worker.ClusterAutoscaler.Enabled() {
 		return fmt.Errorf("cluster-autoscaler support can't be enabled for a main cluster because allowing so" +
 			"results in unreliability while scaling nodes out. " +


### PR DESCRIPTION
[As of Jan 19, these are no longer mutually exclusive](https://aws.amazon.com/about-aws/whats-new/2017/01/amazon-ec2-spot-instances-now-support-dedicated-tenancy/).

Will be testing this shortly and will report back here.

The two features that I added to `kube-aws`, together at last. 😃