### PR TITLE
Add support for customization of network topologies

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -185,8 +185,8 @@ func (c *Cluster) SetDefaults() {
 	publicTopologyImplied := c.RouteTableID != "" && c.MapPublicIPs
 
 	for i, s := range c.Subnets {
-		if s.CustomName == "" {
-			c.Subnets[i].CustomName = fmt.Sprintf("Subnet%d", i)
+		if s.Name == "" {
+			c.Subnets[i].Name = fmt.Sprintf("Subnet%d", i)
 		}
 
 		// DEPRECATED AND REMOVED IN THE FUTURE
@@ -969,7 +969,7 @@ func (s DeploymentSettings) AllSubnets() []model.Subnet {
 
 func (c DeploymentSettings) FindSubnetMatching(condition model.Subnet) model.Subnet {
 	for _, s := range c.Subnets {
-		if s.CustomName == condition.CustomName {
+		if s.Name == condition.Name {
 			return s
 		}
 	}
@@ -1015,14 +1015,15 @@ func (c DeploymentSettings) NATGateways() []model.NATGateway {
 		var publicSubnet model.Subnet
 		ngwConfig := privateSubnet.NATGateway
 		if privateSubnet.ManageNATGateway() {
-			found := false
+			publicSubnetFound := false
 			for _, s := range c.PublicSubnets() {
 				if s.AvailabilityZone == privateSubnet.AvailabilityZone {
 					publicSubnet = s
-					found = true
+					publicSubnetFound = true
+					break
 				}
 			}
-			if !found {
+			if !publicSubnetFound {
 				panic(fmt.Sprintf("No appropriate public subnet found for a non-preconfigured NAT gateway associated to private subnet %s", privateSubnet.LogicalName()))
 			}
 			ngw := model.NewNATGateway(ngwConfig, privateSubnet, publicSubnet)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -315,7 +315,7 @@ func TestMultipleSubnets(t *testing.T) {
 
 	validConfigs := []struct {
 		conf    string
-		subnets []*model.Subnet
+		subnets []model.Subnet
 	}{
 		{
 			conf: `
@@ -328,18 +328,16 @@ subnets:
   - availabilityZone: ap-northeast-1c
     instanceCIDR: 10.4.4.0/24
 `,
-			subnets: []*model.Subnet{
+			subnets: []model.Subnet{
 				{
 					InstanceCIDR:     "10.4.3.0/24",
 					AvailabilityZone: "ap-northeast-1a",
 					CustomName:       "Subnet0",
-					TopLevel:         true,
 				},
 				{
 					InstanceCIDR:     "10.4.4.0/24",
 					AvailabilityZone: "ap-northeast-1c",
 					CustomName:       "Subnet1",
-					TopLevel:         true,
 				},
 			},
 		},
@@ -351,12 +349,11 @@ controllerIP: 10.4.3.50
 availabilityZone: ap-northeast-1a
 instanceCIDR: 10.4.3.0/24
 `,
-			subnets: []*model.Subnet{
+			subnets: []model.Subnet{
 				{
 					AvailabilityZone: "ap-northeast-1a",
 					InstanceCIDR:     "10.4.3.0/24",
 					CustomName:       "Subnet0",
-					TopLevel:         true,
 				},
 			},
 		},
@@ -369,12 +366,11 @@ availabilityZone: ap-northeast-1a
 instanceCIDR: 10.4.3.0/24
 subnets: []
 `,
-			subnets: []*model.Subnet{
+			subnets: []model.Subnet{
 				{
 					AvailabilityZone: "ap-northeast-1a",
 					InstanceCIDR:     "10.4.3.0/24",
 					CustomName:       "Subnet0",
-					TopLevel:         true,
 				},
 			},
 		},
@@ -384,12 +380,11 @@ subnets: []
 availabilityZone: "ap-northeast-1a"
 subnets: []
 `,
-			subnets: []*model.Subnet{
+			subnets: []model.Subnet{
 				{
 					AvailabilityZone: "ap-northeast-1a",
 					InstanceCIDR:     "10.0.0.0/24",
 					CustomName:       "Subnet0",
-					TopLevel:         true,
 				},
 			},
 		},
@@ -398,12 +393,11 @@ subnets: []
 # Missing subnets field fall-backs to the single subnet with the default az/cidr.
 availabilityZone: "ap-northeast-1a"
 `,
-			subnets: []*model.Subnet{
+			subnets: []model.Subnet{
 				{
 					AvailabilityZone: "ap-northeast-1a",
 					InstanceCIDR:     "10.0.0.0/24",
 					CustomName:       "Subnet0",
-					TopLevel:         true,
 				},
 			},
 		},
@@ -743,16 +737,11 @@ func newMinimalConfig() (*Config, error) {
 	cluster := NewDefaultCluster()
 	cluster.ExternalDNSName = "k8s.example.com"
 	cluster.Region = "us-west-1"
-	cluster.Subnets = []*model.Subnet{
-		&model.Subnet{
-			AvailabilityZone: "us-west-1a",
-			InstanceCIDR:     "10.0.0.0/24",
-		},
-		&model.Subnet{
-			AvailabilityZone: "us-west-1b",
-			InstanceCIDR:     "10.0.1.0/24",
-		},
+	cluster.Subnets = []model.Subnet{
+		model.NewPublicSubnet("us-west-1a", "10.0.0.0/24"),
+		model.NewPublicSubnet("us-west-1b", "10.0.1.0/24"),
 	}
+	cluster.SetDefaults()
 	c, err := cluster.Config()
 	if err != nil {
 		return nil, err
@@ -886,9 +875,9 @@ func TestValidateExistingVPC(t *testing.T) {
 	cluster := NewDefaultCluster()
 
 	cluster.VPCCIDR = "10.0.0.0/16"
-	cluster.Subnets = []*model.Subnet{
-		{"ap-northeast-1a", "10.0.1.0/24", "", "", "", model.NatGateway{}, true},
-		{"ap-northeast-1a", "10.0.2.0/24", "", "", "", model.NatGateway{}, true},
+	cluster.Subnets = []model.Subnet{
+		model.NewPublicSubnet("ap-northeast-1a", "10.0.1.0/24"),
+		model.NewPublicSubnet("ap-northeast-1a", "10.0.2.0/24"),
 	}
 
 	for _, testCase := range validCases {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -332,12 +332,12 @@ subnets:
 				{
 					InstanceCIDR:     "10.4.3.0/24",
 					AvailabilityZone: "ap-northeast-1a",
-					CustomName:       "Subnet0",
+					Name:             "Subnet0",
 				},
 				{
 					InstanceCIDR:     "10.4.4.0/24",
 					AvailabilityZone: "ap-northeast-1c",
-					CustomName:       "Subnet1",
+					Name:             "Subnet1",
 				},
 			},
 		},
@@ -353,7 +353,7 @@ instanceCIDR: 10.4.3.0/24
 				{
 					AvailabilityZone: "ap-northeast-1a",
 					InstanceCIDR:     "10.4.3.0/24",
-					CustomName:       "Subnet0",
+					Name:             "Subnet0",
 				},
 			},
 		},
@@ -370,7 +370,7 @@ subnets: []
 				{
 					AvailabilityZone: "ap-northeast-1a",
 					InstanceCIDR:     "10.4.3.0/24",
-					CustomName:       "Subnet0",
+					Name:             "Subnet0",
 				},
 			},
 		},
@@ -384,7 +384,7 @@ subnets: []
 				{
 					AvailabilityZone: "ap-northeast-1a",
 					InstanceCIDR:     "10.0.0.0/24",
-					CustomName:       "Subnet0",
+					Name:             "Subnet0",
 				},
 			},
 		},
@@ -397,7 +397,7 @@ availabilityZone: "ap-northeast-1a"
 				{
 					AvailabilityZone: "ap-northeast-1a",
 					InstanceCIDR:     "10.0.0.0/24",
-					CustomName:       "Subnet0",
+					Name:             "Subnet0",
 				},
 			},
 		},

--- a/config/stack_config_test.go
+++ b/config/stack_config_test.go
@@ -10,10 +10,11 @@ func TestRenderStackTemplate(t *testing.T) {
 	clusterConfig := newDefaultClusterWithDeps(&dummyEncryptService{})
 
 	clusterConfig.Region = "us-west-1"
-	clusterConfig.Subnets = []*model.Subnet{
-		{"us-west-1a", "10.0.1.0/16", "", "", "", model.NatGateway{}, false},
-		{"us-west-1b", "10.0.2.0/16", "", "", "", model.NatGateway{}, false},
+	clusterConfig.Subnets = []model.Subnet{
+		model.NewPublicSubnet("us-west-1a", "10.0.1.0/16"),
+		model.NewPublicSubnet("us-west-1b", "10.0.2.0/16"),
 	}
+	clusterConfig.SetDefaults()
 
 	helper.WithDummyCredentials(func(dir string) {
 		var stackTemplateOptions = StackTemplateOptions{
@@ -44,10 +45,11 @@ func TestValidateUserData(t *testing.T) {
 	cluster := newDefaultClusterWithDeps(&dummyEncryptService{})
 
 	cluster.Region = "us-west-1"
-	cluster.Subnets = []*model.Subnet{
-		{"us-west-1a", "10.0.1.0/16", "", "", "", model.NatGateway{}, false},
-		{"us-west-1b", "10.0.2.0/16", "", "", "", model.NatGateway{}, false},
+	cluster.Subnets = []model.Subnet{
+		model.NewPublicSubnet("us-west-1a", "10.0.1.0/16"),
+		model.NewPublicSubnet("us-west-1b", "10.0.2.0/16"),
 	}
+	cluster.SetDefaults()
 
 	helper.WithDummyCredentials(func(dir string) {
 		var stackTemplateOptions = StackTemplateOptions{

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -205,7 +205,8 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #     #   id: "ngw-abcdef12"
 #     #   # Pre-allocated EIP for NAT Gateways. Used with private subnets.
 #     #   eipAllocationId: "eipalloc-abcdef12"
-#     subnetId: "subnet-xxxxxxxx" #optional
+#     # Existing subnet. Beware that `availabilityZone` can't be omitted; it must be the one in which the subnet exists.
+#     # id: "subnet-xxxxxxxx" #optional
 
 # CIDR for all service IP addresses
 # serviceCIDR: "10.3.0.0/24"

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -59,11 +59,27 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #    minSize: 1
 #    maxSize: 3
 #    rollingUpdateMinInstancesInService: 2
+#  # If omitted, public subnets are created by kube-aws and used for controller nodes
 #  subnets:
-#    - availabilityZone: us-west-1a
-#      instanceCIDR: "10.0.4.0/24"
-#    - availabilityZone: us-west-1b
-#      instanceCIDR: "10.0.5.0/24"
+#    # References subnets defined under the top-level `subnets` key by their names
+#    - name: ManagedPublicSubnet1
+#    - name: ManagedPublicSubnet2
+#  loadBalancer:
+#    # kube-aws creates the ELB for the k8s API endpoint as `Schema=internet-facing` by default and
+#    # only public subnets defined under the top-level `subnets` key are used for the ELB
+#    # private: false
+#    #
+#    # If you like specific public subnets to be used by the internet-facing ELB:
+#    # subnets:
+#    #   - name: ManagedPublicSubnet0
+#
+#    # When explicitly set to true, the ELB for the k8s API endpoint becomes `Schema=internal` rather than default `Schema=internet-facing` one and
+#    # only private subnets defined under the top-level `subnets` key are used for the ELB
+#    # private: true
+#    #
+#    # If you like specific private subnets to be used by the internal ELB:
+#    # subnets:
+#    #   - name: ManagedPrivateSubnet0
 
 # Set to true to put the ELB on the public subnet although having controller nodes on private subnets
 #controllerLoadBalancerPrivate: false
@@ -93,11 +109,10 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #    minSize: 1
 #    maxSize: 3
 #    rollingUpdateMinInstancesInService: 2
+#  # If omitted, public subnets are created by kube-aws and used for worker nodes
 #  subnets:
-#    - availabilityZone: us-west-1a
-#      instanceCIDR: "10.0.6.0/24"
-#    - availabilityZone: us-west-1b
-#      instanceCIDR: "10.0.7.0/24"
+#    # References subnets defined under the top-level `subnets` key by their names
+#    - name: ManagedPublicSubnet1
 
 # Setting worker topology private ensures NAT Gateways are created for use in node pools.
 #workerTopologyPrivate: false
@@ -140,11 +155,11 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # etcdCount: 1
 
 #etcd:
+#  # If omitted, public subnets are created by kube-aws and used for etcd nodes
 #  subnets:
-#    - availabilityZone: us-west-1a
-#      instanceCIDR: "10.0.2.0/24"
-#    - availabilityZone: us-west-1b
-#      instanceCIDR: "10.0.3.0/24"
+#    # References subnets defined under the top-level `subnets` key by their names
+#    - name: ManagedPrivateSubnet1
+#    - name: ManagedPrivateSubnet2
 
 # Instance type for etcd node
 # etcdInstanceType: t2.medium
@@ -184,8 +199,21 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # ID of existing Internet Gateway to associate subnet with. Leave blank to create a new Internet Gateway
 # internetGatewayId:
 
-# ID of existing route table in existing VPC to attach subnet to. Leave blank to use the VPC's main route table.
-# routeTableId:
+# Advanced: ID of existing route table in existing VPC to attach subnet to.
+# Leave blank to use the VPC's main route table.
+# This should be specified if and only if vpcId is specified.
+#
+# IMPORTANT NOTICE:
+#
+# If routeTableId is specified, it's your responsibility to add an appropriate route to
+# an internet gateway(IGW) or a NAT gateway(NGW) to the route table.
+#
+# More concretely,
+# * If you like to make all the subnets private, pre-configure an NGW yourself and add a route to the NGW beforehand
+# * If you like to make all the subnets public, pre-configure an IGW yourself and add a route to the IGW beforehand
+# * If you like to mix private and public subnets, omit routeTableId but specify subnets[].routeTable.id per subnet
+#
+# routeTableId: rtb-xxxxxxxx
 
 # CIDR for Kubernetes VPC. If vpcId is specified, must match the CIDR of existing vpc.
 # vpcCIDR: "10.0.0.0/16"
@@ -193,20 +221,160 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # CIDR for Kubernetes subnet when placing nodes in a single availability zone (not highly-available) Leave commented out for multi availability zone setting and use the below `subnets` section instead.
 # instanceCIDR: "10.0.0.0/24"
 
-# Kubernetes subnets with their CIDRs and availability zones. Differentiating availability zone for 2 or more subnets result in high-availability (failures of a single availability zone won't result in immediate downtimes)
+# Kubernetes subnets with their CIDRs and availability zones.
+# Differentiating availability zone for 2 or more subnets result in high-availability (failures of a single availability zone won't result in immediate downtimes)
 # subnets:
-#   - availabilityZone: us-west-1a
+#   #
+#   # Managed public subnet managed by kube-aws
+#   #
+#   - name: ManagedPublicSubnet1
+#     # Set to false if this subnet is public
+#     # private: false
+#     availabilityZone: us-west-1a
 #     instanceCIDR: "10.0.0.0/24"
-#     subnetId: "subnet-xxxxxxxx" #optional
-#   - availabilityZone: us-west-1b
+#
+#   #
+#   # Managed private subnet managed by kube-aws
+#   #
+#   - name: ManagedPrivateSubnet1
+#     # Set to true if this subnet is private
+#     private: true
+#     availabilityZone: us-west-1a
 #     instanceCIDR: "10.0.1.0/24"
-#     # natGateway:
-#     #   # Pre-allocated NAT Gateway. Used with private subnets.
-#     #   id: "ngw-abcdef12"
-#     #   # Pre-allocated EIP for NAT Gateways. Used with private subnets.
-#     #   eipAllocationId: "eipalloc-abcdef12"
-#     # Existing subnet. Beware that `availabilityZone` can't be omitted; it must be the one in which the subnet exists.
-#     # id: "subnet-xxxxxxxx" #optional
+#
+#   #
+#   # Advanced: Unmanaged/existing public subnet reused but not managed by kube-aws
+#   #
+#   # An internet gateway(igw) and a route table contains the route to the igw must have been properly configured by YOU.
+#   # kube-aws tries to reuse the subnet specified by id or idFromStackOutput but kube-aws never modify the subnet
+#   #
+#   - name: ExistingPublicSubnet1
+#     # Beware that `availabilityZone` can't be omitted; it must be the one in which the subnet exists.
+#     availabilityZone: us-west-1a
+#     # ID of existing subnet to be reused.
+#     # availabilityZone should still be provided but instanceCIDR can be omitted when id is specified.
+#     id: "subnet-xxxxxxxx"
+#     # Exported output's name from another stack
+#     # Only specify either id or idFromStackOutput but not both
+#     #idFromStackOutput: myinfra-PublicSubnet1
+#
+#   #
+#   # Advanced: Unmanaged/existing private subnet reused but not managed by kube-aws
+#   #
+#   # A nat gateway(ngw) and a route table contains the route to the ngw must have been properly configured by YOU.
+#   # kube-aws tries to reuse the subnet specified by id or idFromStackOutput but kube-aws never modify the subnet
+#   #
+#   - name: ExistingPrivateSubnet1
+#     # Beware that `availabilityZone` can't be omitted; it must be the one in which the subnet exists.
+#     availabilityZone: us-west-1a
+#     # Existing subnet.
+#     id: "subnet-xxxxxxxx"
+#     # Exported output's name from another stack
+#     # Only specify either id or idFromStackOutput but not both
+#     #idFromStackOutput: myinfra-PrivateSubnet1
+#
+#   #
+#   # Advanced: Managed private subnet with an existing NAT gateway
+#   #
+#   # kube-aws tries to reuse the ngw specified by id or idFromStackOutput
+#   # by adding a route to the ngw to a route table managed by kube-aws
+#   #
+#   # Please be sure that the NGW is properly deployed. kube-aws will never modify ngw itself.
+#   #
+#   - name: ManagedPrivateSubnetWithExistingNGW
+#     private: true
+#     availabilityZone: us-west-1a
+#     instanceCIDR: "10.0.1.0/24"
+#     natGateway:
+#       id: "ngw-xxxxxxxx"
+#       # Exported output's name from another stack
+#       # Only specify either id or idFromStackOutput but not both
+#       #idFromStackOutput: myinfra-PrivateSubnet1
+#
+#   #
+#   # Advanced: Managed private subnet with an existing NAT gateway
+#   #
+#   # kube-aws tries to reuse the ngw specified by id or idFromStackOutput
+#   # by adding a route to the ngw to a route table managed by kube-aws
+#   #
+#   # Please be sure that the NGW is properly deployed. kube-aws will never modify ngw itself.
+#   # For example, kube-aws won't assign a pre-allocated EIP to the existing ngw for you.
+#   #
+#   - name: ManagedPrivateSubnetWithExistingNGW
+#     private: true
+#     availabilityZone: us-west-1a
+#     instanceCIDR: "10.0.1.0/24"
+#     natGateway:
+#       # Pre-allocated NAT Gateway. Used with private subnets.
+#       id: "ngw-xxxxxxxx"
+#       # Exported output's name from another stack
+#       # Only specify either id or idFromStackOutput but not both
+#       #idFromStackOutput: myinfra-PrivateSubnet1
+#
+#   #
+#   # Advanced: Managed private subnet with an existing EIP for kube-aws managed NGW
+#   #
+#   # kube-aws tries to reuse the EIP specified by eipAllocationId
+#   # by associating the EIP to a NGW managed by kube-aws.
+#   # Please be sure that kube-aws won't assign an EIP to an existing NGW i.e.
+#   # either natGateway.id or eipAllocationId can be specified but not both.
+#   #
+#   - name: ManagedPrivateSubnetWithManagedNGWWithExistingEIP
+#     private: true
+#     availabilityZone: us-west-1a
+#     instanceCIDR: "10.0.1.0/24"
+#     natGateway:
+#       # Pre-allocated EIP for NAT Gateways. Used with private subnets.
+#       eipAllocationId: eipalloc-xxxxxxxx
+#
+#   #
+#   # Advanced: Managed private subnet with an existing route table
+#   #
+#   # kube-aws tries to reuse the route table specified by id or idFromStackOutput
+#   # by assigning this subnet to the route table.
+#   #
+#   # Please be sure that it's your responsibility to:
+#   # * Configure an AWS managed NAT or a NAT instance or an another NAT and
+#   # * Add a route to the NAT to the route table being reused
+#   #
+#   # i.e. kube-aws neither modify route table nor create other related resources like
+#   # ngw, route to nat gateway, eip for ngw, etc.
+#   #
+#   - name: ManagedPrivateSubnetWithExistingRouteTable
+#     private: true
+#     availabilityZone: us-west-1a
+#     instanceCIDR: "10.0.1.0/24"
+#     routeTable:
+#       # Pre-allocated route table
+#       id: "rtb-xxxxxxxx"
+#       # Exported output's name from another stack
+#       # Only specify either id or idFromStackOutput but not both
+#       #idFromStackOutput: myinfra-PrivateRouteTable1
+#
+#   #
+#   # Advanced: Managed public subnet with an existing route table
+#   #
+#   # kube-aws tries to reuse the route table specified by id or idFromStackOutput
+#   # by assigning this subnet to the route table.
+#   #
+#   # Please be sure that it's your responsibility to:
+#   # * Configure an internet gateway(IGW) and
+#   # * Attach the IGW to the VPC you're deploying to
+#   # * Add a route to the IGW to the route table being reused
+#   #
+#   # i.e. kube-aws neither modify route table nor create other related resources like
+#   # igw, route to igw, igw vpc attachment, etc.
+#   #
+#   - name: ManagedPublicSubnetWithExistingRouteTable
+#     availabilityZone: us-west-1a
+#     instanceCIDR: "10.0.1.0/24"
+#     routeTable:
+#       # Pre-allocated route table
+#       id: "rtb-xxxxxxxx"
+#       # Exported output's name from another stack
+#       # Only specify either id or idFromStackOutput but not both
+#       #idFromStackOutput: myinfra-PublicRouteTable1
+
 
 # CIDR for all service IP addresses
 # serviceCIDR: "10.3.0.0/24"

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -47,9 +47,7 @@
         "VPCZoneIdentifier": [
           {{range $index, $subnet := .Worker.Subnets}}
           {{if gt $index 0}},{{end}}
-          {
-            "Ref": "{{$.Worker.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}"
-          }
+          {{$subnet.Ref}}
           {{end}}
         ]
       },
@@ -148,9 +146,7 @@
         "VPCZoneIdentifier": [
           {{range $index, $subnet := .Controller.Subnets}}
           {{if gt $index 0}},{{end}}
-          {
-            "Ref": "{{$.Controller.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}"
-          }
+          {{$subnet.Ref}}
           {{end}}
         ],
         "LoadBalancerNames" : [
@@ -229,7 +225,8 @@
             }
           }
         }
-      }
+      },
+      "DependsOn": ["InstanceEtcd0"]
     },
     {{ if .CreateRecordSet }}
     "ExternalDNS": {
@@ -512,9 +509,7 @@
     {{range $etcdIndex, $etcdInstance := .EtcdInstances}}
     "InstanceEtcd{{$etcdIndex}}eni": {
       "Properties": {
-          "SubnetId": {
-              "Ref": "{{$etcdInstance.SubnetLogicalNamePrefix}}{{$etcdInstance.Subnet.LogicalName}}"
-          },
+          "SubnetId": {{$etcdInstance.Subnet.Ref}},
           "GroupSet": [
             {
               "Ref": "SecurityGroupEtcd"
@@ -576,6 +571,9 @@
         "Tenancy": "{{$.EtcdTenancy}}",
         "UserData": { "Fn::FindInMap" : [ "EtcdInstanceParams", "UserData", "cloudconfig"] }
       },
+      {{if $etcdInstance.Subnet.Private}}
+      "DependsOn": ["{{$etcdInstance.Subnet.NATGatewayRouteName}}"],
+      {{end}}
       "Type": "AWS::EC2::Instance"
     },
     {{end}}
@@ -723,9 +721,9 @@
           "IdleTimeout" : "3600"
         },
         "Subnets" : [
-          {{range $index, $subnet := .ControllerElb.Subnets}}
+          {{range $index, $subnet := .Controller.LoadBalancer.Subnets}}
           {{if gt $index 0}},{{end}}
-          {"Ref": "{{$.ControllerElb.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}"}
+          {{$subnet.Ref}}
           {{end}}
         ],
         "Listeners" : [
@@ -736,7 +734,7 @@
             "Protocol" : "TCP"
           }
         ],
-        {{if .ControllerLoadBalancerPrivate}}
+        {{if .Controller.LoadBalancer.Private}}
         "Scheme": "internal",
         {{else}}
         "Scheme": "internet-facing",
@@ -1150,13 +1148,13 @@
     {{end}}
 
     {{range $index, $subnet := .Subnets}}
-    {{if not $subnet.ID }}
+    {{if not $subnet.HasIdentifier }}
     ,
     "{{$subnet.LogicalName}}": {
       "Properties": {
         "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
         "CidrBlock": "{{$subnet.InstanceCIDR}}",
-        "MapPublicIpOnLaunch": {{$.MapPublicIPs}},
+        "MapPublicIpOnLaunch": {{$subnet.MapPublicIPs}},
         "Tags": [
           {
             "Key": "Name",
@@ -1170,7 +1168,7 @@
         "VpcId": {{$.VPCRef}}
       },
       "Type": "AWS::EC2::Subnet"
-    },
+    }
     {{end}}
     {{if $.ElasticFileSystemID}}
     ,
@@ -1183,32 +1181,21 @@
       "Type" : "AWS::EFS::MountTarget"
     }
     {{end}}
+    ,
     "{{$subnet.LogicalName}}RouteTableAssociation": {
       "Properties": {
-        "RouteTableId":
-          {{if not $subnet.RouteTableID}}
-          {"Ref" : "PublicRouteTable"},
-          {{else}}
-          "{{$subnet.RouteTableID}}",
-          {{end}}
+        "RouteTableId": {{$subnet.RouteTableRef}},
         "SubnetId": {{$subnet.Ref}}
       },
       "Type": "AWS::EC2::SubnetRouteTableAssociation"
     }
-    {{end}}
-
-    {{if $.Etcd.TopologyPrivate}}
-    {{range $etcdIndex, $etcdInstance := .EtcdInstances}}
     ,
-    "{{$etcdInstance.SubnetLogicalNamePrefix}}{{$etcdInstance.Subnet.LogicalName}}": {
+    "{{$subnet.RouteTableName}}": {
       "Properties": {
-        "AvailabilityZone": "{{$etcdInstance.Subnet.AvailabilityZone}}",
-        "CidrBlock": "{{$etcdInstance.Subnet.InstanceCIDR}}",
-        "MapPublicIpOnLaunch": {{not $.Etcd.TopologyPrivate}},
         "Tags": [
           {
             "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$etcdInstance.SubnetLogicalNamePrefix}}{{$etcdInstance.Subnet.LogicalName}}"
+            "Value": "{{$.ClusterName}}-{{$subnet.RouteTableName}}"
           },
           {
             "Key": "KubernetesCluster",
@@ -1217,112 +1204,16 @@
         ],
         "VpcId": {{$.VPCRef}}
       },
-      "Type": "AWS::EC2::Subnet"
+      "Type": "AWS::EC2::RouteTable"
     }
+    {{if $subnet.Public}}
     ,
-    "{{$etcdInstance.SubnetLogicalNamePrefix}}{{$etcdInstance.Subnet.LogicalName}}RouteTableAssociation": {
-      "Properties": {
-        "RouteTableId":
-          {{if not $etcdInstance.Subnet.RouteTableID}}
-          {"Ref" : "PrivateRouteTable{{$etcdInstance.Subnet.AvailabilityZoneLogicalName}}"},
-          {{else}}
-          "{{$etcdInstance.Subnet.RouteTableID}}",
-          {{end}}
-        "SubnetId": {
-          "Ref": "{{$etcdInstance.SubnetLogicalNamePrefix}}{{$etcdInstance.Subnet.LogicalName}}"
-        }
-      },
-      "Type": "AWS::EC2::SubnetRouteTableAssociation"
-    }
-    {{end}}
-    {{end}}
-
-    {{if $.Controller.TopologyPrivate}}
-    {{range $index, $subnet := .Controller.Subnets}}
-    ,
-    "{{$.Controller.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}": {
-      "Properties": {
-        "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
-        "CidrBlock": "{{$subnet.InstanceCIDR}}",
-        "MapPublicIpOnLaunch": {{not $.Controller.TopologyPrivate}},
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$.Controller.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{$.ClusterName}}"
-          }
-        ],
-        "VpcId": {{$.VPCRef}}
-      },
-      "Type": "AWS::EC2::Subnet"
-    }
-    ,
-    "{{$.Controller.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}RouteTableAssociation": {
-      "Properties": {
-        "RouteTableId":
-          {{if not $subnet.RouteTableID}}
-          {"Ref" : "PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}"},
-          {{else}}
-          "{{$subnet.RouteTableID}}",
-          {{end}}
-        "SubnetId": {
-          "Ref": "{{$.Controller.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}"
-        }
-      },
-      "Type": "AWS::EC2::SubnetRouteTableAssociation"
-    }
-    {{end}}
-    {{end}}
-
-    {{if $.Worker.TopologyPrivate}}
-    {{range $index, $subnet := .Worker.Subnets}}
-    ,
-    "{{$.Worker.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}": {
-      "Properties": {
-        "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
-        "CidrBlock": "{{$subnet.InstanceCIDR}}",
-        "MapPublicIpOnLaunch": {{not $.Worker.TopologyPrivate}},
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$.Worker.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{$.ClusterName}}"
-          }
-        ],
-        "VpcId": {{$.VPCRef}}
-      },
-      "Type": "AWS::EC2::Subnet"
-    }
-    ,
-    "{{$.Worker.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}RouteTableAssociation": {
-      "Properties": {
-        "RouteTableId":
-          {{if not $subnet.RouteTableID}}
-          {"Ref" : "PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}"},
-          {{else}}
-          "{{$subnet.RouteTableID}}",
-          {{end}}
-        "SubnetId": {
-          "Ref": "{{$.Worker.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}"
-        }
-      },
-      "Type": "AWS::EC2::SubnetRouteTableAssociation"
-    }
-    {{end}}
-    {{end}}
-    ,
-    "PublicRouteTable": {
+    "{{$subnet.RouteTableName}}": {
       "Properties": {
         "Tags": [
           {
             "Key": "Name",
-            "Value": "{{$.ClusterName}}-PublicRouteTable"
+            "Value": "{{$.ClusterName}}-{{$subnet.RouteTableName}}"
           },
           {
             "Key": "KubernetesCluster",
@@ -1333,72 +1224,46 @@
       },
       "Type": "AWS::EC2::RouteTable"
     },
-    "PublicRouteToInternet": {
+    "{{$subnet.RouteTableName}}ToInternet": {
       "Properties": {
         "DestinationCidrBlock": "0.0.0.0/0",
         "GatewayId": {{$.InternetGatewayRef}},
-        "RouteTableId": {"Ref" : "PublicRouteTable"}
+        "RouteTableId": {{$subnet.RouteTableRef}}
       },
       "Type": "AWS::EC2::Route"
     }
+    {{end}}
+    {{end}}
 
-    {{if (or .WorkerTopologyPrivate .Worker.TopologyPrivate .Etcd.TopologyPrivate .Controller.TopologyPrivate)}}
-    {{range $index, $subnet := .Subnets}}
-    {{if not $subnet.NatGateway.EIPAllocationID}}
+    {{range $i, $ngw := .NATGateways}}
+    {{if $ngw.ManageEIP}}
     ,
-    "NatGateway{{$subnet.AvailabilityZoneLogicalName}}EIP": {
+    "{{$ngw.EIPLogicalName}}": {
       "Properties": {
         "Domain": "vpc"
       },
       "Type": "AWS::EC2::EIP"
     }
     {{end}}
-    {{if not $subnet.NatGateway.ID}}
+    {{if $ngw.ManageNATGateway}}
     ,
-    "NatGateway{{$subnet.AvailabilityZoneLogicalName}}": {
+    "{{$ngw.LogicalName}}": {
       "Properties": {
-        "AllocationId":
-          {{if not $subnet.NatGateway.EIPAllocationID}}
-          {"Fn::GetAtt": ["NatGateway{{$subnet.AvailabilityZoneLogicalName}}EIP", "AllocationId"]},
-          {{else}}
-          "{{$subnet.NatGateway.EIPAllocationID}}",
-          {{end}}
-        "SubnetId": { "Ref": "{{$subnet.LogicalName}}" }
+        "AllocationId": {{$ngw.EIPAllocationIDRef}},
+        "SubnetId": {{$ngw.PublicSubnetRef}}
       },
       "Type": "AWS::EC2::NatGateway"
     }
-    {{end}}
     ,
-    "PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}": {
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "{{$.ClusterName}}-PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{$.ClusterName}}"
-          }
-        ],
-        "VpcId": {{$.VPCRef}}
-      },
-      "Type": "AWS::EC2::RouteTable"
-    },
-    "PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}RouteToNatGateway": {
+    {{end}}
+    "{{$ngw.NATGatewayRouteName}}": {
       "Properties": {
         "DestinationCidrBlock": "0.0.0.0/0",
-        "NatGatewayId":
-          {{if not $subnet.NatGateway.ID}}
-          {"Ref": "NatGateway{{$subnet.AvailabilityZoneLogicalName}}"},
-          {{else}}
-          "{{$subnet.NatGateway.ID}}",
-          {{end}}
-        "RouteTableId": {"Ref" : "PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}"}
+        "NatGatewayId": {{$ngw.Ref}},
+        "RouteTableId": {{$ngw.PrivateSubnetRouteTableRef}}
       },
       "Type": "AWS::EC2::Route"
     }
-    {{end}}
     {{end}}
 
     {{if not .InternetGatewayID}}
@@ -1459,19 +1324,12 @@
       "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-VPC" }}
     },
     {{end}}
-    "PublicRouteTable" : {
-      "Description" : "The public route table assigned to the internet gateway for worker nodes",
-      "Value" :  { "Ref" : "PublicRouteTable" },
-      "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-PublicRouteTable" }}
-    },
-    {{if (or .WorkerTopologyPrivate .Worker.TopologyPrivate .Etcd.TopologyPrivate .Controller.TopologyPrivate)}}
     {{range $index, $subnet := .Subnets}}
-    "PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}" : {
-      "Description" : "The private route table assigned to the nat gateway for worker nodes",
-      "Value" :  { "Ref" : "PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}" },
-      "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}" }}
+    "{{$subnet.RouteTableName}}" : {
+      "Description" : "The route table assigned to the subnet {{$subnet.LogicalName}}",
+      "Value" :  {{$subnet.RouteTableRef}},
+      "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-{{$subnet.RouteTableName}}" }}
     },
-    {{end}}
     {{end}}
     "WorkerSecurityGroup" : {
       "Description" : "The security group assigned to worker nodes",

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -571,7 +571,7 @@
         "Tenancy": "{{$.EtcdTenancy}}",
         "UserData": { "Fn::FindInMap" : [ "EtcdInstanceParams", "UserData", "cloudconfig"] }
       },
-      {{if $etcdInstance.DependencyRef}}
+      {{if $etcdInstance.DependencyExists}}
       "DependsOn": [{{$etcdInstance.DependencyRef}}],
       {{end}}
       "Type": "AWS::EC2::Instance"
@@ -1148,7 +1148,7 @@
     {{end}}
 
     {{range $index, $subnet := .Subnets}}
-    {{if not $subnet.HasIdentifier }}
+    {{if $subnet.ManageSubnet }}
     ,
     "{{$subnet.LogicalName}}": {
       "Properties": {
@@ -1169,18 +1169,6 @@
       },
       "Type": "AWS::EC2::Subnet"
     }
-    {{end}}
-    {{if $.ElasticFileSystemID}}
-    ,
-    "{{$subnet.LogicalName}}MountTarget": {
-      "Properties" : {
-        "FileSystemId": "{{$.ElasticFileSystemID}}",
-        "SubnetId": {{$subnet.Ref}},
-        "SecurityGroups": [ { "Ref": "SecurityGroupMountTarget" } ]
-      },
-      "Type" : "AWS::EFS::MountTarget"
-    }
-    {{end}}
     ,
     "{{$subnet.LogicalName}}RouteTableAssociation": {
       "Properties": {
@@ -1189,6 +1177,7 @@
       },
       "Type": "AWS::EC2::SubnetRouteTableAssociation"
     }
+    {{if $subnet.ManageRouteTable}}
     ,
     "{{$subnet.RouteTableName}}": {
       "Properties": {
@@ -1206,6 +1195,19 @@
       },
       "Type": "AWS::EC2::RouteTable"
     }
+    {{end}}
+    {{end}}
+    {{if $.ElasticFileSystemID}}
+    ,
+    "{{$subnet.LogicalName}}MountTarget": {
+      "Properties" : {
+        "FileSystemId": "{{$.ElasticFileSystemID}}",
+        "SubnetId": {{$subnet.Ref}},
+        "SecurityGroups": [ { "Ref": "SecurityGroupMountTarget" } ]
+      },
+      "Type" : "AWS::EFS::MountTarget"
+    }
+    {{end}}
     {{if $subnet.ManageRouteToInternet}}
     ,
     "{{$subnet.RouteTableName}}ToInternet": {
@@ -1311,11 +1313,13 @@
     },
     {{end}}
     {{range $index, $subnet := .Subnets}}
+    {{if $subnet.ManageRouteTable}}
     "{{$subnet.RouteTableName}}" : {
       "Description" : "The route table assigned to the subnet {{$subnet.LogicalName}}",
       "Value" :  {{$subnet.RouteTableRef}},
       "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-{{$subnet.RouteTableName}}" }}
     },
+    {{end}}
     {{end}}
     "WorkerSecurityGroup" : {
       "Description" : "The security group assigned to worker nodes",

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -509,7 +509,7 @@
     {{range $etcdIndex, $etcdInstance := .EtcdInstances}}
     "InstanceEtcd{{$etcdIndex}}eni": {
       "Properties": {
-          "SubnetId": {{$etcdInstance.Subnet.Ref}},
+          "SubnetId": {{$etcdInstance.SubnetRef}},
           "GroupSet": [
             {
               "Ref": "SecurityGroupEtcd"
@@ -571,8 +571,8 @@
         "Tenancy": "{{$.EtcdTenancy}}",
         "UserData": { "Fn::FindInMap" : [ "EtcdInstanceParams", "UserData", "cloudconfig"] }
       },
-      {{if $etcdInstance.Subnet.Private}}
-      "DependsOn": ["{{$etcdInstance.Subnet.NATGatewayRouteName}}"],
+      {{if $etcdInstance.DependencyRef}}
+      "DependsOn": [{{$etcdInstance.DependencyRef}}],
       {{end}}
       "Type": "AWS::EC2::Instance"
     },
@@ -1254,8 +1254,9 @@
       },
       "Type": "AWS::EC2::NatGateway"
     }
-    ,
     {{end}}
+    {{if $ngw.ManageRoute}}
+    ,
     "{{$ngw.NATGatewayRouteName}}": {
       "Properties": {
         "DestinationCidrBlock": "0.0.0.0/0",
@@ -1264,6 +1265,7 @@
       },
       "Type": "AWS::EC2::Route"
     }
+    {{end}}
     {{end}}
 
     {{if not .InternetGatewayID}}

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -1206,24 +1206,8 @@
       },
       "Type": "AWS::EC2::RouteTable"
     }
-    {{if $subnet.Public}}
+    {{if $subnet.ManageRouteToInternet}}
     ,
-    "{{$subnet.RouteTableName}}": {
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$subnet.RouteTableName}}"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{$.ClusterName}}"
-          }
-        ],
-        "VpcId": {{$.VPCRef}}
-      },
-      "Type": "AWS::EC2::RouteTable"
-    },
     "{{$subnet.RouteTableName}}ToInternet": {
       "Properties": {
         "DestinationCidrBlock": "0.0.0.0/0",

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -1148,7 +1148,7 @@
     {{end}}
 
     {{range $index, $subnet := .Subnets}}
-    {{if $subnet.ManageSubnet }}
+    {{if $subnet.ManageSubnet}}
     ,
     "{{$subnet.LogicalName}}": {
       "Properties": {
@@ -1179,12 +1179,12 @@
     }
     {{if $subnet.ManageRouteTable}}
     ,
-    "{{$subnet.RouteTableName}}": {
+    "{{$subnet.RouteTableLogicalName}}": {
       "Properties": {
         "Tags": [
           {
             "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$subnet.RouteTableName}}"
+            "Value": "{{$.ClusterName}}-{{$subnet.RouteTableLogicalName}}"
           },
           {
             "Key": "KubernetesCluster",
@@ -1195,7 +1195,6 @@
       },
       "Type": "AWS::EC2::RouteTable"
     }
-    {{end}}
     {{end}}
     {{if $.ElasticFileSystemID}}
     ,
@@ -1210,7 +1209,7 @@
     {{end}}
     {{if $subnet.ManageRouteToInternet}}
     ,
-    "{{$subnet.RouteTableName}}ToInternet": {
+    "{{$subnet.InternetGatewayRouteLogicalName}}": {
       "Properties": {
         "DestinationCidrBlock": "0.0.0.0/0",
         "GatewayId": {{$.InternetGatewayRef}},
@@ -1218,6 +1217,7 @@
       },
       "Type": "AWS::EC2::Route"
     }
+    {{end}}
     {{end}}
     {{end}}
 
@@ -1241,16 +1241,18 @@
       "Type": "AWS::EC2::NatGateway"
     }
     {{end}}
-    {{if $ngw.ManageRoute}}
+    {{range $_, $s := $ngw.PrivateSubnets}}
+    {{if $s.ManageRouteToNATGateway}}
     ,
-    "{{$ngw.NATGatewayRouteName}}": {
+    "{{$s.NATGatewayRouteLogicalName}}": {
       "Properties": {
         "DestinationCidrBlock": "0.0.0.0/0",
         "NatGatewayId": {{$ngw.Ref}},
-        "RouteTableId": {{$ngw.PrivateSubnetRouteTableRef}}
+        "RouteTableId": {{$s.RouteTableRef}}
       },
       "Type": "AWS::EC2::Route"
     }
+    {{end}}
     {{end}}
     {{end}}
 
@@ -1314,10 +1316,17 @@
     {{end}}
     {{range $index, $subnet := .Subnets}}
     {{if $subnet.ManageRouteTable}}
-    "{{$subnet.RouteTableName}}" : {
+    "{{$subnet.RouteTableLogicalName}}" : {
       "Description" : "The route table assigned to the subnet {{$subnet.LogicalName}}",
       "Value" :  {{$subnet.RouteTableRef}},
-      "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-{{$subnet.RouteTableName}}" }}
+      "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-{{$subnet.RouteTableLogicalName}}" }}
+    },
+    {{end}}
+    {{if $subnet.ManageSubnet}}
+    "{{$subnet.LogicalName}}" : {
+      "Description" : "The subnet id of {{$subnet.LogicalName}}",
+      "Value" :  {{$subnet.Ref}},
+      "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-{{$subnet.LogicalName}}" }}
     },
     {{end}}
     {{end}}

--- a/e2e/run
+++ b/e2e/run
@@ -107,6 +107,8 @@ configure() {
 
   ${KUBE_AWS_CMD} render
 
+  ${KUBE_AWS_CMD} up --export --s3-uri ${KUBE_AWS_S3_URI} --pretty-print
+
   ${KUBE_AWS_CMD} validate --s3-uri ${KUBE_AWS_S3_URI}
 
   echo Generated configuration files in ${WORK_DIR}:

--- a/e2e/run
+++ b/e2e/run
@@ -488,6 +488,12 @@ nodepools_destroy() {
   KUBE_AWS_NODE_POOL_INDEX=2 nodepool_destroy
 }
 
+nodepools_rerun() {
+  nodepools_destroy
+  build
+  nodepools
+}
+
 all_destroy() {
   nodepools_destroy
   main_destroy

--- a/model/controller.go
+++ b/model/controller.go
@@ -1,36 +1,16 @@
 package model
 
 type Controller struct {
+	LoadBalancer     ControllerElb `yaml:"loadBalancer,omitempty"`
 	AutoScalingGroup `yaml:"autoScalingGroup,omitempty"`
-	Subnets          []*Subnet `yaml:"subnets,omitempty"`
-}
-
-func (c Controller) TopologyPrivate() bool {
-	if len(c.Subnets) > 0 {
-		return !c.Subnets[0].TopLevel
-	}
-	return false
+	Subnets          []Subnet `yaml:"subnets,omitempty"`
 }
 
 func (c Controller) LogicalName() string {
 	return "Controllers"
 }
 
-func (c Controller) SubnetLogicalNamePrefix() string {
-	if c.TopologyPrivate() == true {
-		return "Controller"
-	}
-	return ""
-}
-
 type ControllerElb struct {
 	Private bool
-	Subnets []*Subnet
-}
-
-func (c ControllerElb) SubnetLogicalNamePrefix() string {
-	if c.Private == true {
-		return "Controller"
-	}
-	return ""
+	Subnets []Subnet
 }

--- a/model/etcd.go
+++ b/model/etcd.go
@@ -1,20 +1,9 @@
 package model
 
 type Etcd struct {
-	Subnets []*Subnet `yaml:"subnets,omitempty"`
-}
-
-func (c Etcd) TopologyPrivate() bool {
-	return len(c.Subnets) > 0
+	Subnets []Subnet `yaml:"subnets,omitempty"`
 }
 
 type EtcdInstance struct {
 	Subnet Subnet
-}
-
-func (c EtcdInstance) SubnetLogicalNamePrefix() string {
-	if c.Subnet.TopLevel == false {
-		return "Etcd"
-	}
-	return ""
 }

--- a/model/etcd.go
+++ b/model/etcd.go
@@ -35,16 +35,13 @@ func (i etcdInstanceImpl) SubnetRef() string {
 }
 
 func (i etcdInstanceImpl) DependencyExists() bool {
-	return i.subnet.Private && i.natGateway != nil && i.natGateway.ManageRoute()
+	return i.subnet.Private && i.subnet.ManageRouteToNATGateway()
 }
 
 func (i etcdInstanceImpl) DependencyRef() (string, error) {
 	// We have to wait until the route to the NAT gateway if it doesn't exist yet(hence ManageRoute=true) or the etcd node fails due to inability to connect internet
 	if i.DependencyExists() {
-		name, err := i.natGateway.NATGatewayRouteName()
-		if err != nil {
-			return "", err
-		}
+		name := i.subnet.NATGatewayRouteLogicalName()
 		return fmt.Sprintf(`"%s"`, name), nil
 	}
 	return "", nil

--- a/model/etcd.go
+++ b/model/etcd.go
@@ -1,9 +1,42 @@
 package model
 
+import "fmt"
+
 type Etcd struct {
 	Subnets []Subnet `yaml:"subnets,omitempty"`
 }
 
-type EtcdInstance struct {
-	Subnet Subnet
+type EtcdInstance interface {
+	SubnetRef() string
+	DependencyRef() string
+}
+
+type etcdInstanceImpl struct {
+	subnet     Subnet
+	natGateway NATGateway
+}
+
+func NewPrivateEtcdInstance(s Subnet, ngw NATGateway) EtcdInstance {
+	return etcdInstanceImpl{
+		subnet:     s,
+		natGateway: ngw,
+	}
+}
+
+func NewPublicEtcdInstance(s Subnet) EtcdInstance {
+	return etcdInstanceImpl{
+		subnet: s,
+	}
+}
+
+func (i etcdInstanceImpl) SubnetRef() string {
+	return i.subnet.Ref()
+}
+
+func (i etcdInstanceImpl) DependencyRef() string {
+	// We have to wait until the route to the NAT gateway if it doesn't exist yet(hence ManageRoute=true) or the etcd node fails due to inability to connect internet
+	if i.subnet.Private && i.natGateway.ManageRoute() {
+		return fmt.Sprintf(`"%s"`, i.natGateway.NATGatewayRouteName())
+	}
+	return ""
 }

--- a/model/identifier.go
+++ b/model/identifier.go
@@ -22,3 +22,17 @@ func (i Identifier) Ref(logicalName string) string {
 		return fmt.Sprintf(`{ "Ref" : %q }`, logicalName)
 	}
 }
+
+func (i Identifier) IdOrRef(refProvider func() (string, error)) (string, error) {
+	if i.IDFromStackOutput != "" {
+		return fmt.Sprintf(`{ "ImportValue" : %q }`, i.IDFromStackOutput), nil
+	} else if i.ID != "" {
+		return fmt.Sprintf(`"%s"`, i.ID), nil
+	} else {
+		logicalName, err := refProvider()
+		if err != nil {
+			return "", fmt.Errorf("failed to get id or ref: %v", err)
+		}
+		return fmt.Sprintf(`{ "Ref" : %q }`, logicalName), nil
+	}
+}

--- a/model/identifier.go
+++ b/model/identifier.go
@@ -1,1 +1,24 @@
 package model
+
+import (
+	"fmt"
+)
+
+type Identifier struct {
+	ID                string `yaml:"id,omitempty"`
+	IDFromStackOutput string `yaml:"idFromStackOutput,omitempty"`
+}
+
+func (i Identifier) HasIdentifier() bool {
+	return i.ID != "" || i.IDFromStackOutput != ""
+}
+
+func (i Identifier) Ref(logicalName string) string {
+	if i.IDFromStackOutput != "" {
+		return fmt.Sprintf(`{ "ImportValue" : %q }`, i.IDFromStackOutput)
+	} else if i.ID != "" {
+		return fmt.Sprintf(`"%s"`, i.ID)
+	} else {
+		return fmt.Sprintf(`{ "Ref" : %q }`, logicalName)
+	}
+}

--- a/model/internet_gateway.go
+++ b/model/internet_gateway.go
@@ -1,0 +1,10 @@
+package model
+
+type InternetGateway struct {
+	Identifier    `yaml:",inline"`
+	Preconfigured bool `yaml:"preconfigured,omitempty"`
+}
+
+func (g InternetGateway) ManageInternetGateway() bool {
+	return !g.HasIdentifier()
+}

--- a/model/internet_gateway.go
+++ b/model/internet_gateway.go
@@ -1,8 +1,7 @@
 package model
 
 type InternetGateway struct {
-	Identifier    `yaml:",inline"`
-	Preconfigured bool `yaml:"preconfigured,omitempty"`
+	Identifier `yaml:",inline"`
 }
 
 func (g InternetGateway) ManageInternetGateway() bool {

--- a/model/nat_gateway.go
+++ b/model/nat_gateway.go
@@ -1,0 +1,73 @@
+package model
+
+import "fmt"
+
+type NATGatewayConfig struct {
+	Identifier      `yaml:",inline"`
+	EIPAllocationID string `yaml:"eipAllocationId,omitempty"`
+}
+
+type NATGateway interface {
+	LogicalName() string
+	ManageNATGateway() bool
+	ManageEIP() bool
+	EIPLogicalName() string
+	EIPAllocationIDRef() string
+	Ref() string
+	PublicSubnetRef() string
+	PrivateSubnetRouteTableRef() string
+	NATGatewayRouteName() string
+}
+
+type natGatewayImpl struct {
+	NATGatewayConfig
+	privateSubnet Subnet
+	publicSubnet  Subnet
+}
+
+func NewNATGateway(c NATGatewayConfig, private Subnet, public Subnet) NATGateway {
+	return natGatewayImpl{
+		NATGatewayConfig: c,
+		privateSubnet:    private,
+		publicSubnet:     public,
+	}
+}
+
+func (g natGatewayImpl) LogicalName() string {
+	return fmt.Sprintf("NatGateway%s", g.privateSubnet.AvailabilityZoneLogicalName())
+}
+
+func (g natGatewayImpl) ManageNATGateway() bool {
+	return !g.HasIdentifier()
+}
+
+func (g natGatewayImpl) ManageEIP() bool {
+	return g.EIPAllocationID == ""
+}
+
+func (g natGatewayImpl) EIPLogicalName() string {
+	return fmt.Sprintf("%sEIP", g.LogicalName())
+}
+
+func (g natGatewayImpl) EIPAllocationIDRef() string {
+	if g.ManageEIP() {
+		return fmt.Sprintf(`{"Fn::GetAtt": ["%s", "AllocationId"]}`, g.EIPLogicalName())
+	}
+	return g.EIPAllocationID
+}
+
+func (g natGatewayImpl) Ref() string {
+	return g.Identifier.Ref(g.LogicalName())
+}
+
+func (g natGatewayImpl) PublicSubnetRef() string {
+	return g.publicSubnet.Ref()
+}
+
+func (g natGatewayImpl) PrivateSubnetRouteTableRef() string {
+	return g.privateSubnet.RouteTableRef()
+}
+
+func (g natGatewayImpl) NATGatewayRouteName() string {
+	return g.privateSubnet.NATGatewayRouteName()
+}

--- a/model/subnet.go
+++ b/model/subnet.go
@@ -41,6 +41,24 @@ func NewExistingPrivateSubnet(az string, id string) Subnet {
 	}
 }
 
+func NewExistingPrivateSubnetWithPreconfiguredNATGateway(az string, id string, rtb string) Subnet {
+	return Subnet{
+		Identifier: Identifier{
+			ID: id,
+		},
+		AvailabilityZone: az,
+		Private:          true,
+		RouteTable: RouteTable{
+			Identifier: Identifier{
+				ID: rtb,
+			},
+		},
+		NATGateway: NATGatewayConfig{
+			Preconfigured: true,
+		},
+	}
+}
+
 func NewImportedPrivateSubnet(az string, name string) Subnet {
 	return Subnet{
 		Identifier: Identifier{
@@ -69,6 +87,10 @@ func NewImportedPublicSubnet(az string, name string) Subnet {
 		AvailabilityZone: az,
 		Private:          false,
 	}
+}
+
+func (s *Subnet) Provided() bool {
+	return s.AvailabilityZone != ""
 }
 
 func (s *Subnet) Public() bool {

--- a/model/subnet.go
+++ b/model/subnet.go
@@ -59,6 +59,38 @@ func NewExistingPrivateSubnetWithPreconfiguredNATGateway(az string, id string, r
 	}
 }
 
+func NewPublicSubnetWithPreconfiguredInternetGateway(az string, cidr string, rtb string) Subnet {
+	return Subnet{
+		AvailabilityZone: az,
+		InstanceCIDR:     cidr,
+		Private:          false,
+		RouteTable: RouteTable{
+			Identifier: Identifier{
+				ID: rtb,
+			},
+		},
+		InternetGateway: InternetGateway{
+			Preconfigured: true,
+		},
+	}
+}
+
+func NewPrivateSubnetWithPreconfiguredNATGateway(az string, cidr string, rtb string) Subnet {
+	return Subnet{
+		AvailabilityZone: az,
+		InstanceCIDR:     cidr,
+		Private:          true,
+		RouteTable: RouteTable{
+			Identifier: Identifier{
+				ID: rtb,
+			},
+		},
+		NATGateway: NATGatewayConfig{
+			Preconfigured: true,
+		},
+	}
+}
+
 func NewImportedPrivateSubnet(az string, name string) Subnet {
 	return Subnet{
 		Identifier: Identifier{
@@ -130,8 +162,8 @@ func (s *Subnet) ManageRouteTable() bool {
 	return !s.RouteTable.HasIdentifier()
 }
 
-func (s *Subnet) ManageInternetGateway() bool {
-	return !s.InternetGateway.HasIdentifier()
+func (s *Subnet) ManageRouteToInternet() bool {
+	return s.Public() && !s.InternetGateway.Preconfigured
 }
 
 func (s *Subnet) NATGatewayRouteName() string {
@@ -151,10 +183,6 @@ func (s *Subnet) RouteTableName() string {
 func (s *Subnet) RouteTableRef() string {
 	logicalName := s.RouteTableName()
 	return s.RouteTable.Ref(logicalName)
-}
-
-type InternetGateway struct {
-	Identifier `yaml:",inline"`
 }
 
 type RouteTable struct {

--- a/model/subnet.go
+++ b/model/subnet.go
@@ -1,44 +1,140 @@
 package model
 
 import (
-	"fmt"
 	"strings"
 )
 
 type Subnet struct {
-	//ID                string `yaml:"id,omitempty"`
-	AvailabilityZone string     `yaml:"availabilityZone,omitempty"`
-	InstanceCIDR     string     `yaml:"instanceCIDR,omitempty"`
-	RouteTableID     string     `yaml:"routeTableId,omitempty"`
-	ID               string     `yaml:"id,omitempty"`
-	CustomName       string     `yaml:"name"`
-	NatGateway       NatGateway `yaml:"natGateway,omitempty"`
-	TopLevel         bool
+	Identifier       `yaml:",inline"`
+	CustomName       string           `yaml:"name,omitempty"`
+	AvailabilityZone string           `yaml:"availabilityZone,omitempty"`
+	InstanceCIDR     string           `yaml:"instanceCIDR,omitempty"`
+	RouteTable       RouteTable       `yaml:"routeTable,omitempty"`
+	NATGateway       NATGatewayConfig `yaml:"natGateway,omitempty"`
+	InternetGateway  InternetGateway  `yaml:"internetGateway,omitempty"`
+	Private          bool
 }
 
-func (c Subnet) AvailabilityZoneLogicalName() string {
-	return strings.Replace(strings.Title(c.AvailabilityZone), "-", "", -1)
-}
-
-func (c Subnet) LogicalName() string {
-	if c.TopLevel == true {
-		if c.CustomName != "" {
-			return c.CustomName
-		}
-		return "Subnet" + c.AvailabilityZoneLogicalName()
+func NewPublicSubnet(az string, cidr string) Subnet {
+	return Subnet{
+		AvailabilityZone: az,
+		InstanceCIDR:     cidr,
+		Private:          false,
 	}
-	return "PrivateSubnet" + c.AvailabilityZoneLogicalName()
+}
+
+func NewPrivateSubnet(az string, cidr string) Subnet {
+	return Subnet{
+		AvailabilityZone: az,
+		InstanceCIDR:     cidr,
+		Private:          true,
+	}
+}
+
+func NewExistingPrivateSubnet(az string, id string) Subnet {
+	return Subnet{
+		Identifier: Identifier{
+			ID: id,
+		},
+		AvailabilityZone: az,
+		Private:          true,
+	}
+}
+
+func NewImportedPrivateSubnet(az string, name string) Subnet {
+	return Subnet{
+		Identifier: Identifier{
+			IDFromStackOutput: name,
+		},
+		AvailabilityZone: az,
+		Private:          true,
+	}
+}
+
+func NewExistingPublicSubnet(az string, id string) Subnet {
+	return Subnet{
+		Identifier: Identifier{
+			ID: id,
+		},
+		AvailabilityZone: az,
+		Private:          false,
+	}
+}
+
+func NewImportedPublicSubnet(az string, name string) Subnet {
+	return Subnet{
+		Identifier: Identifier{
+			IDFromStackOutput: name,
+		},
+		AvailabilityZone: az,
+		Private:          false,
+	}
+}
+
+func (s *Subnet) Public() bool {
+	return !s.Private
+}
+
+func (s *Subnet) AvailabilityZoneLogicalName() string {
+	return strings.Replace(strings.Title(s.AvailabilityZone), "-", "", -1)
+}
+
+func (s *Subnet) MapPublicIPs() bool {
+	return !s.Private
+}
+
+func (s *Subnet) ResourcePrefix() string {
+	var t string
+	if s.Private {
+		t = "Private"
+	} else {
+		t = "Public"
+	}
+	return t
+}
+
+func (s *Subnet) LogicalName() string {
+	if s.CustomName != "" {
+		return s.CustomName
+	}
+	return s.ResourcePrefix() + "Subnet" + s.AvailabilityZoneLogicalName()
+}
+
+func (s *Subnet) RouteTableID() string {
+	return s.RouteTable.ID
+}
+
+func (s *Subnet) ManageRouteTable() bool {
+	return !s.RouteTable.HasIdentifier()
+}
+
+func (s *Subnet) ManageInternetGateway() bool {
+	return !s.InternetGateway.HasIdentifier()
+}
+
+func (s *Subnet) NATGatewayRouteName() string {
+	return s.RouteTableName() + "RouteToNatGateway"
 }
 
 // Ref returns ID or ref to newly created resource
-func (s Subnet) Ref() string {
-	if s.ID != "" {
-		return fmt.Sprintf("%q", s.ID)
-	}
-	return fmt.Sprintf(`{"Ref" : "%s"}`, s.LogicalName())
+func (s *Subnet) Ref() string {
+	return s.Identifier.Ref(s.LogicalName())
 }
 
-type NatGateway struct {
-	ID              string `yaml:"id,omitempty"`
-	EIPAllocationID string `yaml:"eipAllocationId,omitempty"`
+// RouteTableName represents the name of the route table to which this subnet is associated.
+func (s *Subnet) RouteTableName() string {
+	return s.ResourcePrefix() + "RouteTable" + s.AvailabilityZoneLogicalName()
+}
+
+func (s *Subnet) RouteTableRef() string {
+	logicalName := s.RouteTableName()
+	return s.RouteTable.Ref(logicalName)
+}
+
+type InternetGateway struct {
+	Identifier `yaml:",inline"`
+}
+
+type RouteTable struct {
+	Identifier `yaml:",inline"`
 }

--- a/model/worker.go
+++ b/model/worker.go
@@ -6,21 +6,7 @@ type Worker struct {
 	AutoScalingGroup  `yaml:"autoScalingGroup,omitempty"`
 	ClusterAutoscaler ClusterAutoscaler `yaml:"clusterAutoscaler"`
 	SpotFleet         `yaml:"spotFleet,omitempty"`
-	Subnets           []*Subnet `yaml:"subnets,omitempty"`
-}
-
-func (c Worker) TopologyPrivate() bool {
-	if len(c.Subnets) > 0 {
-		return !c.Subnets[0].TopLevel
-	}
-	return false
-}
-
-func (c Worker) SubnetLogicalNamePrefix() string {
-	if c.TopologyPrivate() == true {
-		return "Worker"
-	}
-	return ""
+	Subnets           []Subnet `yaml:"subnets,omitempty"`
 }
 
 type ClusterAutoscaler struct {

--- a/nodepool/config/config.go
+++ b/nodepool/config/config.go
@@ -146,20 +146,15 @@ func ClusterFromBytes(data []byte, main *cfg.Config) (*ProvidedConfig, error) {
 
 	// For backward-compatibility
 	if len(c.Subnets) == 0 {
-		c.Subnets = []*model.Subnet{
-			{
-				AvailabilityZone: c.AvailabilityZone,
-				InstanceCIDR:     c.InstanceCIDR,
-			},
+		c.Subnets = []model.Subnet{
+			model.NewPublicSubnet(c.AvailabilityZone, c.InstanceCIDR),
 		}
 	}
 
 	for i, s := range c.Subnets {
 		if s.CustomName == "" {
-			s.CustomName = fmt.Sprintf("Subnet%d", i)
+			c.Subnets[i].CustomName = fmt.Sprintf("Subnet%d", i)
 		}
-		// Mark top-level subnets appropriately
-		s.TopLevel = true
 	}
 
 	c.EtcdInstances = main.EtcdInstances
@@ -189,7 +184,7 @@ func (c ProvidedConfig) Config() (*ComputedConfig, error) {
 	}
 
 	// Populate top-level subnets to model
-	if len(c.Subnets) > 0 && c.WorkerSettings.TopologyPrivate() == false {
+	if len(c.Subnets) > 0 && len(c.WorkerSettings.Subnets) == 0 {
 		config.WorkerSettings.Subnets = c.Subnets
 	}
 

--- a/nodepool/config/templates/cluster.yaml
+++ b/nodepool/config/templates/cluster.yaml
@@ -167,11 +167,11 @@ vpcCIDR: "{{.VPCCIDR}}"
 # instanceCIDR: "10.0.0.0/24"
 
 # Kubernetes subnets with their CIDRs and availability zones. Differentiating availability zone for 2 or more subnets result in high-availability (failures of a single availability zone won't result in immediate downtimes)
+# However please beware that cluster-autoscaler doesn't support a node pool backed by an ASG assigned to multi AZs.
+# If you're planning to use cluster-autoscaler, just use a single subnet for each node pool and create multiple node pools for high-availability.
 # subnets:
-#   - availabilityZone: us-west-1a
-#     instanceCIDR: "10.0.0.0/24"
-#   - availabilityZone: us-west-1b
-#     instanceCIDR: "10.0.1.0/24"
+#   # Fetch subnets managed in the main cluster by name to be reused in this node pool
+#   - name: PrivateSubnet1a
 
 # Required by kubelet to locate the cluster-internal dns hosted on controller nodes in the base cluster
 dnsServiceIP: "{{.DNSServiceIP}}"

--- a/nodepool/config/templates/stack-template.json
+++ b/nodepool/config/templates/stack-template.json
@@ -98,9 +98,7 @@
               {"GroupId":{{$sgRef}}}
               {{end}}
             ],
-            "SubnetId": {
-              "Ref": "{{$.Worker.SubnetLogicalNamePrefix}}{{$workerSubnet.LogicalName}}"
-            },
+            "SubnetId": {{$workerSubnet.Ref}},
             "UserData": {{template "UserData" $}}
           }
           {{end}}
@@ -152,11 +150,9 @@
         ],
         {{end}}
         "VPCZoneIdentifier": [
-          {{range $index, $workerSubnet := .Worker.Subnets}}
+          {{range $index, $subnet := .Worker.Subnets}}
           {{if gt $index 0}},{{end}}
-          {
-            "Ref": "{{$.Worker.SubnetLogicalNamePrefix}}{{$workerSubnet.LogicalName}}"
-          }
+          {{$subnet.Ref}}
           {{end}}
         ]
       },
@@ -356,31 +352,17 @@
       "Type": "AWS::IAM::Role"
     }
 
-    {{if $.ElasticFileSystemID}}
-    {{range $index, $subnet := .Worker.Subnets}}
+    {{range $index, $subnet := .Subnets}}
     ,
-    "{{$.Worker.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}MountTarget": {
-      "Properties" : {
-        "FileSystemId": "{{$.ElasticFileSystemID}}",
-        "SubnetId": { "Ref": "{{$.Worker.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}" },
-        "SecurityGroups": [ { "Ref": "SecurityGroupMountTarget" } ]
-      },
-      "Type" : "AWS::EFS::MountTarget"
-    }
-    {{end}}
-    {{end}}
-
-    {{range $index, $subnet := .Worker.Subnets}}
-    ,
-    "{{$.Worker.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}": {
+    "{{$subnet.LogicalName}}": {
       "Properties": {
         "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
         "CidrBlock": "{{$subnet.InstanceCIDR}}",
-        "MapPublicIpOnLaunch": {{not $.Worker.TopologyPrivate}},
+        "MapPublicIpOnLaunch": {{$subnet.MapPublicIPs}},
         "Tags": [
           {
             "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$.NodePoolName}}-{{$.Worker.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}"
+            "Value": "{{$.ClusterName}}-{{$.NodePoolName}}-{{$subnet.LogicalName}}"
           },
           {
             "Key": "KubernetesCluster",
@@ -391,24 +373,33 @@
       },
       "Type": "AWS::EC2::Subnet"
     },
-    "{{$.Worker.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}RouteTableAssociation": {
+    "{{$subnet.LogicalName}}RouteTableAssociation": {
       "Properties": {
         "RouteTableId":
           {{if not $subnet.RouteTableID}}
-          {{if $.WorkerTopologyPrivate}}
+          {{if $subnet.Private}}
           {"Fn::ImportValue" : {"Fn::Sub" : "{{$.ClusterName}}-PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}"}},
           {{else}}
-          {"Fn::ImportValue" : {"Fn::Sub" : "{{$.ClusterName}}-PublicRouteTable"}},
+          {"Fn::ImportValue" : {"Fn::Sub" : "{{$.ClusterName}}-PublicRouteTable{{$subnet.AvailabilityZoneLogicalName}}"}},
           {{end}}
           {{else}}
           "{{$subnet.RouteTableID}}",
           {{end}}
-        "SubnetId": {
-          "Ref": "{{$.Worker.SubnetLogicalNamePrefix}}{{$subnet.LogicalName}}"
-        }
+        "SubnetId": {{$subnet.Ref}}
       },
       "Type": "AWS::EC2::SubnetRouteTableAssociation"
     }
+    {{if $.ElasticFileSystemID}}
+    ,
+    "{{$subnet.LogicalName}}MountTarget": {
+      "Properties" : {
+        "FileSystemId": "{{$.ElasticFileSystemID}}",
+        "SubnetId": {{$subnet.Ref}},
+        "SecurityGroups": [ { "Ref": "SecurityGroupMountTarget" } ]
+      },
+      "Type" : "AWS::EFS::MountTarget"
+    }
+    {{end}}
     {{end}}
   }
 }

--- a/nodepool/config/templates/stack-template.json
+++ b/nodepool/config/templates/stack-template.json
@@ -351,55 +351,5 @@
       },
       "Type": "AWS::IAM::Role"
     }
-
-    {{range $index, $subnet := .Subnets}}
-    ,
-    "{{$subnet.LogicalName}}": {
-      "Properties": {
-        "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
-        "CidrBlock": "{{$subnet.InstanceCIDR}}",
-        "MapPublicIpOnLaunch": {{$subnet.MapPublicIPs}},
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$.NodePoolName}}-{{$subnet.LogicalName}}"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{$.ClusterName}}"
-          }
-        ],
-        "VpcId": {{$.VPCRef}}
-      },
-      "Type": "AWS::EC2::Subnet"
-    },
-    "{{$subnet.LogicalName}}RouteTableAssociation": {
-      "Properties": {
-        "RouteTableId":
-          {{if not $subnet.RouteTableID}}
-          {{if $subnet.Private}}
-          {"Fn::ImportValue" : {"Fn::Sub" : "{{$.ClusterName}}-PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}"}},
-          {{else}}
-          {"Fn::ImportValue" : {"Fn::Sub" : "{{$.ClusterName}}-PublicRouteTable{{$subnet.AvailabilityZoneLogicalName}}"}},
-          {{end}}
-          {{else}}
-          "{{$subnet.RouteTableID}}",
-          {{end}}
-        "SubnetId": {{$subnet.Ref}}
-      },
-      "Type": "AWS::EC2::SubnetRouteTableAssociation"
-    }
-    {{if $.ElasticFileSystemID}}
-    ,
-    "{{$subnet.LogicalName}}MountTarget": {
-      "Properties" : {
-        "FileSystemId": "{{$.ElasticFileSystemID}}",
-        "SubnetId": {{$subnet.Ref}},
-        "SecurityGroups": [ { "Ref": "SecurityGroupMountTarget" } ]
-      },
-      "Type" : "AWS::EFS::MountTarget"
-    }
-    {{end}}
-    {{end}}
   }
 }

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -279,6 +279,12 @@ worker:
 					if !reflect.DeepEqual(c.Etcd.Subnets, privateSubnets) {
 						t.Errorf("Etcd subnets didn't match: expected=%v actual=%v", privateSubnets, c.Etcd.Subnets)
 					}
+
+					for i, s := range c.PrivateSubnets() {
+						if s.NATGateway.Preconfigured {
+							t.Errorf("NAT gateway for the private subnet #%d should be created by kube-aws but it is not going to be", i)
+						}
+					}
 				},
 			},
 		},
@@ -344,6 +350,12 @@ subnets:
 					}
 					if !reflect.DeepEqual(c.Etcd.Subnets, publicSubnets) {
 						t.Errorf("Etcd subnets didn't match: expected=%v actual=%v", publicSubnets, c.Etcd.Subnets)
+					}
+
+					for i, s := range c.PrivateSubnets() {
+						if s.NATGateway.Preconfigured {
+							t.Errorf("NAT gateway for the private subnet #%d should be created by kube-aws but it is not going to be", i)
+						}
 					}
 				},
 			},
@@ -429,6 +441,12 @@ worker:
 					if !reflect.DeepEqual(c.Etcd.Subnets, privateSubnets) {
 						t.Errorf("Etcd subnets didn't match: expected=%v actual=%v", privateSubnets, c.Etcd.Subnets)
 					}
+
+					for i, s := range c.PrivateSubnets() {
+						if s.NATGateway.Preconfigured {
+							t.Errorf("NAT gateway for the private subnet #%d should be created by kube-aws but it is not going to be", i)
+						}
+					}
 				},
 			},
 		},
@@ -509,6 +527,114 @@ worker:
 					if !reflect.DeepEqual(c.Etcd.Subnets, privateSubnets) {
 						t.Errorf("Etcd subnets didn't match: expected=%v actual=%v", privateSubnets, c.Etcd.Subnets)
 					}
+
+					for i, s := range c.PrivateSubnets() {
+						if s.NATGateway.Preconfigured {
+							t.Errorf("NAT gateway for the private subnet #%d should be created by kube-aws but it is not going to be", i)
+						}
+					}
+				},
+			},
+		},
+		// See https://github.com/coreos/kube-aws/pull/284#issuecomment-275955785
+		{
+			context: "WithNetworkTopologyExistingPrivateSubnetsWithNonAWSNATGateway",
+			configYaml: kubeAwsSettings.mainClusterYaml + `
+vpcId: vpc-1a2b3c4d
+# routeTableId must be omitted
+# See https://github.com/coreos/kube-aws/pull/284#issuecomment-275962332
+# routeTableId: rtb-1a2b3c4d
+subnets:
+- name: private1
+  availabilityZone: us-west-1a
+  id: subnet-1
+  private: true
+  natGateway:
+    preconfigured: true
+  # this, in combination with "natGateway.preconfigured=true", implies that the route table already has a route to an existing NAT gateway
+  routeTable:
+    id: routetable-withpreconfigurednat1a
+- name: private2
+  availabilityZone: us-west-1b
+  id: subnet-2
+  private: true
+  natGateway:
+    preconfigured: true
+  # this, in combination with "natGateway.preconfigured=true", implies that the route table already has a route to an existing NAT gateway
+  routeTable:
+    id: routetable-withpreconfigurednat1b
+- name: public1
+  availabilityZone: us-west-1a
+  id: subnet-3
+- name: public2
+  availabilityZone: us-west-1b
+  id: subnet-4
+controller:
+  subnets:
+  - name: private1
+  - name: private2
+  loadBalancer:
+    private: false
+etcd:
+  subnets:
+  - name: private1
+  - name: private2
+worker:
+  subnets:
+  - name: private1
+  - name: private2
+`,
+			assertConfig: []ConfigTester{
+				hasDefaultExperimentalFeatures,
+				func(c *config.Cluster, t *testing.T) {
+					private1 := model.NewExistingPrivateSubnetWithPreconfiguredNATGateway("us-west-1a", "subnet-1", "routetable-withpreconfigurednat1a")
+					private1.CustomName = "private1"
+
+					private2 := model.NewExistingPrivateSubnetWithPreconfiguredNATGateway("us-west-1b", "subnet-2", "routetable-withpreconfigurednat1b")
+					private2.CustomName = "private2"
+
+					public1 := model.NewExistingPublicSubnet("us-west-1a", "subnet-3")
+					public1.CustomName = "public1"
+
+					public2 := model.NewExistingPublicSubnet("us-west-1b", "subnet-4")
+					public2.CustomName = "public2"
+
+					subnets := []model.Subnet{
+						private1,
+						private2,
+						public1,
+						public2,
+					}
+					publicSubnets := []model.Subnet{
+						public1,
+						public2,
+					}
+					privateSubnets := []model.Subnet{
+						private1,
+						private2,
+					}
+
+					if !reflect.DeepEqual(c.AllSubnets(), subnets) {
+						t.Errorf("Managed subnets didn't match: expected=%v actual=%v", subnets, c.AllSubnets())
+					}
+					if !reflect.DeepEqual(c.Worker.Subnets, privateSubnets) {
+						t.Errorf("Worker subnets didn't match: expected=%v actual=%v", publicSubnets, c.Worker.Subnets)
+					}
+					if !reflect.DeepEqual(c.Controller.Subnets, privateSubnets) {
+						t.Errorf("Controller subnets didn't match: expected=%v actual=%v", privateSubnets, c.Controller.Subnets)
+					}
+					if !reflect.DeepEqual(c.Controller.LoadBalancer.Subnets, publicSubnets) {
+						t.Errorf("Controller loadbalancer subnets didn't match: expected=%v actual=%v", privateSubnets, c.Controller.LoadBalancer.Subnets)
+					}
+					if !reflect.DeepEqual(c.Etcd.Subnets, privateSubnets) {
+						t.Errorf("Etcd subnets didn't match: expected=%v actual=%v", privateSubnets, c.Etcd.Subnets)
+					}
+
+					for i, s := range c.PrivateSubnets() {
+						if !s.NATGateway.Preconfigured {
+							t.Errorf("NAT gateway for the private subnet #%d is externally managed and shouldn't created by kube-aws", i)
+						}
+					}
 				},
 			},
 		},
@@ -588,6 +714,12 @@ worker:
 					}
 					if !reflect.DeepEqual(c.Etcd.Subnets, privateSubnets) {
 						t.Errorf("Etcd subnets didn't match: expected=%v actual=%v", privateSubnets, c.Etcd.Subnets)
+					}
+
+					for i, s := range c.PrivateSubnets() {
+						if s.NATGateway.Preconfigured {
+							t.Errorf("NAT gateway for the private subnet #%d should be created by kube-aws but it is not going to be", i)
+						}
 					}
 				},
 			},

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -18,7 +18,7 @@ type ConfigTester func(c *config.Cluster, t *testing.T)
 func TestMainClusterConfig(t *testing.T) {
 	hasDefaultEtcdSettings := func(c *config.Cluster, t *testing.T) {
 		subnet1 := model.NewPublicSubnet("us-west-1c", "10.0.0.0/24")
-		subnet1.CustomName = "Subnet0"
+		subnet1.Name = "Subnet0"
 		expected := config.EtcdSettings{
 			Etcd: model.Etcd{
 				Subnets: []model.Subnet{
@@ -232,10 +232,10 @@ subnets:
 				hasDefaultExperimentalFeatures,
 				func(c *config.Cluster, t *testing.T) {
 					private1 := model.NewPrivateSubnetWithPreconfiguredNATGateway("us-west-1a", "10.0.1.0/24", "rtb-1a2b3c4d")
-					private1.CustomName = "Subnet0"
+					private1.Name = "Subnet0"
 
 					private2 := model.NewPrivateSubnetWithPreconfiguredNATGateway("us-west-1b", "10.0.2.0/24", "rtb-1a2b3c4d")
-					private2.CustomName = "Subnet1"
+					private2.Name = "Subnet1"
 
 					subnets := []model.Subnet{
 						private1,
@@ -309,10 +309,10 @@ subnets:
 				hasDefaultExperimentalFeatures,
 				func(c *config.Cluster, t *testing.T) {
 					private1 := model.NewPublicSubnetWithPreconfiguredInternetGateway("us-west-1a", "10.0.1.0/24", "rtb-1a2b3c4d")
-					private1.CustomName = "Subnet0"
+					private1.Name = "Subnet0"
 
 					private2 := model.NewPublicSubnetWithPreconfiguredInternetGateway("us-west-1b", "10.0.2.0/24", "rtb-1a2b3c4d")
-					private2.CustomName = "Subnet1"
+					private2.Name = "Subnet1"
 
 					subnets := []model.Subnet{
 						private1,
@@ -400,16 +400,16 @@ worker:
 				everyPublicSubnetHasRouteToIGW,
 				func(c *config.Cluster, t *testing.T) {
 					private1 := model.NewPrivateSubnet("us-west-1a", "10.0.1.0/24")
-					private1.CustomName = "private1"
+					private1.Name = "private1"
 
 					private2 := model.NewPrivateSubnet("us-west-1b", "10.0.2.0/24")
-					private2.CustomName = "private2"
+					private2.Name = "private2"
 
 					public1 := model.NewPublicSubnet("us-west-1a", "10.0.3.0/24")
-					public1.CustomName = "public1"
+					public1.Name = "public1"
 
 					public2 := model.NewPublicSubnet("us-west-1b", "10.0.4.0/24")
-					public2.CustomName = "public2"
+					public2.Name = "public2"
 
 					subnets := []model.Subnet{
 						private1,
@@ -483,16 +483,16 @@ subnets:
 				everyPublicSubnetHasRouteToIGW,
 				func(c *config.Cluster, t *testing.T) {
 					private1 := model.NewPrivateSubnet("us-west-1a", "10.0.1.0/24")
-					private1.CustomName = "private1"
+					private1.Name = "private1"
 
 					private2 := model.NewPrivateSubnet("us-west-1b", "10.0.2.0/24")
-					private2.CustomName = "private2"
+					private2.Name = "private2"
 
 					public1 := model.NewPublicSubnet("us-west-1a", "10.0.3.0/24")
-					public1.CustomName = "public1"
+					public1.Name = "public1"
 
 					public2 := model.NewPublicSubnet("us-west-1b", "10.0.4.0/24")
-					public2.CustomName = "public2"
+					public2.Name = "public2"
 
 					subnets := []model.Subnet{
 						private1,
@@ -576,16 +576,16 @@ worker:
 				everyPublicSubnetHasRouteToIGW,
 				func(c *config.Cluster, t *testing.T) {
 					private1 := model.NewPrivateSubnet("us-west-1a", "10.0.1.0/24")
-					private1.CustomName = "private1"
+					private1.Name = "private1"
 
 					private2 := model.NewPrivateSubnet("us-west-1b", "10.0.2.0/24")
-					private2.CustomName = "private2"
+					private2.Name = "private2"
 
 					public1 := model.NewPublicSubnet("us-west-1a", "10.0.3.0/24")
-					public1.CustomName = "public1"
+					public1.Name = "public1"
 
 					public2 := model.NewPublicSubnet("us-west-1b", "10.0.4.0/24")
-					public2.CustomName = "public2"
+					public2.Name = "public2"
 
 					subnets := []model.Subnet{
 						private1,
@@ -670,16 +670,16 @@ worker:
 				everyPublicSubnetHasRouteToIGW,
 				func(c *config.Cluster, t *testing.T) {
 					private1 := model.NewPrivateSubnet("us-west-1a", "10.0.1.0/24")
-					private1.CustomName = "private1"
+					private1.Name = "private1"
 
 					private2 := model.NewPrivateSubnet("us-west-1b", "10.0.2.0/24")
-					private2.CustomName = "private2"
+					private2.Name = "private2"
 
 					public1 := model.NewPublicSubnet("us-west-1a", "10.0.3.0/24")
-					public1.CustomName = "public1"
+					public1.Name = "public1"
 
 					public2 := model.NewPublicSubnet("us-west-1b", "10.0.4.0/24")
-					public2.CustomName = "public2"
+					public2.Name = "public2"
 
 					subnets := []model.Subnet{
 						private1,
@@ -759,16 +759,16 @@ worker:
 				hasDefaultExperimentalFeatures,
 				func(c *config.Cluster, t *testing.T) {
 					private1 := model.NewExistingPrivateSubnet("us-west-1a", "subnet-1")
-					private1.CustomName = "private1"
+					private1.Name = "private1"
 
 					private2 := model.NewImportedPrivateSubnet("us-west-1b", "mycluster-private-subnet-1")
-					private2.CustomName = "private2"
+					private2.Name = "private2"
 
 					public1 := model.NewExistingPublicSubnet("us-west-1a", "subnet-2")
-					public1.CustomName = "public1"
+					public1.Name = "public1"
 
 					public2 := model.NewImportedPublicSubnet("us-west-1b", "mycluster-public-subnet-1")
-					public2.CustomName = "public2"
+					public2.Name = "public2"
 
 					subnets := []model.Subnet{
 						private1,
@@ -833,7 +833,7 @@ routeTableId: rtb-1a2b3c4d
 				hasDefaultExperimentalFeatures,
 				func(c *config.Cluster, t *testing.T) {
 					subnet1 := model.NewPublicSubnetWithPreconfiguredInternetGateway("us-west-1c", "10.0.0.0/24", "rtb-1a2b3c4d")
-					subnet1.CustomName = "Subnet0"
+					subnet1.Name = "Subnet0"
 					subnets := []model.Subnet{
 						subnet1,
 					}
@@ -967,7 +967,7 @@ etcdDataVolumeIOPS: 104
 				hasDefaultExperimentalFeatures,
 				func(c *config.Cluster, t *testing.T) {
 					subnet1 := model.NewPublicSubnetWithPreconfiguredInternetGateway("us-west-1c", "10.0.0.0/24", "rtb-1a2b3c4d")
-					subnet1.CustomName = "Subnet0"
+					subnet1.Name = "Subnet0"
 					subnets := []model.Subnet{
 						subnet1,
 					}


### PR DESCRIPTION
This change allows us to define private and public subnets in the top-level of `cluster.yaml` to be chosen for worker/controller/etcd nodes and a controller loadbalancer.

Thanks to @neoandroid and @sasso for submitting the pull request #169 and #227 respectively which had been the basis of this feature.

Let me also add that several resources including subnets, NAT gateways, route tables can now be reused by specifying `id` or `idFromStackOutput`.
Thanks to @icereval for his PR #195 to firstly introducing the idea of `type Identifier` to add support for existing AWS resources in an universal way.

A minimum config utilizing this feature would look like:

```yaml
clusterName: mycluster
externalDNSName: mycluster.example.com
hostedZoneId: yourhostedzoneid
keyName: yourkeyname
kmsKeyArn: "arn:aws:kms:<region>:<account>:key/<id>"
region: <region>
createRecordSet: true
experimental:
  waitSignal:
    enabled: true
subnets:
- name: private1
  availabilityZone: ap-northeast-1a
  instanceCIDR: "10.0.1.0/24"
  private: true
- name: private2
  availabilityZone: ap-northeast-1c
  instanceCIDR: "10.0.2.0/24"
  private: true
- name: public1
  availabilityZone: ap-northeast-1a
  instanceCIDR: "10.0.3.0/24"
- name: public2
  availabilityZone: ap-northeast-1c
  instanceCIDR: "10.0.4.0/24"
controller:
  subnets:
  - name: private1
  - name: private2
  loadBalancer:
    private: false
etcd:
  subnets:
  - name: private1
  - name: private2
worker:
  subnets:
  - name: public1
  - name: public2
```

This will create 2 private subnets and 2 public subnets. Private ones are used by etcd and controller nodes and the public ones are used by worker nodes and the controller loadbalancer.

It is flexible enough to differentiate private subnets between etcd and controllers:

```yaml
subnets:
- name: etcdPrivate1
  availabilityZone: ap-northeast-1a
  instanceCIDR: "10.0.1.0/24"
  private: true
- name: etcdPrivate2
  availabilityZone: ap-northeast-1c
  instanceCIDR: "10.0.2.0/24"
  private: true
- name: controllerPrivate1
  availabilityZone: ap-northeast-1a
  instanceCIDR: "10.0.3.0/24"
  private: true
- name: controllerPrivate2
  availabilityZone: ap-northeast-1c
  instanceCIDR: "10.0.4.0/24"
  private: true
- name: public1
  availabilityZone: ap-northeast-1a
  instanceCIDR: "10.0.5.0/24"
- name: public2
  availabilityZone: ap-northeast-1c
  instanceCIDR: "10.0.6.0/24"
controller:
  subnets:
  - name: controllerPrivate1
  - name: controllerPrivate2
  loadBalancer:
    private: false
etcd:
  subnets:
  - name: etcdPrivate1
  - name: etcdPrivate2
worker:
  subnets:
  - name: public1
  - name: public2
```

It even support using existing subnets by specifying subnet IDs:

```yaml
subnets:
- name: private1
  id: subnet-12345a
  availabilityZone: ap-northeast-1a
  private: true
- name: private2
  id: subnet-12345b
  availabilityZone: ap-northeast-1c
  private: true
- name: public1
  id: subnet-12345c
  availabilityZone: ap-northeast-1a
- name: public2
  id: subnet-12345d
  availabilityZone: ap-northeast-1c
controller:
  subnets:
  - name: private1
  - name: private2
  loadBalancer:
    private: false
etcd:
  subnets:
  - name: private1
  - name: private2
worker:
  subnets:
  - name: public1
  - name: public2
```

Or importing subnet IDs from another cfn stack(s):

```yaml
subnets:
- name: private1
  idFromStackoutput: myinfrastack-privateSubnet1
  availabilityZone: ap-northeast-1a
  private: true
- name: private2
  idFromStackoutput: myinfrastack-privateSubnet2
  availabilityZone: ap-northeast-1c
  private: true
- name: public1
  idFromStackoutput: myinfrastack-publicSubnet2
  availabilityZone: ap-northeast-1a
- name: public2
  idFromStackoutput: myinfrastack-publicSubnet3
  availabilityZone: ap-northeast-1c
controller:
  subnets:
  - name: private1
  - name: private2
  loadBalancer:
    private: false
etcd:
  subnets:
  - name: private1
  - name: private2
worker:
  subnets:
  - name: public1
  - name: public2
```

