### PR TITLE
Add ClusterAutoscaler experimental option to setup iam permissions

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -38,7 +38,7 @@ func NewDefaultCluster() *Cluster {
 		AwsNodeLabels{
 			Enabled: false,
 		},
-		ClusterAutoScaler{
+		ClusterAutoscalerSupport{
 			Enabled: false,
 		},
 		EphemeralImageStorage{
@@ -404,17 +404,17 @@ type Cluster struct {
 }
 
 type Experimental struct {
-	AuditLog              AuditLog              `yaml:"auditLog"`
-	AwsEnvironment        AwsEnvironment        `yaml:"awsEnvironment"`
-	AwsNodeLabels         AwsNodeLabels         `yaml:"awsNodeLabels"`
-	ClusterAutoScaler     ClusterAutoScaler     `yaml:"clusterAutoScaler"`
-	EphemeralImageStorage EphemeralImageStorage `yaml:"ephemeralImageStorage"`
-	LoadBalancer          LoadBalancer          `yaml:"loadBalancer"`
-	NodeDrainer           NodeDrainer           `yaml:"nodeDrainer"`
-	NodeLabels            NodeLabels            `yaml:"nodeLabels"`
-	Plugins               Plugins               `yaml:"plugins"`
-	Taints                []Taint               `yaml:"taints"`
-	WaitSignal            WaitSignal            `yaml:"waitSignal"`
+	AuditLog                 AuditLog                 `yaml:"auditLog"`
+	AwsEnvironment           AwsEnvironment           `yaml:"awsEnvironment"`
+	AwsNodeLabels            AwsNodeLabels            `yaml:"awsNodeLabels"`
+	ClusterAutoscalerSupport ClusterAutoscalerSupport `yaml:"clusterAutoscalerSupport"`
+	EphemeralImageStorage    EphemeralImageStorage    `yaml:"ephemeralImageStorage"`
+	LoadBalancer             LoadBalancer             `yaml:"loadBalancer"`
+	NodeDrainer              NodeDrainer              `yaml:"nodeDrainer"`
+	NodeLabels               NodeLabels               `yaml:"nodeLabels"`
+	Plugins                  Plugins                  `yaml:"plugins"`
+	Taints                   []Taint                  `yaml:"taints"`
+	WaitSignal               WaitSignal               `yaml:"waitSignal"`
 }
 
 type AwsEnvironment struct {
@@ -432,7 +432,7 @@ type AwsNodeLabels struct {
 	Enabled bool `yaml:"enabled"`
 }
 
-type ClusterAutoScaler struct {
+type ClusterAutoscalerSupport struct {
 	Enabled bool `yaml:"enabled"`
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,9 @@ func NewDefaultCluster() *Cluster {
 		AwsNodeLabels{
 			Enabled: false,
 		},
+		ClusterAutoScaler{
+			Enabled: false,
+		},
 		EphemeralImageStorage{
 			Enabled:    false,
 			Disk:       "xvdb",
@@ -404,6 +407,7 @@ type Experimental struct {
 	AuditLog              AuditLog              `yaml:"auditLog"`
 	AwsEnvironment        AwsEnvironment        `yaml:"awsEnvironment"`
 	AwsNodeLabels         AwsNodeLabels         `yaml:"awsNodeLabels"`
+	ClusterAutoScaler     ClusterAutoScaler     `yaml:"clusterAutoScaler"`
 	EphemeralImageStorage EphemeralImageStorage `yaml:"ephemeralImageStorage"`
 	LoadBalancer          LoadBalancer          `yaml:"loadBalancer"`
 	NodeDrainer           NodeDrainer           `yaml:"nodeDrainer"`
@@ -425,6 +429,10 @@ type AuditLog struct {
 }
 
 type AwsNodeLabels struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+type ClusterAutoScaler struct {
 	Enabled bool `yaml:"enabled"`
 }
 

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -441,6 +441,9 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #   # The set includes names of launch configurations and autoscaling groups
 #   awsNodeLabels:
 #     enabled: true
+#   # Will provision worker nodes with IAM permissions to run cluster-autoscaler
+#   clusterAutoscalerSupport:
+#     enable: true
 #   # This option has not yet been tested with rkt as container runtime
 #   ephemeralImageStorage:
 #     enabled: true
@@ -478,5 +481,3 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # User-provided YAML map available in stack-template.json
 #customSettings:
 #  key1: [ 1, 2, 3 ]
-#  clusterAutoScaler:
-#    enabled: false

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -478,3 +478,5 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # User-provided YAML map available in stack-template.json
 #customSettings:
 #  key1: [ 1, 2, 3 ]
+#  clusterAutoScaler:
+#    enabled: false

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -444,7 +444,7 @@
                   "Resource": [ "*" ]
                 },
                 {{end}}
-                {{if .Experimental.ClusterAutoScaler.Enabled}}
+                {{if .Experimental.ClusterAutoscalerSupport.Enabled}}
                 {
                 "Effect": "Allow",
                   "Action": [

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -444,6 +444,18 @@
                   "Resource": [ "*" ]
                 },
                 {{end}}
+                {{if .Experimental.ClusterAutoScaler.Enabled}}
+                {
+                "Effect": "Allow",
+                  "Action": [
+                    "autoscaling:DescribeAutoScalingGroups",
+                    "autoscaling:DescribeAutoScalingInstances",
+                    "autoscaling:SetDesiredCapacity",
+                    "autoscaling:TerminateInstanceInAutoScalingGroup"
+                  ],
+                  "Resource": "*"
+                },
+                {{end}}
                 {
                   "Action": [
                     "ecr:GetAuthorizationToken",
@@ -742,7 +754,13 @@
         "SecurityGroups" : [
           { "Ref" : "SecurityGroupElbAPIServer" }
         ]
-      }
+      },
+      "DependsOn" : [
+        {{range $etcdIndex, $etcdInstance := .EtcdInstances}}
+        {{if gt $etcdIndex 0}},{{end}}
+        "InstanceEtcd{{$etcdIndex}}"
+        {{end}}
+      ]
     },
     "SecurityGroupElbAPIServer" : {
       "Properties": {

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -754,13 +754,7 @@
         "SecurityGroups" : [
           { "Ref" : "SecurityGroupElbAPIServer" }
         ]
-      },
-      "DependsOn" : [
-        {{range $etcdIndex, $etcdInstance := .EtcdInstances}}
-        {{if gt $etcdIndex 0}},{{end}}
-        "InstanceEtcd{{$etcdIndex}}"
-        {{end}}
-      ]
+      }
     },
     "SecurityGroupElbAPIServer" : {
       "Properties": {


### PR DESCRIPTION
Simple change to optionally provision worker nodes with sufficient privileges to run the cluster-autoscaler controller.