### PR TITLE
adding kube2iam experimental support

### DIFF
--- a/cfnstack/provisioner.go
+++ b/cfnstack/provisioner.go
@@ -166,7 +166,7 @@ func (c *Provisioner) baseCreateStackInput() *cloudformation.CreateStackInput {
 	return &cloudformation.CreateStackInput{
 		StackName:       aws.String(c.stackName),
 		OnFailure:       aws.String(cloudformation.OnFailureDoNothing),
-		Capabilities:    []*string{aws.String(cloudformation.CapabilityCapabilityIam)},
+		Capabilities:    []*string{aws.String(cloudformation.CapabilityCapabilityIam), aws.String(cloudformation.CapabilityCapabilityNamedIam)},
 		Tags:            tags,
 		StackPolicyBody: aws.String(c.stackPolicyBody),
 	}
@@ -180,7 +180,7 @@ func (c *Provisioner) createStackFromTemplateURL(cfSvc CreationService, stackTem
 
 func (c *Provisioner) baseUpdateStackInput() *cloudformation.UpdateStackInput {
 	return &cloudformation.UpdateStackInput{
-		Capabilities: []*string{aws.String(cloudformation.CapabilityCapabilityIam)},
+		Capabilities: []*string{aws.String(cloudformation.CapabilityCapabilityIam), aws.String(cloudformation.CapabilityCapabilityNamedIam)},
 		StackName:    aws.String(c.stackName),
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -63,6 +63,9 @@ func NewDefaultCluster() *Cluster {
 			Enabled:      false,
 			MaxBatchSize: 1,
 		},
+		Kube2IamSupport{
+			Enabled: false,
+		},
 	}
 
 	return &Cluster{
@@ -340,17 +343,18 @@ type DeploymentSettings struct {
 
 // Part of configuration which is specific to worker nodes
 type WorkerSettings struct {
-	model.Worker           `yaml:"worker,omitempty"`
-	WorkerCount            int      `yaml:"workerCount,omitempty"`
-	WorkerCreateTimeout    string   `yaml:"workerCreateTimeout,omitempty"`
-	WorkerInstanceType     string   `yaml:"workerInstanceType,omitempty"`
-	WorkerRootVolumeType   string   `yaml:"workerRootVolumeType,omitempty"`
-	WorkerRootVolumeIOPS   int      `yaml:"workerRootVolumeIOPS,omitempty"`
-	WorkerRootVolumeSize   int      `yaml:"workerRootVolumeSize,omitempty"`
-	WorkerSpotPrice        string   `yaml:"workerSpotPrice,omitempty"`
-	WorkerSecurityGroupIds []string `yaml:"workerSecurityGroupIds,omitempty"`
-	WorkerTenancy          string   `yaml:"workerTenancy,omitempty"`
-	WorkerTopologyPrivate  bool     `yaml:"workerTopologyPrivate,omitempty"`
+	model.Worker             `yaml:"worker,omitempty"`
+	WorkerCount              int      `yaml:"workerCount,omitempty"`
+	WorkerCreateTimeout      string   `yaml:"workerCreateTimeout,omitempty"`
+	WorkerInstanceType       string   `yaml:"workerInstanceType,omitempty"`
+	WorkerRootVolumeType     string   `yaml:"workerRootVolumeType,omitempty"`
+	WorkerRootVolumeIOPS     int      `yaml:"workerRootVolumeIOPS,omitempty"`
+	WorkerRootVolumeSize     int      `yaml:"workerRootVolumeSize,omitempty"`
+	WorkerSpotPrice          string   `yaml:"workerSpotPrice,omitempty"`
+	WorkerSecurityGroupIds   []string `yaml:"workerSecurityGroupIds,omitempty"`
+	WorkerTenancy            string   `yaml:"workerTenancy,omitempty"`
+	WorkerTopologyPrivate    bool     `yaml:"workerTopologyPrivate,omitempty"`
+	WorkerManagedIamRoleName string   `yaml:"workerManagedIamRoleName,omitempty"`
 }
 
 // Part of configuration which is specific to controller nodes
@@ -416,6 +420,7 @@ type Experimental struct {
 	Plugins                  Plugins                  `yaml:"plugins"`
 	Taints                   []Taint                  `yaml:"taints"`
 	WaitSignal               WaitSignal               `yaml:"waitSignal"`
+	Kube2IamSupport          Kube2IamSupport          `yaml:"kube2IamSupport,omitempty"`
 }
 
 type AwsEnvironment struct {
@@ -489,6 +494,10 @@ func (t Taint) String() string {
 type WaitSignal struct {
 	Enabled      bool `yaml:"enabled"`
 	MaxBatchSize int  `yaml:"maxBatchSize"`
+}
+
+type Kube2IamSupport struct {
+	Enabled bool `yaml:"enabled"`
 }
 
 const (

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -125,6 +125,11 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # Disk type for worker node (one of standard, io1, or gp2)
 #workerRootVolumeType: gp2
 
+# if you specify workerManagedIamRoleName the role created will not suffix the random id at the end
+# Role will be created with "Ref": {"AWS::StackName"}-{"AWS::Region"}-yourManagedRole
+# to follow the recommendation in AWS documentation  http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html
+#workerManagedIamRoleName: "yourManagedRole"
+
 # Number of I/O operations per second (IOPS) that the worker node disk supports. Leave blank if workerRootVolumeType is not io1
 #workerRootVolumeIOPS: 0
 
@@ -475,6 +480,11 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #     # See https://github.com/coreos/kube-aws/issues/230 for more information.
 #     rbac:
 #       enabled: true
+#    # When enabled it will grant sts:assumeRole permission to everyrole in the IAM Worker Role.
+
+#    kube2IamSupport:
+#      enabled: true
+#
 
 # AWS Tags for cloudformation stack resources
 #stackTags:

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -388,6 +388,9 @@
           "Version": "2012-10-17"
         },
         "Path": "/",
+        {{if .WorkerManagedIamRoleName }}
+        "RoleName":  {"Fn::Join": ["",[{"Ref": "AWS::StackName"},"-",{"Ref": "AWS::Region"},"-","{{.WorkerManagedIamRoleName}}"]]},
+        {{end}}
         "Policies": [
           {
             "PolicyDocument": {
@@ -407,13 +410,20 @@
                   "Effect": "Allow",
                   "Resource": "*"
                 },
-		{
+                {
                   "Effect": "Allow",
-		  "Action": [
-			"s3:GetObject"
-		  ],
-		  "Resource": "arn:aws:s3:::{{$.UserDataWorkerS3Path}}"
-		},
+                  "Action": [
+                    "s3:GetObject"
+                  ],
+                  "Resource": "arn:aws:s3:::{{$.UserDataWorkerS3Path}}"
+                },
+                {{if .Experimental.Kube2IamSupport.Enabled }}
+                {
+                  "Action": "sts:AssumeRole",
+                  "Effect":"Allow",
+                  "Resource":"*"
+                },
+                {{end}}
                 {{if .ManageCertificates}}
                 {
                   "Action" : "kms:Decrypt",

--- a/nodepool/config/templates/stack-template.json
+++ b/nodepool/config/templates/stack-template.json
@@ -261,6 +261,9 @@
           "Version": "2012-10-17"
         },
         "Path": "/",
+        {{if .WorkerManagedIamRoleName }}
+        "RoleName":  {"Fn::Join": ["",[{"Ref": "AWS::StackName"},"-",{"Ref": "AWS::Region"},"-","{{.WorkerManagedIamRoleName}}"]]},
+        {{end}}
         "Policies": [
           {
             "PolicyDocument": {
@@ -287,6 +290,13 @@
                   ],
                   "Resource": "arn:aws:s3:::{{$.UserDataWorkerS3Path}}"
                 },
+                {{if .Experimental.Kube2IamSupport.Enabled }}
+                {
+                  "Action": "sts:AssumeRole",
+                  "Effect":"Allow",
+                  "Resource":"*"
+                },
+                {{end}}
                 {
                   "Action" : "kms:Decrypt",
                   "Effect" : "Allow",

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -222,6 +222,8 @@ experimental:
       effect: NoSchedule
   waitSignal:
     enabled: true
+  kube2IamSupport:
+    enabled: true
 `,
 			assertConfig: []ConfigTester{
 				hasDefaultEtcdSettings,
@@ -268,6 +270,9 @@ experimental:
 						WaitSignal: config.WaitSignal{
 							Enabled:      true,
 							MaxBatchSize: 1,
+						},
+						Kube2IamSupport: config.Kube2IamSupport{
+							Enabled: true,
 						},
 					}
 
@@ -1121,6 +1126,21 @@ routeTableId: rtb-1a2b3c4d
 							expected,
 							actual,
 						)
+					}
+				},
+			},
+		},
+		{
+			context: "WithWorkerManagedIamRoleName",
+			configYaml: minimalValidConfigYaml + `
+workerManagedIamRoleName: "yourManagedRole"
+`,
+			assertConfig: []ConfigTester{
+				hasDefaultEtcdSettings,
+				hasDefaultExperimentalFeatures,
+				func(c *config.Cluster, t *testing.T) {
+					if c.WorkerManagedIamRoleName != "yourManagedRole" {
+						t.Errorf("workerManagedIamRoleName: expected=yourManagedRole actual=%s", c.WorkerManagedIamRoleName)
 					}
 				},
 			},

--- a/test/integration/nodepool_test.go
+++ b/test/integration/nodepool_test.go
@@ -162,6 +162,8 @@ experimental:
       effect: NoSchedule
   waitSignal:
     enabled: true
+  kube2IamSupport:
+    enabled: true
 `,
 			assertProvidedConfig: []NodePoolConfigTester{
 				hasDefaultLaunchSpecifications,
@@ -203,6 +205,9 @@ experimental:
 						WaitSignal: cfg.WaitSignal{
 							Enabled:      true,
 							MaxBatchSize: 1,
+						},
+						Kube2IamSupport: cfg.Kube2IamSupport{
+							Enabled: true,
 						},
 					}
 
@@ -390,6 +395,31 @@ worker:
 							expected,
 							actual,
 						)
+					}
+				},
+			},
+		},
+		{
+			context: "WithWorkerManagedIamRole",
+			configYaml: minimalValidConfigYaml + `
+workerManagedIamRoleName: "yourManagedRole"
+`,
+			assertProvidedConfig: []NodePoolConfigTester{
+				hasDefaultExperimentalFeatures,
+				hasDefaultLaunchSpecifications,
+			},
+		},
+		{
+			context: "WithWorkerManagedIamRole",
+			configYaml: minimalValidConfigYaml + `
+workerManagedIamRoleName: "yourManagedRole"
+`,
+			assertProvidedConfig: []NodePoolConfigTester{
+				hasDefaultExperimentalFeatures,
+				hasDefaultLaunchSpecifications,
+				func(c *config.ProvidedConfig, t *testing.T) {
+					if c.WorkerManagedIamRoleName != "yourManagedRole" {
+						t.Errorf("workerManagedIamRoleName: expected=yourManagedRole actual=%s", c.WorkerManagedIamRoleName)
 					}
 				},
 			},


### PR DESCRIPTION
If you plan to use kube2iam in existing kubeaws cluster you face two things:

- Default WorkerRole does not have the sts:assumeRole grant blocking kube2iam to assume the role for the container.
- target roles needs to change the trust policy to allow kube-aws worker IAM Role to assume the role. Because normally cloudformation generates the role with the role name and a random ID at the end makes the IAM Role less predictable and therefore more complicated to work with if you want to automate this trust.

This pr introduces kube2iam experimental flag, when kube2iam flag is enabled it will add sts:assumeRole to the worker IAM role to allow kube2iam to work, additionally you can specified a named role to generate a worker IAM Role more human and automation friendly as explained here http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-rolename


If you find the named role useful maybe could be merged in the general configuration not only for the worker