### PR TITLE
Wait for signals by default

### DIFF
--- a/cmd/nodepool/up.go
+++ b/cmd/nodepool/up.go
@@ -78,9 +78,6 @@ func runCmdUp(cmd *cobra.Command, args []string) error {
 		if err := ioutil.WriteFile(templatePath, stackTemplate, 0600); err != nil {
 			return fmt.Errorf("Error writing %s : %v", templatePath, err)
 		}
-		if conf.KMSKeyARN == "" {
-			fmt.Printf("BEWARE: %s contains your TLS secrets!\n", templatePath)
-		}
 		return nil
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,7 @@ var (
 	configPath = "cluster.yaml"
 )
 
-func stackTemplateOptions(s3URI string, prettyPrint bool) config.StackTemplateOptions {
+func stackTemplateOptions(s3URI string, prettyPrint bool, skipWait bool) config.StackTemplateOptions {
 	return config.StackTemplateOptions{
 		TLSAssetsDir:          "credentials",
 		ControllerTmplFile:    "userdata/cloud-config-controller",
@@ -24,5 +24,6 @@ func stackTemplateOptions(s3URI string, prettyPrint bool) config.StackTemplateOp
 		StackTemplateTmplFile: "stack-template.json",
 		S3URI:       s3URI,
 		PrettyPrint: prettyPrint,
+		SkipWait:    skipWait,
 	}
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -20,8 +20,8 @@ var (
 	}
 
 	updateOpts = struct {
-		awsDebug, prettyPrint bool
-		s3URI                 string
+		awsDebug, prettyPrint, skipWait bool
+		s3URI                           string
 	}{}
 )
 
@@ -30,6 +30,7 @@ func init() {
 	cmdUpdate.Flags().BoolVar(&updateOpts.awsDebug, "aws-debug", false, "Log debug information from aws-sdk-go library")
 	cmdUpdate.Flags().BoolVar(&updateOpts.prettyPrint, "pretty-print", false, "Pretty print the resulting CloudFormation")
 	cmdUpdate.Flags().StringVar(&updateOpts.s3URI, "s3-uri", "", "When your template is bigger than the cloudformation limit of 51200 bytes, upload the template to the specified location in S3. S3 location expressed as s3://<bucket>/path/to/dir")
+	cmdUpdate.Flags().BoolVar(&updateOpts.skipWait, "skip-wait", false, "Don't wait the resources finish")
 }
 
 func runCmdUpdate(cmd *cobra.Command, args []string) error {
@@ -54,7 +55,7 @@ func runCmdUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Failed to read cluster config: %v", err)
 	}
 
-	opts := stackTemplateOptions(updateOpts.s3URI, updateOpts.prettyPrint)
+	opts := stackTemplateOptions(updateOpts.s3URI, updateOpts.prettyPrint, updateOpts.skipWait)
 
 	cluster, err := cluster.NewCluster(confCluster, opts, upOpts.awsDebug)
 	if err != nil {

--- a/config/config_cluster_size_test.go
+++ b/config/config_cluster_size_test.go
@@ -37,15 +37,15 @@ func TestASGsOnlyMinConfigured(t *testing.T) {
 func TestASGsOnlyMaxConfigured(t *testing.T) {
 	configuredMax := 3
 	// we expect min to be equal to main count if only max specified
-	checkControllerASG(nil, nil, &configuredMax, nil, 1, 3, 2, "", t)
-	checkWorkerASG(nil, nil, &configuredMax, nil, 1, 3, 2, "", t)
+	checkControllerASG(nil, nil, &configuredMax, nil, 1, 3, 1, "", t)
+	checkWorkerASG(nil, nil, &configuredMax, nil, 1, 3, 1, "", t)
 }
 
 func TestASGsMinMaxConfigured(t *testing.T) {
 	configuredMin := 2
 	configuredMax := 5
-	checkControllerASG(nil, &configuredMin, &configuredMax, nil, 2, 5, 4, "", t)
-	checkWorkerASG(nil, &configuredMin, &configuredMax, nil, 2, 5, 4, "", t)
+	checkControllerASG(nil, &configuredMin, &configuredMax, nil, 2, 5, 1, "", t)
+	checkWorkerASG(nil, &configuredMin, &configuredMax, nil, 2, 5, 1, "", t)
 }
 
 func TestASGsInvalidMin(t *testing.T) {

--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -243,7 +243,7 @@ coreos:
         ExecStartPre=/usr/bin/systemctl is-active kubelet.service
         ExecStartPre=/usr/bin/bash -c "while sleep 1; do if /usr/bin/curl -s -m 20 -f  http://127.0.0.1:8080/healthz > /dev/null &&  /usr/bin/curl -s -m 20 -f  http://127.0.0.1:10252/healthz > /dev/null && /usr/bin/curl -s -m 20 -f  http://127.0.0.1:10251/healthz > /dev/null &&  /usr/bin/curl --insecure -s -m 20 -f  https://127.0.0.1:10250/healthz > /dev/null ; then break ; fi;  done"
         ExecStart=/opt/bin/taint-and-uncordon
-{{if .Experimental.WaitSignal.Enabled}}
+{{if .WaitSignal.Enabled}}
     - name: cfn-signal.service
       command: start
       content: |

--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -290,7 +290,7 @@ coreos:
         ExecStart=/opt/bin/taint-and-uncordon
 {{end}}
 
-{{ if .Experimental.WaitSignal.Enabled }}
+{{ if .WaitSignal.Enabled }}
     - name: cfn-signal.service
       command: start
       content: |

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -428,6 +428,11 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 # daemons start up.
 # manageCertificates: true
 
+# When enabled, autoscaling groups managing worker and controller nodes wait for nodes to be up and running.
+#waitSignal:
+#  enabled: true
+#   maxBatchSize: 1
+
 # Experimental features will change in backward-incompatible ways
 # experimental:
 #   # Used to provide `/etc/environment` env vars with values from arbitrary CloudFormation refs
@@ -465,11 +470,6 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #     - key: dedicated
 #       value: search
 #       effect: NoSchedule
-#   # When enabled, autoscaling groups managing worker and controller nodes wait for nodes to be up and running.
-#   # Although this is still an experimental feature, it is recommended to be enabled and
-#   # it will even be enabled by default in the near future.
-#   waitSignal:
-#     enabled: true
 #   plugins:
 #     # When enabled, you also need to configure a minimum set of role bindings or everything breaks.
 #     # See https://github.com/coreos/kube-aws/issues/230 for more information.

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -52,7 +52,7 @@
         ]
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
-      {{if .Experimental.WaitSignal.Enabled}}
+      {{if .WaitSignal.Enabled}}
       "CreationPolicy" : {
         "ResourceSignal" : {
           "Count" : "{{.MinWorkerCount}}",
@@ -68,9 +68,9 @@
           {{else}}
           "{{.WorkerRollingUpdateMinInstancesInService}}"
           {{end}},
-          {{if .Experimental.WaitSignal.Enabled}}
+          {{if .WaitSignal.Enabled}}
           "WaitOnResourceSignals" : "true",
-          "MaxBatchSize" : "{{.Experimental.WaitSignal.MaxBatchSize}}",
+          "MaxBatchSize" : "{{.WaitSignal.MaxBatchSize}}",
           "PauseTime": "{{.WorkerCreateTimeout}}"
           {{else}}
           "MaxBatchSize" : "1",
@@ -153,7 +153,7 @@
           { "Ref" : "ElbAPIServer" }
         ]
       },
-      {{if .Experimental.WaitSignal.Enabled}}
+      {{if .WaitSignal.Enabled}}
       "CreationPolicy" : {
         "ResourceSignal" : {
           "Count" : "{{.MinControllerCount}}",
@@ -165,7 +165,7 @@
         "AutoScalingRollingUpdate" : {
           "MinInstancesInService" : "{{.ControllerRollingUpdateMinInstancesInService}}",
           "MaxBatchSize" : "1",
-          {{if .Experimental.WaitSignal.Enabled}}
+          {{if .WaitSignal.Enabled}}
           "WaitOnResourceSignals" : "true",
           "PauseTime": "{{.ControllerCreateTimeout}}"
           {{else}}
@@ -317,7 +317,7 @@
 		  ],
 		  "Resource": "arn:aws:s3:::{{$.UserDataControllerS3Path}}"
 		},
-                {{if .Experimental.WaitSignal.Enabled}}
+                {{if .WaitSignal.Enabled}}
                 {
                   "Action": "cloudformation:SignalResource",
                   "Effect": "Allow",
@@ -421,7 +421,7 @@
                   "Resource" : "{{.KMSKeyARN}}"
                 },
                 {{end}}
-                {{if .Experimental.WaitSignal.Enabled}}
+                {{if .WaitSignal.Enabled}}
                 {
                   "Action": "cloudformation:SignalResource",
                   "Effect": "Allow",

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -118,7 +118,7 @@ The test cluster created by the `e2e/run` script can be customized via various e
 
 `KUBE_AWS_NODE_LABELS_ENABLED=1`: Enable the `nodeLabels` experimental feature to tag node pool(s) with example user-provided tags.
 
-`KUBE_AWS_WAIT_SIGNAL_ENABLED=1`: Enable the `waitSignal` experimental feature.
+`KUBE_AWS_WAIT_SIGNAL_ENABLED=1`: Enable the `waitSignal` feature.
 
 `KUBE_AWS_AWS_ENV_ENABLED=1`: Enable the `awsEnvironment` experimental feature.
 

--- a/e2e/run
+++ b/e2e/run
@@ -129,9 +129,7 @@ customize_worker() {
   #
 
   echo -e 'experimental:\n  nodeDrainer:\n    enabled: true' >> cluster.yaml
-  if [ "${KUBE_AWS_WAIT_SIGNAL_ENABLED}" != "" ]; then
-    echo -e '  waitSignal:\n    enabled: true' >> cluster.yaml
-  fi
+
   if [ "${KUBE_AWS_AWS_NODE_LABELS_ENABLED}" != "" ]; then
     echo -e '  awsNodeLabels:\n    enabled: true' >> cluster.yaml
   fi

--- a/model/worker.go
+++ b/model/worker.go
@@ -40,9 +40,16 @@ type LaunchSpecification struct {
 	RootVolumeIOPS   int    `yaml:"rootVolumeIOPS,omitempty"`
 }
 
+func NewDefaultController() Controller {
+	return Controller{
+		AutoScalingGroup: AutoScalingGroup{RollingUpdateMinInstancesInService: 1},
+	}
+}
+
 func NewDefaultWorker() Worker {
 	return Worker{
-		SpotFleet: newDefaultSpotFleet(),
+		SpotFleet:        newDefaultSpotFleet(),
+		AutoScalingGroup: AutoScalingGroup{RollingUpdateMinInstancesInService: 1},
 	}
 }
 

--- a/nodepool/config/templates/stack-template.json
+++ b/nodepool/config/templates/stack-template.json
@@ -157,7 +157,7 @@
         ]
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
-      {{if .Experimental.WaitSignal.Enabled}}
+      {{if .WaitSignal.Enabled}}
       "CreationPolicy" : {
         "ResourceSignal" : {
           "Count" : "{{.MinWorkerCount}}",
@@ -173,9 +173,9 @@
           {{else}}
           "{{.WorkerRollingUpdateMinInstancesInService}}"
           {{end}},
-          {{if .Experimental.WaitSignal.Enabled}}
+          {{if .WaitSignal.Enabled}}
           "WaitOnResourceSignals" : "true",
-          "MaxBatchSize" : "{{.Experimental.WaitSignal.MaxBatchSize}}",
+          "MaxBatchSize" : "{{.WaitSignal.MaxBatchSize}}",
           "PauseTime": "{{.WorkerCreateTimeout}}"
           {{else}}
           "MaxBatchSize" : "1",
@@ -292,7 +292,7 @@
                   "Effect" : "Allow",
                   "Resource" : "{{.KMSKeyARN}}"
                 },
-                {{if .Experimental.WaitSignal.Enabled}}
+                {{if .WaitSignal.Enabled}}
                 {
                   "Action": "cloudformation:SignalResource",
                   "Effect": "Allow",

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -72,10 +72,6 @@ func TestMainClusterConfig(t *testing.T) {
 			},
 			NodeLabels: config.NodeLabels{},
 			Taints:     []config.Taint{},
-			WaitSignal: config.WaitSignal{
-				Enabled:      false,
-				MaxBatchSize: 1,
-			},
 		}
 
 		actual := c.Experimental
@@ -220,8 +216,6 @@ experimental:
     - key: reservation
       value: spot
       effect: NoSchedule
-  waitSignal:
-    enabled: true
 `,
 			assertConfig: []ConfigTester{
 				hasDefaultEtcdSettings,
@@ -264,10 +258,6 @@ experimental:
 						},
 						Taints: []config.Taint{
 							{Key: "reservation", Value: "spot", Effect: "NoSchedule"},
-						},
-						WaitSignal: config.WaitSignal{
-							Enabled:      true,
-							MaxBatchSize: 1,
 						},
 					}
 

--- a/test/integration/nodepool_test.go
+++ b/test/integration/nodepool_test.go
@@ -116,10 +116,6 @@ etcdEndpoints: "10.0.0.1"
 			},
 			NodeLabels: cfg.NodeLabels{},
 			Taints:     []cfg.Taint{},
-			WaitSignal: cfg.WaitSignal{
-				Enabled:      false,
-				MaxBatchSize: 1,
-			},
 		}
 
 		actual := c.Experimental
@@ -160,8 +156,7 @@ experimental:
     - key: reservation
       value: spot
       effect: NoSchedule
-  waitSignal:
-    enabled: true
+
 `,
 			assertProvidedConfig: []NodePoolConfigTester{
 				hasDefaultLaunchSpecifications,
@@ -199,10 +194,6 @@ experimental:
 						},
 						Taints: []cfg.Taint{
 							{Key: "reservation", Value: "spot", Effect: "NoSchedule"},
-						},
-						WaitSignal: cfg.WaitSignal{
-							Enabled:      true,
-							MaxBatchSize: 1,
 						},
 					}
 
@@ -570,18 +561,6 @@ vpcId: vpc-1a2b3c4d
 # vpcCIDR (10.1.0.0/16) does not contain instanceCIDR (10.0.1.0/24)
 vpcCIDR: "10.1.0.0/16"
 `,
-		},
-		{
-			context: "WithSpotFleetWithExperimentalWaitSignal",
-			configYaml: minimalValidConfigYaml + `
-worker:
-  spotFleet:
-    targetCapacity: 10
-experimental:
-  waitSignal:
-    enabled: true
-`,
-			expectedErrorMessage: "The experimental feature `waitSignal` assumes a node pool is managed by an ASG rather than a Spot Fleet.",
 		},
 		{
 			context: "WithSpotFleetWithInvalidRootVolumeType",


### PR DESCRIPTION
Add skip-wait flag
Enable feature waitSignal as default
Setup initial value for RollingUpdateMinInstancesInService as 1
Require s3-flag on validate command
Fix #259

@mumoshu, could you run your e2e tests and do some reviews? I'm writing some docs explaining how the signal works