### PR TITLE
controller-cfn: kubelet SecurityGroupIngress

### DIFF
--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -842,6 +842,20 @@
       },
       "Type": "AWS::EC2::SecurityGroup"
     },
+    "SecurityGroupControllerIngressFromControllerToKubelet": {
+      "Properties": {
+        "FromPort": 10250,
+        "GroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": {
+          "Ref": "SecurityGroupController"
+        },
+        "ToPort": 10250
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
+    },
     "SecurityGroupControllerIngressFromWorkerToEtcd": {
       "Properties": {
         "FromPort": 2379,


### PR DESCRIPTION
Add a SecurityGroupIngress for controllers to access the kubelet
port (10250) on other controllers. This is needed for when there
are multiple masters.

Fixes #309