### PR TITLE
Fix error message when failed to init cluster

### DIFF
--- a/cmd/nodepool/up.go
+++ b/cmd/nodepool/up.go
@@ -60,7 +60,7 @@ func runCmdUp(cmd *cobra.Command, args []string) error {
 
 	cluster, err := cluster.NewCluster(conf, opts, upOpts.awsDebug)
 	if err != nil {
-		return fmt.Errorf("Failed to initialize cluster driver : %v", err)
+		return fmt.Errorf("Failed to initialize cluster driver: %v", err)
 	}
 
 	if err := cluster.ValidateUserData(); err != nil {

--- a/cmd/nodepool/update.go
+++ b/cmd/nodepool/update.go
@@ -58,7 +58,7 @@ func runCmdUpdate(cmd *cobra.Command, args []string) error {
 
 	cluster, err := cluster.NewCluster(conf, opts, updateOpts.awsDebug)
 	if err != nil {
-		return fmt.Errorf("Failed to initialize cluster driver : %v ", cluster)
+		return fmt.Errorf("Failed to initialize cluster driver: %v", err)
 	}
 
 	if err := cluster.ValidateUserData(); err != nil {

--- a/cmd/nodepool/validate.go
+++ b/cmd/nodepool/validate.go
@@ -39,7 +39,7 @@ func runCmdValidate(cmd *cobra.Command, args []string) error {
 	opts := stackTemplateOptions(validateOpts.s3URI, false)
 	cluster, err := cluster.NewCluster(conf, opts, validateOpts.awsDebug)
 	if err != nil {
-		return fmt.Errorf("Failed to initialize cluster driver : %v ", cluster)
+		return fmt.Errorf("Failed to initialize cluster driver: %v", err)
 	}
 
 	report, err := cluster.ValidateStack()

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -61,7 +61,7 @@ func runCmdUp(cmd *cobra.Command, args []string) error {
 
 	cluster, err := cluster.NewCluster(conf, opts, upOpts.awsDebug)
 	if err != nil {
-		return fmt.Errorf("Failed to initialize cluster driver : %v", cluster)
+		return fmt.Errorf("Failed to initialize cluster driver: %v", err)
 	}
 
 	if err := cluster.ValidateUserData(); err != nil {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -58,7 +58,7 @@ func runCmdUpdate(cmd *cobra.Command, args []string) error {
 
 	cluster, err := cluster.NewCluster(confCluster, opts, upOpts.awsDebug)
 	if err != nil {
-		return fmt.Errorf("Failed to initialize cluster driver : %v", cluster)
+		return fmt.Errorf("Failed to initialize cluster driver: %v", err)
 	}
 
 	if err := cluster.ValidateUserData(); err != nil {

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -50,7 +50,7 @@ func runCmdValidate(cmd *cobra.Command, args []string) error {
 
 	cluster, err := cluster.NewCluster(cfg, opts, validateOpts.awsDebug)
 	if err != nil {
-		return fmt.Errorf("Failed to initialize cluster driver : %v", err)
+		return fmt.Errorf("Failed to initialize cluster driver: %v", err)
 	}
 
 	fmt.Printf("Validating UserData and stack template...\n")


### PR DESCRIPTION
The error message should include the message from the original error, but
the original error is not included in error message.

This will be printed out when an error occurred:

```
Error: Failed to initialize cluster driver : <nil>
```