### PR TITLE
Experimental webhook token authentication support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -58,6 +58,13 @@ func NewDefaultCluster() *Cluster {
 				Enabled: false,
 			},
 		},
+		Authentication{
+			Webhook{
+				Enabled:  false,
+				CacheTTL: "5m0s",
+				Config:   "",
+			},
+		},
 		[]Taint{},
 		WaitSignal{
 			Enabled:      false,
@@ -414,8 +421,19 @@ type Experimental struct {
 	NodeDrainer              NodeDrainer              `yaml:"nodeDrainer"`
 	NodeLabels               NodeLabels               `yaml:"nodeLabels"`
 	Plugins                  Plugins                  `yaml:"plugins"`
+	Authentication           Authentication           `yaml:"authentication"`
 	Taints                   []Taint                  `yaml:"taints"`
 	WaitSignal               WaitSignal               `yaml:"waitSignal"`
+}
+
+type Authentication struct {
+	Webhook Webhook `yaml:"webhook"`
+}
+
+type Webhook struct {
+	Enabled  bool   `yaml:"enabled"`
+	CacheTTL string `yaml:"cacheTTL"`
+	Config   string `yaml:"configBase64"`
 }
 
 type AwsEnvironment struct {

--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -799,9 +799,11 @@ write_files:
           - mountPath: /etc/ssl/certs
             name: ssl-certs-host
             readOnly: true
+          {{if .Experimental.Authentication.Webhook.Enabled}}
           - mountPath: /etc/kubernetes/webhooks
             name: kubernetes-webhooks
             readOnly: true
+          {{ end }}
         volumes:
         - hostPath:
             path: /etc/kubernetes/ssl
@@ -809,9 +811,11 @@ write_files:
         - hostPath:
             path: /usr/share/ca-certificates
           name: ssl-certs-host
+        {{if .Experimental.Authentication.Webhook.Enabled}}
         - hostPath:
             path: /etc/kubernetes/webhooks
           name: kubernetes-webhooks
+        {{end}}
 
   - path: /etc/kubernetes/manifests/kube-controller-manager.yaml
     content: |

--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -406,7 +406,7 @@ write_files:
       kind: ConfigMap
       apiVersion: v1
       metadata:
-        name: calico-config 
+        name: calico-config
         namespace: kube-system
       data:
         etcd_endpoints: "#ETCD_ENDPOINTS#"
@@ -482,7 +482,7 @@ write_files:
                       configMapKeyRef:
                         name: calico-config
                         key: etcd_endpoints
-                  - name: CALICO_NETWORKING_BACKEND 
+                  - name: CALICO_NETWORKING_BACKEND
                     value: "none"
                   - name: CALICO_DISABLE_FILE_LOGGING
                     value: "true"
@@ -564,7 +564,7 @@ write_files:
       ---
 
       apiVersion: extensions/v1beta1
-      kind: Deployment 
+      kind: Deployment
       metadata:
         name: calico-policy-controller
         namespace: kube-system
@@ -621,7 +621,7 @@ write_files:
               - name: etcd-certs
                 secret:
                   secretName: calico-etcd-secrets
-  
+
   - path: /opt/bin/populate-tls-calico-etcd
     owner: root:root
     permissions: 0700
@@ -765,6 +765,10 @@ write_files:
           - --authorization-mode=RBAC
           - --authorization-rbac-super-user=kube-admin
           {{ end }}
+          {{if .Experimental.Authentication.Webhook.Enabled}}
+          - --authentication-token-webhook-config-file=/etc/kubernetes/webhooks/authentication.yaml
+          - --authentication-token-webhook-cache-ttl={{ .Experimental.Authentication.Webhook.CacheTTL }}
+          {{ end }}
           - --advertise-address=$private_ipv4
           - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota
           - --anonymous-auth=false
@@ -795,6 +799,9 @@ write_files:
           - mountPath: /etc/ssl/certs
             name: ssl-certs-host
             readOnly: true
+          - mountPath: /etc/kubernetes/webhooks
+            name: kubernetes-webhooks
+            readOnly: true
         volumes:
         - hostPath:
             path: /etc/kubernetes/ssl
@@ -802,6 +809,9 @@ write_files:
         - hostPath:
             path: /usr/share/ca-certificates
           name: ssl-certs-host
+        - hostPath:
+            path: /etc/kubernetes/webhooks
+          name: kubernetes-webhooks
 
   - path: /etc/kubernetes/manifests/kube-controller-manager.yaml
     content: |
@@ -1164,18 +1174,18 @@ write_files:
     content: |
         kind: Service
         apiVersion: v1
-        metadata: 
+        metadata:
           name: heapster
           namespace: kube-system
-          labels: 
+          labels:
             kubernetes.io/cluster-service: "true"
             kubernetes.io/name: "Heapster"
             k8s-app: heapster
-        spec: 
-          ports: 
+        spec:
+          ports:
             - port: 80
               targetPort: 8082
-          selector: 
+          selector:
             k8s-app: heapster
 
   - path: /srv/kubernetes/manifests/kube-dashboard-rc.yaml
@@ -1238,7 +1248,7 @@ write_files:
           ports:
           - port: 80
             targetPort: 9090
-        
+
 {{ if .ManageCertificates }}
   - path: /etc/kubernetes/ssl/ca.pem.enc
     encoding: gzip+base64
@@ -1272,4 +1282,10 @@ write_files:
                 "isDefaultGateway": true
             }
         }
+{{ end }}
+
+{{if .Experimental.Authentication.Webhook.Enabled}}
+  - path: /etc/kubernetes/webhooks/authentication.yaml
+    encoding: base64
+    content: {{ .Experimental.Authentication.Webhook.Config }}
 {{ end }}

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -480,6 +480,7 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #         enabled: true
 #         cacheTTL: 1m0s
 #         configBase64: base64-encoded-webhook-yaml
+
 # AWS Tags for cloudformation stack resources
 #stackTags:
 #  Name: "Kubernetes"

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -476,6 +476,8 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #     rbac:
 #       enabled: true
 #     authentication:
+#       See https://kubernetes.io/docs/admin/authentication/#webhook-token-authentication
+#       for more information.
 #       webhook:
 #         enabled: true
 #         cacheTTL: 1m0s

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -475,7 +475,11 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #     # See https://github.com/coreos/kube-aws/issues/230 for more information.
 #     rbac:
 #       enabled: true
-
+#     authentication:
+#       webhook:
+#         enabled: true
+#         cacheTTL: 1m0s
+#         configBase64: base64-encoded-webhook-yaml
 # AWS Tags for cloudformation stack resources
 #stackTags:
 #  Name: "Kubernetes"

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -76,6 +76,12 @@ func TestMainClusterConfig(t *testing.T) {
 				Enabled:      false,
 				MaxBatchSize: 1,
 			},
+			Authentication: config.Authentication{
+				Webhook: config.Webhook{
+					Enabled:  false,
+					CacheTTL: "5m0s",
+				},
+			},
 		}
 
 		actual := c.Experimental
@@ -260,6 +266,12 @@ experimental:
 						Plugins: config.Plugins{
 							Rbac: config.Rbac{
 								Enabled: true,
+							},
+						},
+						Authentication: config.Authentication{
+							Webhook: config.Webhook{
+								Enabled:  false,
+								CacheTTL: "5m0s",
 							},
 						},
 						Taints: []config.Taint{

--- a/test/integration/nodepool_test.go
+++ b/test/integration/nodepool_test.go
@@ -120,6 +120,12 @@ etcdEndpoints: "10.0.0.1"
 				Enabled:      false,
 				MaxBatchSize: 1,
 			},
+			Authentication: cfg.Authentication{
+				Webhook: cfg.Webhook{
+					Enabled:  false,
+					CacheTTL: "5m0s",
+				},
+			},
 		}
 
 		actual := c.Experimental
@@ -203,6 +209,12 @@ experimental:
 						WaitSignal: cfg.WaitSignal{
 							Enabled:      true,
 							MaxBatchSize: 1,
+						},
+						Authentication: cfg.Authentication{
+							Webhook: cfg.Webhook{
+								Enabled:  false,
+								CacheTTL: "5m0s",
+							},
 						},
 					}
 


### PR DESCRIPTION
This PR adds experimental support for webhook token authentication, https://kubernetes.io/docs/admin/authentication/#webhook-token-authentication

To use add the following config:

```yaml
experimental:
 authentication:
   webhook:
     enabled: true
     cacheTTL: 1m0s
     configBase64: base64-encoded-webhook-yaml
```

configBase64 is a base64 encoded webhook-yaml configuration. 