### PR TITLE
Add DOCKER_OPTS environment variable to limit docker log files.

### DIFF
--- a/config/templates/cloud-config-controller
+++ b/config/templates/cloud-config-controller
@@ -76,6 +76,11 @@ coreos:
             EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
             ExecStartPre=/usr/bin/systemctl is-active flanneld.service
 
+        - name: 60-logfilelimit.conf
+          content: |
+            [Service]
+            Environment="DOCKER_OPTS=--log-opt max-size=50m --log-opt max-file=3"
+
     - name: flanneld.service
       drop-ins:
         - name: 10-etcd.conf

--- a/config/templates/cloud-config-worker
+++ b/config/templates/cloud-config-worker
@@ -50,6 +50,11 @@ coreos:
             EnvironmentFile=/etc/kubernetes/cni/docker_opts_cni.env
             ExecStartPre=/usr/bin/systemctl is-active flanneld.service
 
+        - name: 60-logfilelimit.conf
+          content: |
+            [Service]
+            Environment="DOCKER_OPTS=--log-opt max-size=50m --log-opt max-file=3"
+
     - name: flanneld.service
       drop-ins:
         - name: 10-etcd.conf


### PR DESCRIPTION
Fixes https://github.com/coreos/kube-aws/issues/134.