### PR TITLE
Add experimental support for pod security policies

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -26,6 +26,11 @@ const (
 
 func NewDefaultCluster() *Cluster {
 	experimental := Experimental{
+		Admission{
+			PodSecurityPolicy{
+				Enabled: false,
+			},
+		},
 		AuditLog{
 			Enabled: false,
 			MaxAge:  30,
@@ -418,6 +423,7 @@ type Cluster struct {
 }
 
 type Experimental struct {
+	Admission                Admission                `yaml:"admission"`
 	AuditLog                 AuditLog                 `yaml:"auditLog"`
 	Authentication           Authentication           `yaml:"authentication"`
 	AwsEnvironment           AwsEnvironment           `yaml:"awsEnvironment"`
@@ -430,6 +436,14 @@ type Experimental struct {
 	NodeLabels               NodeLabels               `yaml:"nodeLabels"`
 	Plugins                  Plugins                  `yaml:"plugins"`
 	Taints                   []Taint                  `yaml:"taints"`
+}
+
+type Admission struct {
+	PodSecurityPolicy PodSecurityPolicy `yaml:"podSecurityPolicy"`
+}
+
+type PodSecurityPolicy struct {
+	Enabled bool `yaml:"enabled"`
 }
 
 type AuditLog struct {

--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -920,13 +920,13 @@ write_files:
           - --authentication-token-webhook-cache-ttl={{ .Experimental.Authentication.Webhook.CacheTTL }}
           {{ end }}
           - --advertise-address=$private_ipv4
-          - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota
+          - --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},PodSecurityPolicy{{ end }},ResourceQuota
           - --anonymous-auth=false
           - --tls-cert-file=/etc/kubernetes/ssl/apiserver.pem
           - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
           - --client-ca-file=/etc/kubernetes/ssl/ca.pem
           - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
-          - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1{{if .Experimental.Plugins.Rbac.Enabled}},rbac.authorization.k8s.io/v1alpha1=true{{ end }}
+          - --runtime-config=extensions/v1beta1/networkpolicies=true,batch/v2alpha1{{if .Experimental.Plugins.Rbac.Enabled}},rbac.authorization.k8s.io/v1alpha1=true{{ end }}{{if .Experimental.Admission.PodSecurityPolicy.Enabled}},extensions/v1beta1/podsecuritypolicy=true{{ end }}
           - --cloud-provider=aws
           livenessProbe:
             httpGet:

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -559,6 +559,10 @@ worker:
 
 # Experimental features will change in backward-incompatible ways
 # experimental:
+#   # Enable admission controllers
+#   admission:
+#     podSecurityPolicy:
+#       enabled: true
 #   # Used to provide `/etc/environment` env vars with values from arbitrary CloudFormation refs
 #   awsEnvironment:
 #     enabled: true

--- a/test/integration/maincluster_test.go
+++ b/test/integration/maincluster_test.go
@@ -49,6 +49,11 @@ func TestMainClusterConfig(t *testing.T) {
 
 	hasDefaultExperimentalFeatures := func(c *config.Config, t *testing.T) {
 		expected := controlplane_config.Experimental{
+			Admission: controlplane_config.Admission{
+				PodSecurityPolicy: controlplane_config.PodSecurityPolicy{
+					Enabled: false,
+				},
+			},
 			AuditLog: controlplane_config.AuditLog{
 				Enabled: false,
 				MaxAge:  30,
@@ -278,6 +283,9 @@ availabilityZone: us-west-1c
 			context: "WithExperimentalFeatures",
 			configYaml: minimalValidConfigYaml + `
 experimental:
+  admission:
+    podSecurityPolicy:
+      enabled: true
   auditLog:
     enabled: true
     maxage: 100
@@ -325,6 +333,11 @@ worker:
 				asgBasedNodePoolHasWaitSignalEnabled,
 				func(c *config.Config, t *testing.T) {
 					expected := controlplane_config.Experimental{
+						Admission: controlplane_config.Admission{
+							PodSecurityPolicy: controlplane_config.PodSecurityPolicy{
+								Enabled: true,
+							},
+						},
 						AuditLog: controlplane_config.AuditLog{
 							Enabled: true,
 							MaxAge:  100,
@@ -397,6 +410,9 @@ worker:
 worker:
   nodePools:
   - name: pool1
+    admission:
+      podSecurityPolicy:
+        enabled: true
     auditLog:
       enabled: true
       maxage: 100


### PR DESCRIPTION
This adds support for enabling pod security policies.

Note - this only enables the admission controller and does not create any pod security policies or bindings themselves. This is a similar issue to #230 in that one might argue kube-aws should also provide some minimal pod security policies so that basic pods can be admitted to the cluster before the administrator affects their own policies and rolebindings.

Unlike #230, however, enabling this doesn't result in a "broken cluster" at like the missing RBAC roles did; the kubernetes components work with PSPs enabled.

I have not done exhaustive testing about the ramifications of having PSPs enabled but having no policies, but I think it's worth having this patch in kube-aws so the administrator can make their own choices about how to initialize the cluster objects. Thanks!