### PR TITLE
credentials: Add /O=systems:master for kube-admin

### DIFF
--- a/core/controlplane/config/tls_config.go
+++ b/core/controlplane/config/tls_config.go
@@ -168,8 +168,9 @@ func (c *Cluster) NewTLSAssets(caKey *rsa.PrivateKey, caCert *x509.Certificate) 
 	}
 
 	adminConfig := tlsutil.ClientCertConfig{
-		CommonName: "kube-admin",
-		Duration:   certDuration,
+		CommonName:   "kube-admin",
+		Organization: []string{"system:masters"},
+		Duration:     certDuration,
 	}
 	adminCert, err := tlsutil.NewSignedClientCertificate(adminConfig, adminKey, caCert, caKey)
 	if err != nil {

--- a/tlsutil/x509.go
+++ b/tlsutil/x509.go
@@ -30,10 +30,11 @@ type ServerCertConfig struct {
 }
 
 type ClientCertConfig struct {
-	CommonName  string
-	DNSNames    []string
-	IPAddresses []string
-	Duration    time.Duration
+	CommonName   string
+	Organization []string
+	DNSNames     []string
+	IPAddresses  []string
+	Duration     time.Duration
 }
 
 func NewSelfSignedCACertificate(cfg CACertConfig, key *rsa.PrivateKey) (*x509.Certificate, error) {
@@ -114,7 +115,7 @@ func NewSignedClientCertificate(cfg ClientCertConfig, key *rsa.PrivateKey, caCer
 	certTmpl := x509.Certificate{
 		Subject: pkix.Name{
 			CommonName:   cfg.CommonName,
-			Organization: caCert.Subject.Organization,
+			Organization: append(caCert.Subject.Organization, cfg.Organization...),
 		},
 		DNSNames:     cfg.DNSNames,
 		IPAddresses:  ips,


### PR DESCRIPTION
Fixes #344 

----
This is tested in so far as that it produces a seemingly correct subject in the admin certificate. I'm still replacing my cluster to confirm that this indeed is enough.