### PR TITLE
Add apiserver-count parameter in kube-apiserver config

### DIFF
--- a/core/controlplane/config/templates/cloud-config-controller
+++ b/core/controlplane/config/templates/cloud-config-controller
@@ -898,6 +898,7 @@ write_files:
           command:
           - /hyperkube
           - apiserver
+          - --apiserver-count={{if .MinControllerCount}}{{ .MinControllerCount }}{{else}}{{ .ControllerCount }}{{end}}
           - --bind-address=0.0.0.0
           - --etcd-servers=#ETCD_ENDPOINTS#
           - --etcd-cafile=/etc/kubernetes/ssl/ca.pem


### PR DESCRIPTION
Issues concerning conflicts between apiservers during leader allocation causes the (kubectl) kubernetes.service endpoint value to change arbitrarily (https://github.com/kubernetes/kubernetes/issues/19989) which we've encountered first-hand. The solution implemented sets the 'apiserver-count' parameter to the number of controllers used in the cluster .

The 'apiserver-count' value is set to the minimum number of controller nodes set in cluster.yaml (if controller auto-scaling is used).