### PR TITLE
Drop deprecated `hostedZone`(not `hostedZoneId`) in cluster.yaml

### DIFF
--- a/core/controlplane/cluster/cluster.go
+++ b/core/controlplane/cluster/cluster.go
@@ -381,46 +381,6 @@ func (c *ClusterRef) validateDNSConfig(r53 r53Service) error {
 		return nil
 	}
 
-	if c.HostedZoneID == "" {
-		//TODO(colhom): When HostedZone parameter is gone, this block can be removed
-		//Config will gaurantee that HostedZoneID is set from the get-go
-		listHostedZoneInput := route53.ListHostedZonesByNameInput{
-			DNSName: aws.String(c.HostedZone),
-		}
-
-		zonesResp, err := r53.ListHostedZonesByName(&listHostedZoneInput)
-		if err != nil {
-			return fmt.Errorf("Error validating HostedZone: %s", err)
-		}
-
-		zones := zonesResp.HostedZones
-
-		if len(zones) == 0 {
-			return fmt.Errorf("hosted zone %s does not exist", c.HostedZone)
-		}
-
-		var matchingZone *route53.HostedZone
-		for _, zone := range zones {
-			if aws.StringValue(zone.Name) == c.HostedZone {
-				if matchingZone != nil {
-					//This means we've found another match, and HostedZone is ambiguous
-					return fmt.Errorf("multiple hosted-zones found for DNS name \"%s\"", c.HostedZone)
-				}
-				matchingZone = zone
-			} else {
-				/* Weird API semantics: if we see a zone which doesn't match the name
-				   we've exhausted all zones which match the name
-				  http://docs.aws.amazon.com/cli/latest/reference/route53/list-hosted-zones-by-name.html#options */
-
-				break
-			}
-		}
-		if matchingZone == nil {
-			return fmt.Errorf("hosted zone %s does not exist", c.HostedZone)
-		}
-		c.HostedZoneID = aws.StringValue(matchingZone.Id)
-	}
-
 	hzOut, err := r53.GetHostedZone(&route53.GetHostedZoneInput{Id: aws.String(c.HostedZoneID)})
 	if err != nil {
 		return fmt.Errorf("error getting hosted zone %s: %v", c.HostedZoneID, err)
@@ -445,7 +405,7 @@ func (c *ClusterRef) validateDNSConfig(r53 r53Service) error {
 				return fmt.Errorf(
 					"RecordSet for \"%s\" already exists in Hosted Zone \"%s.\"",
 					c.ExternalDNSName,
-					c.HostedZone,
+					c.HostedZoneID,
 				)
 			}
 		}

--- a/core/controlplane/cluster/cluster_test.go
+++ b/core/controlplane/cluster/cluster_test.go
@@ -376,10 +376,6 @@ func TestValidateDNSConfig(t *testing.T) {
 		`
 createRecordSet: true
 recordSetTTL: 60
-hostedZone: core-os.net
-`, `
-createRecordSet: true
-recordSetTTL: 60
 hostedZoneId: staging_id_1
 `, `
 createRecordSet: true
@@ -392,23 +388,11 @@ hostedZoneId: /hostedzone/staging_id_2
 		`
 createRecordSet: true
 recordSetTTL: 60
-hostedZone: staging.core-os.net # hostedZone is ambiguous
-`, `
-createRecordSet: true
-recordSetTTL: 60
 hostedZoneId: /hostedzone/staging_id_3 # <staging_id_id> is not a super-domain
 `, `
 createRecordSet: true
 recordSetTTL: 60
-hostedZone: zebras.coreos.com # zebras.coreos.com is not a super-domain
-`, `
-createRecordSet: true
-recordSetTTL: 60
 hostedZoneId: /hostedzone/staging_id_5 #non-existant hostedZoneId
-`, `
-createRecordSet: true
-recordSetTTL: 60
-hostedZone: unicorns.core-os.net  #non-existant hostedZone DNS name
 `,
 	}
 
@@ -416,7 +400,7 @@ hostedZone: unicorns.core-os.net  #non-existant hostedZone DNS name
 		configBody := defaultConfigValues(t, validConfig)
 		clusterConfig, err := config.ClusterFromBytes([]byte(configBody))
 		if err != nil {
-			t.Errorf("could not get valid cluster config: %v", err)
+			t.Errorf("could not get valid cluster config in `%s`: %v", configBody, err)
 			continue
 		}
 		c := &ClusterRef{Cluster: clusterConfig}

--- a/core/controlplane/config/config_test.go
+++ b/core/controlplane/config/config_test.go
@@ -46,14 +46,11 @@ routeTableId: rtb-xxxxxx
 vpcId: vpc-xxxxx
 `, `
 createRecordSet: false
-hostedZone: ""
+hostedZoneId: ""
 `, `
 createRecordSet: true
 recordSetTTL: 400
-hostedZone: core-os.net
-`, `
-createRecordSet: true
-hostedZone: "staging.core-os.net"
+hostedZoneId: "XXXXXXXXXXX"
 `, `
 createRecordSet: true
 hostedZoneId: "XXXXXXXXXXX"
@@ -118,10 +115,13 @@ createRecordSet: true
 createRecordSet: false
 recordSetTTL: 400
 `, `
-createRecordSet: true
-recordSetTTL: 60
-hostedZone: staging.core-os.net
+# hostedZoneId should'nt be modified when createRecordSet is false
+createRecordSet: false
 hostedZoneId: /hostedzone/staging_id_2 #hostedZone and hostedZoneId defined
+`, `
+# hostedZone had been deprecated and then dropped
+createRecordSet: true
+hostedZone: "staging.core-os.net"
 `,
 }
 


### PR DESCRIPTION
closes #287