### PR TITLE
Emit a warning message when `t2.nano` or `t2.micro` is set for `*instanceType`

### DIFF
--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -872,6 +872,10 @@ func (c Cluster) valid() error {
 		return fmt.Errorf("awsNodeLabels can't be enabled for controllers because the total number of characters in clusterName(=\"%s\") exceeds the limit of %d", c.ClusterName, limit)
 	}
 
+	if c.ControllerInstanceType == "t2.micro" || c.EtcdInstanceType == "t2.micro" || c.ControllerInstanceType == "t2.nano" || c.EtcdInstanceType == "t2.nano" {
+		fmt.Println(`WARNING: instance types "t2.nano" and "t2.micro" are not recommended. See https://github.com/coreos/kube-aws/issues/258 for more information`)
+	}
+
 	return nil
 }
 

--- a/model/node_pool_config.go
+++ b/model/node_pool_config.go
@@ -111,6 +111,10 @@ func (c NodePoolConfig) Valid() error {
 		return err
 	}
 
+	if c.InstanceType == "t2.micro" || c.InstanceType == "t2.nano" {
+		fmt.Println(`WARNING: instance types "t2.nano" and "t2.micro" are not recommended. See https://github.com/coreos/kube-aws/issues/258 for more information`)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
closes #258