### PR TITLE
Fix an issue with glue security group documentation

### DIFF
--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -202,6 +202,13 @@ worker:
 #      # This option has not yet been tested with rkt as container runtime
 #      ephemeralImageStorage:
 #        enabled: true
+#
+#      # Existing "glue" security groups attached to worker nodes which are typically used to allow
+#      # access from worker nodes to services running on an existing infrastructure
+#      securityGroupIds:
+#        - sg-1234abcd
+#        - sg-5678efab
+#
 #      # When enabled it will grant sts:assumeRole permission to the IAM roles for worker nodes.
 #      # This is intended to be used in combination with managedIamRoleName. See #297 for more information.
 #      kube2IamSupport:
@@ -281,11 +288,6 @@ worker:
 
 # Price (Dollars) to bid for spot instances. Omit for on-demand instances.
 # workerSpotPrice: "0.05"
-
-# Existing "glue" security groups attached to worker nodes which are typically used to allow access from worker nodes to services running on an existing infrastructure
-# workerSecurityGroupIds:
-#   - sg-1234abcd
-#   - sg-5678efab
 
 ## Etcd Cluster config
 ## WARNING: Any changes to etcd parameters after the cluster is first created will not be applied


### PR DESCRIPTION
This config moved from `workerSecurityGroupIds[]` to `worker.nodePools[].securityGroupIds[]`.
https://github.com/coreos/kube-aws/issues/333