### PR TITLE
Upgrade kubernetes version to v1.5.4

### DIFF
--- a/contrib/bump-version
+++ b/contrib/bump-version
@@ -6,11 +6,11 @@
 
 if [ $# -ne 1 ] || [ `expr $1 : ".*_.*"` == 0 ]; then
     echo "USAGE: $0 <target-version>"
-    echo "  example: $0 'v1.5.3_coreos.0'"
+    echo "  example: $0 'v1.5.4_coreos.0'"
     exit 1
 fi
 
-CURRENT_VERSION=${CURRENT_VERSION:-"v1.5.3_coreos.0"}
+CURRENT_VERSION=${CURRENT_VERSION:-"v1.5.4_coreos.0"}
 TARGET_VERSION=${1}
 
 CURRENT_VERSION_BASE=${CURRENT_VERSION%%_*}

--- a/core/controlplane/config/config.go
+++ b/core/controlplane/config/config.go
@@ -84,7 +84,7 @@ func NewDefaultCluster() *Cluster {
 			ClusterName:        "kubernetes",
 			VPCCIDR:            "10.0.0.0/16",
 			ReleaseChannel:     "stable",
-			K8sVer:             "v1.5.3_coreos.0",
+			K8sVer:             "v1.5.4_coreos.0",
 			HyperkubeImageRepo: "quay.io/coreos/hyperkube",
 			AWSCliImageRepo:    "quay.io/coreos/awscli",
 			AWSCliTag:          "master",

--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -592,7 +592,7 @@ worker:
 #tlsCertDurationDays: 365
 
 # Version of hyperkube image to use. This is the tag for the hyperkube image repository.
-# kubernetesVersion: v1.5.3_coreos.0
+# kubernetesVersion: v1.5.4_coreos.0
 
 # Hyperkube image repository to use.
 # hyperkubeImageRepo: quay.io/coreos/hyperkube

--- a/e2e/kubernetes/Dockerfile
+++ b/e2e/kubernetes/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.7.1
 
-ARG KUBERNETES_VERSION=${KUBERNETES_VERSION:-v1.5.3+coreos.0}
+ARG KUBERNETES_VERSION=${KUBERNETES_VERSION:-v1.5.4+coreos.0}
 
 RUN apt-get update && \
     apt-get install -y rsync && \

--- a/e2e/kubernetes/Makefile
+++ b/e2e/kubernetes/Makefile
@@ -1,4 +1,4 @@
-KUBERNETES_VERSION ?= v1.5.3+coreos.0
+KUBERNETES_VERSION ?= v1.5.4+coreos.0
 DOCKER_REPO ?=
 DOCKER_TAG ?= $(DOCKER_REPO)kube-e2e:$(KUBERNETES_VERSION)
 DOCKER_TAG_SANITIZED ?= $(shell echo $(DOCKER_TAG) | sed -e 's/+/_/')

--- a/model/derived/etcd_cluster_test.go
+++ b/model/derived/etcd_cluster_test.go
@@ -65,7 +65,7 @@ func TestEtcdClusterDNSNames(t *testing.T) {
 		t.Run("us-east-1", func(t *testing.T) {
 			cluster := NewEtcdCluster(config, usEast1, etcdNet, etcdCount)
 			actual := cluster.DNSNames()
-			expected := []string{"*.us-east-1.compute.amazonaws.com"}
+			expected := []string{"*.compute-1.amazonaws.com"}
 			if !reflect.DeepEqual(actual, expected) {
 				t.Errorf("invalid dns names: expecetd=%v, got=%v", expected, actual)
 			}

--- a/model/region.go
+++ b/model/region.go
@@ -28,6 +28,9 @@ func (r regionImpl) PrivateDomainName() string {
 }
 
 func (r regionImpl) PublicDomainName() string {
+	if r.name == "us-east-1" {
+		return "compute-1.amazonaws.com"
+	}
 	return fmt.Sprintf("%s.compute.amazonaws.com", r.name)
 }
 


### PR DESCRIPTION
This PR upgrades the kubernetes version to the most updated release v1.5.4 which solves some major bugs for AWS:
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG.md#changelog-since-v153