### PR TITLE
Fix typo in ClusterAutoScalerSupport attribute name in template

### DIFF
--- a/core/controlplane/config/templates/cluster.yaml
+++ b/core/controlplane/config/templates/cluster.yaml
@@ -198,7 +198,7 @@ worker:
 #        enabled: true
 #      # Will provision worker nodes with IAM permissions to run cluster-autoscaler
 #      clusterAutoscalerSupport:
-#        enable: true
+#        enabled: true
 #      # This option has not yet been tested with rkt as container runtime
 #      ephemeralImageStorage:
 #        enabled: true


### PR DESCRIPTION
Changed the attribute name to `enabled` so it matches the [expected name](https://github.com/coreos/kube-aws/blob/master/core/controlplane/config/config.go#L474) for that attribute when parsing the `cluster.yaml` file.